### PR TITLE
fix(frontend): replace all underscores in StatusBadge status text

### DIFF
--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -22,7 +22,7 @@ export default function StatusBadge({ status }: StatusBadgeProps) {
     <span
       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${colors}`}
     >
-      {status.replace("_", " ")}
+      {status.replaceAll("_", " ")}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Fix `StatusBadge` component to correctly handle statuses with multiple underscores
by replacing `.replace("_", " ")` with `.replaceAll("_", " ")`.

## Problem

`String.prototype.replace()` with a string argument only replaces the **first**
occurrence. Multi-word statuses containing more than one underscore (e.g.
`PENDING_ADMIN_REVIEW`) would render with remaining underscores intact
(`PENDING ADMIN_REVIEW`).

## Changes

- **frontend/src/components/StatusBadge.tsx** — Changed `.replace("_", " ")` to
  `.replaceAll("_", " ")` so all underscores are converted to spaces.

Closes #2