### PR TITLE
feat: add user settings and edit profile page

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2453,7 +2453,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bytes": {
@@ -3458,8 +3457,9 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/gensync": {
@@ -4493,30 +4493,6 @@
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
     },
     "node_modules/jest-runtime": {
       "version": "30.2.0",
@@ -6031,7 +6007,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from "express";
 import { PrismaClient } from "@prisma/client";
-import { AuthRequest } from "../middleware/auth";
+import { z } from "zod";
+import { AuthRequest, authenticate } from "../middleware/auth";
 import { validate } from "../middleware/validation";
 import { asyncHandler } from "../middleware/error";
 import {
@@ -11,6 +12,131 @@ import {
 
 const router = Router();
 const prisma = new PrismaClient();
+
+// Zod schema for profile update payload
+const updateProfileSchema = z.object({
+  username: z
+    .string()
+    .min(3, "Username must be at least 3 characters")
+    .max(30, "Username must be at most 30 characters")
+    .regex(/^[a-zA-Z0-9_-]+$/, "Username can only contain letters, numbers, hyphens, and underscores")
+    .optional(),
+  email: z
+    .string()
+    .email("Invalid email address")
+    .optional()
+    .nullable(),
+  bio: z
+    .string()
+    .max(500, "Bio must be at most 500 characters")
+    .optional()
+    .nullable(),
+  avatarUrl: z
+    .string()
+    .url("Invalid URL for avatar")
+    .optional()
+    .nullable(),
+  role: z
+    .enum(["CLIENT", "FREELANCER"], {
+      errorMap: () => ({ message: "Role must be either CLIENT or FREELANCER" }),
+    })
+    .optional(),
+});
+
+// GET /api/users/me — return current authenticated user's full profile
+router.get("/me", authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.userId },
+      select: {
+        id: true,
+        username: true,
+        walletAddress: true,
+        email: true,
+        bio: true,
+        avatarUrl: true,
+        role: true,
+        createdAt: true,
+      },
+    });
+
+    if (!user) {
+      res.status(404).json({ error: "User not found." });
+      return;
+    }
+
+    res.json(user);
+  } catch (error) {
+    console.error("Get current user error:", error);
+    res.status(500).json({ error: "Internal server error." });
+  }
+});
+
+// PUT /api/users/me — update current authenticated user's profile
+router.put("/me", authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    const parsed = updateProfileSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      const errors = parsed.error.errors.map((e) => ({
+        field: e.path.join("."),
+        message: e.message,
+      }));
+      res.status(400).json({ error: "Validation failed.", details: errors });
+      return;
+    }
+
+    const data = parsed.data;
+
+    // Check username uniqueness if being updated
+    if (data.username) {
+      const existingUser = await prisma.user.findFirst({
+        where: {
+          username: data.username,
+          NOT: { id: req.userId },
+        },
+      });
+      if (existingUser) {
+        res.status(409).json({ error: "Username is already taken." });
+        return;
+      }
+    }
+
+    // Check email uniqueness if being updated
+    if (data.email) {
+      const existingUser = await prisma.user.findFirst({
+        where: {
+          email: data.email,
+          NOT: { id: req.userId },
+        },
+      });
+      if (existingUser) {
+        res.status(409).json({ error: "Email is already taken." });
+        return;
+      }
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id: req.userId },
+      data,
+      select: {
+        id: true,
+        username: true,
+        walletAddress: true,
+        email: true,
+        bio: true,
+        avatarUrl: true,
+        role: true,
+        createdAt: true,
+      },
+    });
+
+    res.json(updatedUser);
+  } catch (error) {
+    console.error("Update profile error:", error);
+    res.status(500).json({ error: "Internal server error." });
+  }
+});
 
 // Get user profile by ID
 router.get(

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2,6 +2,21 @@
 @tailwind components;
 @tailwind utilities;
 
+@keyframes slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.animate-slide-in {
+  animation: slide-in 0.3s ease-out;
+}
+
 @layer base {
   body {
     @apply bg-dark-bg text-dark-text;

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -2,11 +2,19 @@
 
 import { WalletProvider } from "@/context/WalletContext";
 import { SocketProvider } from "@/context/SocketContext";
+import { AuthProvider } from "@/context/AuthContext";
+import { ToastProvider } from "@/components/Toast";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <WalletProvider>
-      <SocketProvider>{children}</SocketProvider>
+      <SocketProvider>
+        <AuthProvider>
+          <ToastProvider>
+            {children}
+          </ToastProvider>
+        </AuthProvider>
+      </SocketProvider>
     </WalletProvider>
   );
 }

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+import { useAuth } from "@/context/AuthContext";
+import { useToast } from "@/components/Toast";
+import { User, Settings, Mail, FileText, Link as LinkIcon, Loader2 } from "lucide-react";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
+
+interface FormErrors {
+  username?: string;
+  email?: string;
+  bio?: string;
+  avatarUrl?: string;
+  general?: string;
+}
+
+export default function SettingsPage() {
+  const { user, token, isLoading: authLoading, updateUser } = useAuth();
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [bio, setBio] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState("");
+  const [role, setRole] = useState<"CLIENT" | "FREELANCER">("FREELANCER");
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [isPageLoading, setIsPageLoading] = useState(true);
+
+  // Redirect if not authenticated
+  useEffect(() => {
+    if (!authLoading && !token) {
+      router.push("/");
+    }
+  }, [authLoading, token, router]);
+
+  // Fetch latest profile data and pre-fill form
+  useEffect(() => {
+    if (!token) return;
+
+    async function fetchProfile() {
+      try {
+        const res = await axios.get(`${API_URL}/users/me`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = res.data;
+        setUsername(data.username || "");
+        setEmail(data.email || "");
+        setBio(data.bio || "");
+        setAvatarUrl(data.avatarUrl || "");
+        setRole(data.role || "FREELANCER");
+      } catch {
+        toast.error("Failed to load profile data.");
+      } finally {
+        setIsPageLoading(false);
+      }
+    }
+
+    fetchProfile();
+  }, [token]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Client-side validation
+  function validate(): boolean {
+    const newErrors: FormErrors = {};
+
+    if (!username || username.length < 3) {
+      newErrors.username = "Username must be at least 3 characters.";
+    } else if (username.length > 30) {
+      newErrors.username = "Username must be at most 30 characters.";
+    } else if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
+      newErrors.username = "Username can only contain letters, numbers, hyphens, and underscores.";
+    }
+
+    if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      newErrors.email = "Please enter a valid email address.";
+    }
+
+    if (bio && bio.length > 500) {
+      newErrors.bio = "Bio must be at most 500 characters.";
+    }
+
+    if (avatarUrl && !/^https?:\/\/.+/.test(avatarUrl)) {
+      newErrors.avatarUrl = "Please enter a valid URL.";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setIsSaving(true);
+    setErrors({});
+
+    try {
+      const payload: Record<string, any> = {
+        username,
+        role,
+      };
+      if (email) payload.email = email;
+      else payload.email = null;
+      if (bio) payload.bio = bio;
+      else payload.bio = null;
+      if (avatarUrl) payload.avatarUrl = avatarUrl;
+      else payload.avatarUrl = null;
+
+      const res = await axios.put(`${API_URL}/users/me`, payload, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      updateUser(res.data);
+      toast.success("Profile updated successfully!");
+    } catch (error: any) {
+      const message =
+        error.response?.data?.error || "Failed to update profile. Please try again.";
+      setErrors({ general: message });
+      toast.error(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  if (authLoading || isPageLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Loader2 size={32} className="animate-spin text-stellar-blue" />
+      </div>
+    );
+  }
+
+  if (!user) return null;
+
+  return (
+    <div className="min-h-screen py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-center gap-3 mb-8">
+          <Settings size={28} className="text-stellar-blue" />
+          <h1 className="text-3xl font-bold text-dark-heading">Settings</h1>
+        </div>
+
+        <form onSubmit={handleSubmit} className="card space-y-6">
+          <h2 className="text-xl font-semibold text-dark-heading">Edit Profile</h2>
+
+          {errors.general && (
+            <div className="bg-red-900/30 border border-red-700 text-red-200 rounded-lg px-4 py-3 text-sm">
+              {errors.general}
+            </div>
+          )}
+
+          {/* Username */}
+          <div>
+            <label htmlFor="username" className="block text-sm font-medium text-dark-heading mb-2">
+              <span className="flex items-center gap-2">
+                <User size={14} />
+                Username
+              </span>
+            </label>
+            <input
+              id="username"
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className="input-field"
+              placeholder="Your username"
+              aria-describedby={errors.username ? "username-error" : undefined}
+            />
+            {errors.username && (
+              <p id="username-error" className="text-red-400 text-xs mt-1">
+                {errors.username}
+              </p>
+            )}
+          </div>
+
+          {/* Email */}
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-dark-heading mb-2">
+              <span className="flex items-center gap-2">
+                <Mail size={14} />
+                Email
+              </span>
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="input-field"
+              placeholder="your@email.com"
+              aria-describedby={errors.email ? "email-error" : undefined}
+            />
+            {errors.email && (
+              <p id="email-error" className="text-red-400 text-xs mt-1">
+                {errors.email}
+              </p>
+            )}
+          </div>
+
+          {/* Bio */}
+          <div>
+            <label htmlFor="bio" className="block text-sm font-medium text-dark-heading mb-2">
+              <span className="flex items-center gap-2">
+                <FileText size={14} />
+                Bio
+              </span>
+            </label>
+            <textarea
+              id="bio"
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              className="input-field min-h-[120px] resize-y"
+              placeholder="Tell us about yourself..."
+              maxLength={500}
+              aria-describedby={errors.bio ? "bio-error" : "bio-count"}
+            />
+            <div className="flex justify-between mt-1">
+              {errors.bio ? (
+                <p id="bio-error" className="text-red-400 text-xs">
+                  {errors.bio}
+                </p>
+              ) : (
+                <span />
+              )}
+              <span id="bio-count" className="text-dark-text text-xs">
+                {bio.length}/500
+              </span>
+            </div>
+          </div>
+
+          {/* Avatar URL */}
+          <div>
+            <label htmlFor="avatarUrl" className="block text-sm font-medium text-dark-heading mb-2">
+              <span className="flex items-center gap-2">
+                <LinkIcon size={14} />
+                Avatar URL
+              </span>
+            </label>
+            <input
+              id="avatarUrl"
+              type="url"
+              value={avatarUrl}
+              onChange={(e) => setAvatarUrl(e.target.value)}
+              className="input-field"
+              placeholder="https://example.com/avatar.png"
+              aria-describedby={errors.avatarUrl ? "avatar-error" : undefined}
+            />
+            {errors.avatarUrl && (
+              <p id="avatar-error" className="text-red-400 text-xs mt-1">
+                {errors.avatarUrl}
+              </p>
+            )}
+            {avatarUrl && !errors.avatarUrl && (
+              <div className="mt-3 flex items-center gap-3">
+                <img
+                  src={avatarUrl}
+                  alt="Avatar preview"
+                  className="w-12 h-12 rounded-full object-cover border border-dark-border"
+                  onError={(e) => {
+                    (e.target as HTMLImageElement).style.display = "none";
+                  }}
+                />
+                <span className="text-dark-text text-xs">Preview</span>
+              </div>
+            )}
+          </div>
+
+          {/* Role Toggle */}
+          <div>
+            <label className="block text-sm font-medium text-dark-heading mb-3">
+              Role
+            </label>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setRole("CLIENT")}
+                className={`flex-1 py-3 px-4 rounded-lg border text-sm font-medium transition-colors ${
+                  role === "CLIENT"
+                    ? "bg-stellar-blue/20 border-stellar-blue text-stellar-blue"
+                    : "bg-dark-card border-dark-border text-dark-text hover:border-dark-text"
+                }`}
+                aria-pressed={role === "CLIENT"}
+              >
+                Client
+              </button>
+              <button
+                type="button"
+                onClick={() => setRole("FREELANCER")}
+                className={`flex-1 py-3 px-4 rounded-lg border text-sm font-medium transition-colors ${
+                  role === "FREELANCER"
+                    ? "bg-stellar-purple/20 border-stellar-purple text-stellar-purple"
+                    : "bg-dark-card border-dark-border text-dark-text hover:border-dark-text"
+                }`}
+                aria-pressed={role === "FREELANCER"}
+              >
+                Freelancer
+              </button>
+            </div>
+          </div>
+
+          {/* Submit */}
+          <div className="flex justify-end pt-2">
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="btn-primary flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSaving ? (
+                <>
+                  <Loader2 size={16} className="animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                "Save Changes"
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -11,17 +11,21 @@ import {
   PenLine,
   LogOut,
   Loader2,
+  Settings,
+  UserCircle,
 } from "lucide-react";
 import axios from "axios";
 import { useState, useRef, useEffect } from "react";
 import { useWallet, truncateAddress } from "@/context/WalletContext";
 import { useSocket } from "@/context/SocketContext";
+import { useAuth } from "@/context/AuthContext";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000/api";
 const TOKEN_KEY = "stellarmarket_jwt";
 
 function WalletButton({ className }: { className?: string }) {
   const { address, isConnecting, error, connect, disconnect } = useWallet();
+  const { user, logout } = useAuth();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -59,12 +63,31 @@ function WalletButton({ className }: { className?: string }) {
         </button>
         {menuOpen && (
           <div className="absolute right-0 mt-2 w-48 bg-dark-card border border-dark-border rounded-lg shadow-lg py-1 z-50">
-            <div className="px-4 py-2 text-xs text-dark-muted border-b border-dark-border break-all">
-              {address}
+            <div className="px-4 py-2 text-xs text-dark-text border-b border-dark-border break-all">
+              {user?.username || address}
             </div>
+            {user && (
+              <Link
+                href={`/profile/${user.id}`}
+                onClick={() => setMenuOpen(false)}
+                className="w-full px-4 py-2 text-sm text-dark-text hover:bg-dark-border/50 flex items-center gap-2 transition-colors"
+              >
+                <UserCircle size={14} />
+                Profile
+              </Link>
+            )}
+            <Link
+              href="/settings"
+              onClick={() => setMenuOpen(false)}
+              className="w-full px-4 py-2 text-sm text-dark-text hover:bg-dark-border/50 flex items-center gap-2 transition-colors"
+            >
+              <Settings size={14} />
+              Settings
+            </Link>
             <button
               onClick={() => {
                 disconnect();
+                logout();
                 setMenuOpen(false);
               }}
               className="w-full px-4 py-2 text-sm text-left text-dark-text hover:bg-dark-border/50 flex items-center gap-2 transition-colors"

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  useEffect,
+} from "react";
+import { CheckCircle, XCircle, X } from "lucide-react";
+
+type ToastType = "success" | "error";
+
+interface Toast {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+interface ToastContextValue {
+  toast: {
+    success: (message: string) => void;
+    error: (message: string) => void;
+  };
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+let nextId = 0;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = useCallback((message: string, type: ToastType) => {
+    const id = nextId++;
+    setToasts((prev) => [...prev, { id, message, type }]);
+  }, []);
+
+  const removeToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = {
+    success: (message: string) => addToast(message, "success"),
+    error: (message: string) => addToast(message, "error"),
+  };
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2">
+        {toasts.map((t) => (
+          <ToastItem key={t.id} toast={t} onClose={() => removeToast(t.id)} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+function ToastItem({ toast, onClose }: { toast: Toast; onClose: () => void }) {
+  useEffect(() => {
+    const timer = setTimeout(onClose, 4000);
+    return () => clearTimeout(timer);
+  }, [onClose]);
+
+  return (
+    <div
+      className={`flex items-center gap-3 px-4 py-3 rounded-lg border shadow-lg min-w-[300px] max-w-[420px] animate-slide-in ${
+        toast.type === "success"
+          ? "bg-green-900/80 border-green-700 text-green-100"
+          : "bg-red-900/80 border-red-700 text-red-100"
+      }`}
+      role="alert"
+    >
+      {toast.type === "success" ? (
+        <CheckCircle size={18} className="shrink-0" />
+      ) : (
+        <XCircle size={18} className="shrink-0" />
+      )}
+      <span className="text-sm flex-1">{toast.message}</span>
+      <button
+        onClick={onClose}
+        className="shrink-0 opacity-70 hover:opacity-100 transition-opacity"
+        aria-label="Dismiss notification"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+  if (context === undefined) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import axios from "axios";
+import { User } from "@/types";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
+const TOKEN_KEY = "stellarmarket_token";
+const USER_KEY = "stellarmarket_user";
+
+interface AuthState {
+  user: User | null;
+  token: string | null;
+  isLoading: boolean;
+  login: (token: string, user: User) => void;
+  logout: () => void;
+  refreshUser: () => Promise<void>;
+  updateUser: (data: Partial<User>) => void;
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Restore session from localStorage on mount
+  useEffect(() => {
+    const storedToken = localStorage.getItem(TOKEN_KEY);
+    const storedUser = localStorage.getItem(USER_KEY);
+
+    if (storedToken && storedUser) {
+      try {
+        setToken(storedToken);
+        setUser(JSON.parse(storedUser));
+      } catch {
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(USER_KEY);
+      }
+    }
+    setIsLoading(false);
+  }, []);
+
+  const login = useCallback((newToken: string, newUser: User) => {
+    setToken(newToken);
+    setUser(newUser);
+    localStorage.setItem(TOKEN_KEY, newToken);
+    localStorage.setItem(USER_KEY, JSON.stringify(newUser));
+  }, []);
+
+  const logout = useCallback(() => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+  }, []);
+
+  const refreshUser = useCallback(async () => {
+    if (!token) return;
+
+    try {
+      const res = await axios.get(`${API_URL}/users/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setUser(res.data);
+      localStorage.setItem(USER_KEY, JSON.stringify(res.data));
+    } catch (error: any) {
+      if (error.response?.status === 401) {
+        logout();
+      }
+    }
+  }, [token, logout]);
+
+  const updateUser = useCallback((data: Partial<User>) => {
+    setUser((prev) => {
+      if (!prev) return prev;
+      const updated = { ...prev, ...data };
+      localStorage.setItem(USER_KEY, JSON.stringify(updated));
+      return updated;
+    });
+  }, []);
+
+  const value = useMemo<AuthState>(
+    () => ({
+      user,
+      token,
+      isLoading,
+      login,
+      logout,
+      refreshUser,
+      updateUser,
+    }),
+    [user, token, isLoading, login, logout, refreshUser, updateUser]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthState {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary

- **Backend**: Add `GET /api/users/me` and `PUT /api/users/me` endpoints with Zod schema validation and username/email uniqueness enforcement
- **Frontend**: Create `/settings` page with profile edit form (username, email, bio, avatar URL, role toggle), AuthContext for JWT state management, and Toast notification component
- **Navbar**: Add Settings and Profile links to the wallet dropdown menu

Closes #16

## Changes

### Backend
| File | Change |
|---|---|
| `backend/src/routes/user.routes.ts` | Add GET/PUT `/api/users/me` routes with Zod validation and uniqueness checks |
| `backend/package.json` | Add `zod` dependency |

### Frontend
| File | Change |
|---|---|
| `frontend/src/app/settings/page.tsx` | New settings page with profile edit form |
| `frontend/src/context/AuthContext.tsx` | New AuthContext for JWT token and user state management |
| `frontend/src/components/Toast.tsx` | New lightweight toast notification component |
| `frontend/src/components/Navbar.tsx` | Add Settings/Profile links to wallet dropdown |
| `frontend/src/app/providers.tsx` | Wire AuthProvider and ToastProvider |
| `frontend/src/app/globals.css` | Add slide-in animation for toasts |

## Acceptance Criteria
- [x] Authenticated users can update their profile information
- [x] Username/email uniqueness is enforced (409 conflict response)
- [x] Changes are reflected immediately in the Navbar and profile page via AuthContext

## Test Plan
- [ ] Sign in, navigate to Settings via Navbar dropdown
- [ ] Verify form is pre-filled with current user data
- [ ] Update each field (username, email, bio, avatar URL, role) and save
- [ ] Verify success toast appears and Navbar reflects updated username
- [ ] Test duplicate username/email — verify error toast and inline message
- [ ] Test invalid inputs (short username, bad email, invalid URL) — verify client-side validation
- [ ] Test unauthenticated access to /settings — verify redirect to home