### PR TITLE
feat: implement automatic escrow refund when job is abandoned past deadline #43

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -131,9 +131,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2163a0e204a148662b6b6816d4b5d5668a5f2f8df498ccbd5cd0e864e78fecba"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -618,9 +618,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.87"
+version = "0.3.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
+checksum = "f4eacb0641a310445a4c513f2a5e23e19952e269c6a38887254d5f837a305506"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1428,9 +1428,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "05d7d0fce354c88b7982aec4400b3e7fcf723c32737cef571bd165f7613557ee"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1441,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "55839b71ba921e4f75b674cb16f843f4b1f3b26ddfcb3454de1cf65cc021ec0f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "caf2e969c2d60ff52e7e98b7392ff1588bffdd1ccd4769eba27222fd3d621571"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1464,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "0861f0dcdf46ea819407495634953cdcc8a8c7215ab799a7a7ce366be71c7b30"
 dependencies = [
  "unicode-ident",
 ]

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -1,7 +1,11 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Ledger}, vec, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    vec, Env, String,
+};
 
 #[contract]
 pub struct MockToken;
@@ -10,6 +14,10 @@ pub struct MockToken;
 impl MockToken {
     pub fn transfer(_env: Env, _from: Address, _to: Address, _amount: i128) {}
 }
+
+const GRACE_PERIOD: u64 = 604_800; // 7 days in seconds
+
+// ── Existing tests (updated for auto_refund_after parameter) ─────────────────
 
 #[test]
 fn test_create_job() {
@@ -33,7 +41,7 @@ fn test_create_job() {
         (String::from_str(&env, "Backend integration"), 1500_i128, 4000_u64),
     ];
 
-    let job_id = client.create_job(&user_client, &freelancer, &token, &milestones, &5000_u64);
+    let job_id = client.create_job(&user_client, &freelancer, &token, &milestones, &5000_u64, &GRACE_PERIOD);
     assert_eq!(job_id, 1);
 
     let job = client.get_job(&job_id);
@@ -43,6 +51,7 @@ fn test_create_job() {
     assert_eq!(job.status, JobStatus::Created);
     assert_eq!(job.milestones.len(), 3);
     assert_eq!(job.job_deadline, 5000);
+    assert_eq!(job.auto_refund_after, GRACE_PERIOD);
 }
 
 #[test]
@@ -63,8 +72,8 @@ fn test_job_count_increments() {
         (String::from_str(&env, "Task 1"), 100_i128, 2000_u64),
     ];
 
-    let id1 = client.create_job(&user, &freelancer, &token, &milestones, &2500_u64);
-    let id2 = client.create_job(&user, &freelancer, &token, &milestones, &2500_u64);
+    let id1 = client.create_job(&user, &freelancer, &token, &milestones, &2500_u64, &GRACE_PERIOD);
+    let id2 = client.create_job(&user, &freelancer, &token, &milestones, &2500_u64, &GRACE_PERIOD);
 
     assert_eq!(id1, 1);
     assert_eq!(id2, 2);
@@ -90,7 +99,7 @@ fn test_create_job_invalid_deadline() {
         (String::from_str(&env, "Task 1"), 100_i128, 500_u64), // Invalid, < 1000
     ];
 
-    client.create_job(&user, &freelancer, &token, &milestones, &2000_u64);
+    client.create_job(&user, &freelancer, &token, &milestones, &2000_u64, &GRACE_PERIOD);
 }
 
 #[test]
@@ -112,7 +121,7 @@ fn test_submit_milestone_past_deadline() {
         (String::from_str(&env, "Task 1"), 100_i128, 2000_u64),
     ];
 
-    let job_id = client.create_job(&user, &freelancer, &token, &milestones, &3000_u64);
+    let job_id = client.create_job(&user, &freelancer, &token, &milestones, &3000_u64, &GRACE_PERIOD);
     client.fund_job(&job_id, &user);
 
     // fast forward past deadline
@@ -139,8 +148,8 @@ fn test_is_milestone_overdue() {
         (String::from_str(&env, "Task 1"), 100_i128, 2000_u64),
     ];
 
-    let job_id = client.create_job(&user, &freelancer, &token, &milestones, &3000_u64);
-    
+    let job_id = client.create_job(&user, &freelancer, &token, &milestones, &3000_u64, &GRACE_PERIOD);
+
     // not overdue initially
     assert_eq!(client.is_milestone_overdue(&job_id, &0), false);
 
@@ -169,10 +178,282 @@ fn test_extend_deadline() {
         (String::from_str(&env, "Task 1"), 100_i128, 2000_u64),
     ];
 
-    let job_id = client.create_job(&user, &freelancer, &token, &milestones, &3000_u64);
+    let job_id = client.create_job(&user, &freelancer, &token, &milestones, &3000_u64, &GRACE_PERIOD);
 
     client.extend_deadline(&job_id, &0, &4000_u64);
 
     let job = client.get_job(&job_id);
     assert_eq!(job.milestones.get(0).unwrap().deadline, 4000);
+}
+
+// ── Helpers for claim_refund tests ───────────────────────────────────────────
+
+fn setup_refund_env(env: &Env) -> (EscrowContractClient, Address) {
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let contract_id = env.register_contract(None, EscrowContract);
+    let escrow = EscrowContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let token_addr = env.register_stellar_asset_contract(admin.clone());
+
+    (escrow, token_addr)
+}
+
+fn mint_tokens(env: &Env, token: &Address, to: &Address, amount: i128) {
+    let admin_client = StellarAssetClient::new(env, token);
+    admin_client.mint(to, &amount);
+}
+
+fn default_milestones(env: &Env) -> Vec<(String, i128, u64)> {
+    vec![
+        env,
+        (String::from_str(env, "Design"), 500_i128, 500_000_u64),
+        (String::from_str(env, "Frontend"), 1000_i128, 700_000_u64),
+        (String::from_str(env, "Backend"), 1500_i128, 900_000_u64),
+    ]
+}
+
+const JOB_DEADLINE: u64 = 1_000_000;
+
+// ── Full refund: no milestones approved, job funded and abandoned ─────────────
+
+#[test]
+fn test_claim_refund_full() {
+    let env = Env::default();
+    let (escrow, token) = setup_refund_env(&env);
+
+    let client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+    let milestones = default_milestones(&env);
+
+    let job_id = escrow.create_job(
+        &client, &freelancer, &token, &milestones, &JOB_DEADLINE, &GRACE_PERIOD,
+    );
+
+    mint_tokens(&env, &token, &client, 3000);
+    escrow.fund_job(&job_id, &client);
+
+    // Advance time past job_deadline + grace period
+    env.ledger().with_mut(|l| l.timestamp = JOB_DEADLINE + GRACE_PERIOD + 1);
+
+    escrow.claim_refund(&job_id, &client);
+
+    let job = escrow.get_job(&job_id);
+    assert_eq!(job.status, JobStatus::Cancelled);
+
+    // Client should have received full refund (3000)
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&client), 3000);
+}
+
+// ── Partial refund: one milestone approved, rest refunded ────────────────────
+
+#[test]
+fn test_claim_refund_partial() {
+    let env = Env::default();
+    let (escrow, token) = setup_refund_env(&env);
+
+    let client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+    let milestones = default_milestones(&env);
+
+    let job_id = escrow.create_job(
+        &client, &freelancer, &token, &milestones, &JOB_DEADLINE, &GRACE_PERIOD,
+    );
+
+    mint_tokens(&env, &token, &client, 3000);
+    escrow.fund_job(&job_id, &client);
+
+    // Freelancer submits milestone 0, client approves it (500 released)
+    escrow.submit_milestone(&job_id, &0, &freelancer);
+    escrow.approve_milestone(&job_id, &0, &client);
+
+    // Advance past job_deadline + grace
+    env.ledger().with_mut(|l| l.timestamp = JOB_DEADLINE + GRACE_PERIOD + 1);
+
+    escrow.claim_refund(&job_id, &client);
+
+    let job = escrow.get_job(&job_id);
+    assert_eq!(job.status, JobStatus::Cancelled);
+
+    // Client gets back 3000 - 500 = 2500
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&client), 2500);
+
+    // Freelancer received 500 from the approved milestone
+    assert_eq!(token_client.balance(&freelancer), 500);
+}
+
+// ── Refund on InProgress job ─────────────────────────────────────────────────
+
+#[test]
+fn test_claim_refund_in_progress_status() {
+    let env = Env::default();
+    let (escrow, token) = setup_refund_env(&env);
+
+    let client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+    let milestones = default_milestones(&env);
+
+    let job_id = escrow.create_job(
+        &client, &freelancer, &token, &milestones, &JOB_DEADLINE, &GRACE_PERIOD,
+    );
+
+    mint_tokens(&env, &token, &client, 3000);
+    escrow.fund_job(&job_id, &client);
+
+    // Submit and approve first milestone to move to InProgress
+    escrow.submit_milestone(&job_id, &0, &freelancer);
+    escrow.approve_milestone(&job_id, &0, &client);
+
+    let job = escrow.get_job(&job_id);
+    assert_eq!(job.status, JobStatus::InProgress);
+
+    env.ledger().with_mut(|l| l.timestamp = JOB_DEADLINE + GRACE_PERIOD + 1);
+
+    escrow.claim_refund(&job_id, &client);
+    let job = escrow.get_job(&job_id);
+    assert_eq!(job.status, JobStatus::Cancelled);
+}
+
+// ── Fail: grace period not met ───────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")] // GracePeriodNotMet
+fn test_claim_refund_fails_before_grace_period() {
+    let env = Env::default();
+    let (escrow, token) = setup_refund_env(&env);
+
+    let client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+    let milestones = default_milestones(&env);
+
+    let job_id = escrow.create_job(
+        &client, &freelancer, &token, &milestones, &JOB_DEADLINE, &GRACE_PERIOD,
+    );
+
+    mint_tokens(&env, &token, &client, 3000);
+    escrow.fund_job(&job_id, &client);
+
+    // Time is before job_deadline + grace (only at deadline)
+    env.ledger().with_mut(|l| l.timestamp = JOB_DEADLINE);
+
+    escrow.claim_refund(&job_id, &client);
+}
+
+// ── Fail: pending milestone submission ───────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")] // HasPendingMilestone
+fn test_claim_refund_fails_with_pending_milestone() {
+    let env = Env::default();
+    let (escrow, token) = setup_refund_env(&env);
+
+    let client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+    let milestones = default_milestones(&env);
+
+    let job_id = escrow.create_job(
+        &client, &freelancer, &token, &milestones, &JOB_DEADLINE, &GRACE_PERIOD,
+    );
+
+    mint_tokens(&env, &token, &client, 3000);
+    escrow.fund_job(&job_id, &client);
+
+    // Freelancer submits a milestone (status = Submitted, not yet approved)
+    escrow.submit_milestone(&job_id, &0, &freelancer);
+
+    env.ledger().with_mut(|l| l.timestamp = JOB_DEADLINE + GRACE_PERIOD + 1);
+
+    // Should fail because there's a submitted milestone awaiting review
+    escrow.claim_refund(&job_id, &client);
+}
+
+// ── Fail: wrong caller (not the client) ──────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")] // Unauthorized
+fn test_claim_refund_fails_unauthorized() {
+    let env = Env::default();
+    let (escrow, token) = setup_refund_env(&env);
+
+    let client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+    let milestones = default_milestones(&env);
+
+    let job_id = escrow.create_job(
+        &client, &freelancer, &token, &milestones, &JOB_DEADLINE, &GRACE_PERIOD,
+    );
+
+    mint_tokens(&env, &token, &client, 3000);
+    escrow.fund_job(&job_id, &client);
+
+    env.ledger().with_mut(|l| l.timestamp = JOB_DEADLINE + GRACE_PERIOD + 1);
+
+    // Freelancer tries to claim refund — should fail
+    escrow.claim_refund(&job_id, &freelancer);
+}
+
+// ── Fail: job already completed ──────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")] // InvalidStatus
+fn test_claim_refund_fails_on_completed_job() {
+    let env = Env::default();
+    let (escrow, token) = setup_refund_env(&env);
+
+    let client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+
+    // Single milestone so we can complete the whole job
+    let milestones = vec![&env, (String::from_str(&env, "Only task"), 1000_i128, 500_000_u64)];
+
+    let job_id = escrow.create_job(
+        &client, &freelancer, &token, &milestones, &JOB_DEADLINE, &GRACE_PERIOD,
+    );
+
+    mint_tokens(&env, &token, &client, 1000);
+    escrow.fund_job(&job_id, &client);
+
+    // Complete the job
+    escrow.submit_milestone(&job_id, &0, &freelancer);
+    escrow.approve_milestone(&job_id, &0, &client);
+
+    let job = escrow.get_job(&job_id);
+    assert_eq!(job.status, JobStatus::Completed);
+
+    env.ledger().with_mut(|l| l.timestamp = JOB_DEADLINE + GRACE_PERIOD + 1);
+
+    // Should fail — job is already completed
+    escrow.claim_refund(&job_id, &client);
+}
+
+// ── Fail: job already cancelled ──────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")] // InvalidStatus
+fn test_claim_refund_fails_on_cancelled_job() {
+    let env = Env::default();
+    let (escrow, token) = setup_refund_env(&env);
+
+    let client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+    let milestones = default_milestones(&env);
+
+    let job_id = escrow.create_job(
+        &client, &freelancer, &token, &milestones, &JOB_DEADLINE, &GRACE_PERIOD,
+    );
+
+    mint_tokens(&env, &token, &client, 3000);
+    escrow.fund_job(&job_id, &client);
+
+    // Cancel the job first via existing cancel_job
+    escrow.cancel_job(&job_id, &client);
+
+    env.ledger().with_mut(|l| l.timestamp = JOB_DEADLINE + GRACE_PERIOD + 1);
+
+    // Should fail — job is already cancelled
+    escrow.claim_refund(&job_id, &client);
 }


### PR DESCRIPTION
## Summary

- Adds `auto_refund_after: u64` configurable grace period field to `Job` struct and `create_job` function
- Implements `claim_refund(job_id, client)` allowing clients to reclaim escrowed funds after the job deadline + grace period has elapsed
- Refund calculation excludes amounts for already-approved milestones (partial refund support)
- Prevents refund if freelancer has a pending (submitted) milestone awaiting review
- Validates job status is `Funded` or `InProgress`; fails gracefully for `Completed`/`Cancelled` jobs
- Adds 3 new error variants: `HasPendingMilestone`, `NoRefundDue`, `GracePeriodNotMet`
- Follows upstream patterns: TTL bumping, event emission, `require_auth`

Closes #43

## Test plan

- [x] Full refund scenario — no milestones approved, client gets back entire escrow
- [x] Partial refund scenario — one milestone approved (500), client gets 2500 of 3000
- [x] Refund works on `InProgress` status jobs
- [x] Fails before grace period elapses (`GracePeriodNotMet`)
- [x] Fails when freelancer has submitted milestone awaiting approval (`HasPendingMilestone`)
- [x] Fails when non-client calls (`Unauthorized`)
- [x] Fails on already completed job (`InvalidStatus`)
- [x] Fails on already cancelled job (`InvalidStatus`)
- [x] All 14 tests pass (6 existing + 8 new)