### PR TITLE
docs(contracts): add deployment scripts and contributor deployment docs

### DIFF
--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -1,0 +1,8 @@
+# Stellar network configured in your CLI (example: testnet)
+STELLAR_NETWORK=testnet
+
+# Source account identity configured in Stellar CLI
+SOURCE_ACCOUNT=alice
+
+# Token contract address used by escrow/reputation flows
+TOKEN_ADDRESS=CDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/contracts/ADDRESSES.md
+++ b/contracts/ADDRESSES.md
@@ -1,0 +1,21 @@
+# Contract Addresses
+
+Use this file to record deployed contract IDs after each testnet deployment.
+
+## Testnet Deployments
+
+Deployment Date: `YYYY-MM-DD`  
+Network: `testnet`  
+Deployer (`SOURCE_ACCOUNT`): `<account-name-or-address>`  
+Commit SHA: `<git-sha>`
+
+| Contract | Contract ID | Deployer | Commit SHA | Notes |
+| --- | --- | --- | --- | --- |
+| escrow | `<fill-after-deploy>` | `<fill>` | `<fill>` | |
+| reputation | `<fill-after-deploy>` | `<fill>` | `<fill>` | |
+| dispute | `<fill-after-deploy>` | `<fill>` | `<fill>` | |
+
+## Notes
+
+- Update this file immediately after running deployment scripts.
+- Keep prior deployment records by adding a new section per deployment date.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,223 @@
+# StellarMarket Contracts
+
+This directory contains Soroban smart contracts for:
+
+- `escrow` (`stellar-market-escrow`)
+- `reputation` (`stellar-market-reputation`)
+- `dispute` (`stellar-market-dispute`)
+- `integration-tests` (`stellar-market-integration-tests`)
+
+## Prerequisites
+
+- Rust toolchain (stable)
+- wasm target:
+  - `rustup target add wasm32-unknown-unknown`
+- Stellar CLI installed and configured
+- A funded testnet account identity in Stellar CLI
+
+## Project Map
+
+- `escrow/` - Escrow and milestone payment contract
+- `reputation/` - Reputation and stake-weighted reviews
+- `dispute/` - Dispute voting and resolution
+- `integration-tests/` - Cross-contract integration tests
+- `scripts/` - Deployment scripts
+
+## Build
+
+From `contracts/`:
+
+```bash
+# Build all contracts for wasm
+cargo build --release --target wasm32-unknown-unknown
+
+# Build individual contracts
+cargo build --release --target wasm32-unknown-unknown -p stellar-market-escrow
+cargo build --release --target wasm32-unknown-unknown -p stellar-market-reputation
+cargo build --release --target wasm32-unknown-unknown -p stellar-market-dispute
+```
+
+## Test
+
+From `contracts/`:
+
+```bash
+# All tests in workspace
+cargo test
+
+# Per-contract tests
+cargo test -p stellar-market-escrow
+cargo test -p stellar-market-reputation
+cargo test -p stellar-market-dispute
+
+# Integration tests
+cargo test -p stellar-market-integration-tests
+```
+
+See detailed integration test notes in `contracts/integration-tests/README.md`.
+
+## Environment Setup
+
+Create a local env file:
+
+```bash
+cp contracts/.env.example contracts/.env
+```
+
+Required variables:
+
+- `STELLAR_NETWORK` - network name configured in Stellar CLI (for example `testnet`)
+- `SOURCE_ACCOUNT` - CLI identity/account used for deployments and invokes
+- `TOKEN_ADDRESS` - token contract address used in escrow/reputation flows
+
+## Deploy Contracts
+
+Do not run these scripts unless you intend to deploy.
+
+```bash
+bash contracts/scripts/deploy_escrow.sh
+bash contracts/scripts/deploy_reputation.sh
+bash contracts/scripts/deploy_dispute.sh
+```
+
+Each script:
+
+1. Loads env from `contracts/.env` (if present)
+2. Validates required variables
+3. Builds the target wasm
+4. Runs `stellar contract deploy`
+5. Prints deployed contract ID
+
+After deployment, record IDs in `contracts/ADDRESSES.md`.
+
+## Invoke Examples (Testnet)
+
+Replace placeholders like `<ESCROW_CONTRACT_ID>` before running.
+
+### Escrow
+
+```bash
+# create_job(client, freelancer, token, milestones, job_deadline, auto_refund_after)
+stellar contract invoke \
+  --id <ESCROW_CONTRACT_ID> \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$STELLAR_NETWORK" \
+  -- \
+  create_job \
+  --client <CLIENT_ADDRESS> \
+  --freelancer <FREELANCER_ADDRESS> \
+  --token "$TOKEN_ADDRESS" \
+  --milestones '[["Design",10000000,1735689600],["Build",20000000,1736294400]]' \
+  --job_deadline 1736899200 \
+  --auto_refund_after 1737504000
+
+# get_job(job_id)
+stellar contract invoke \
+  --id <ESCROW_CONTRACT_ID> \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$STELLAR_NETWORK" \
+  -- \
+  get_job \
+  --job_id 1
+```
+
+### Reputation
+
+```bash
+# initialize(admin, decay_rate)
+stellar contract invoke \
+  --id <REPUTATION_CONTRACT_ID> \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$STELLAR_NETWORK" \
+  -- \
+  initialize \
+  --admin <ADMIN_ADDRESS> \
+  --decay_rate 5
+
+# submit_review(escrow_contract_id, reviewer, reviewee, job_id, rating, comment, stake_weight)
+stellar contract invoke \
+  --id <REPUTATION_CONTRACT_ID> \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$STELLAR_NETWORK" \
+  -- \
+  submit_review \
+  --escrow_contract_id <ESCROW_CONTRACT_ID> \
+  --reviewer <REVIEWER_ADDRESS> \
+  --reviewee <REVIEWEE_ADDRESS> \
+  --job_id 1 \
+  --rating 5 \
+  --comment "great work" \
+  --stake_weight 10000000
+
+# get_average_rating(user)
+stellar contract invoke \
+  --id <REPUTATION_CONTRACT_ID> \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$STELLAR_NETWORK" \
+  -- \
+  get_average_rating \
+  --user <USER_ADDRESS>
+```
+
+### Dispute
+
+```bash
+# initialize(admin, reputation_contract, min_voter_reputation, escrow_contract)
+stellar contract invoke \
+  --id <DISPUTE_CONTRACT_ID> \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$STELLAR_NETWORK" \
+  -- \
+  initialize \
+  --admin <ADMIN_ADDRESS> \
+  --reputation_contract <REPUTATION_CONTRACT_ID> \
+  --min_voter_reputation 300 \
+  --escrow_contract <ESCROW_CONTRACT_ID>
+
+# raise_dispute(job_id, client, freelancer, initiator, reason, min_votes, tie_break_method)
+stellar contract invoke \
+  --id <DISPUTE_CONTRACT_ID> \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$STELLAR_NETWORK" \
+  -- \
+  raise_dispute \
+  --job_id 1 \
+  --client <CLIENT_ADDRESS> \
+  --freelancer <FREELANCER_ADDRESS> \
+  --initiator <INITIATOR_ADDRESS> \
+  --reason "milestone quality issue" \
+  --min_votes 3 \
+  --tie_break_method "Escalate"
+
+# cast_vote(dispute_id, voter, choice, reason)
+stellar contract invoke \
+  --id <DISPUTE_CONTRACT_ID> \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$STELLAR_NETWORK" \
+  -- \
+  cast_vote \
+  --dispute_id 1 \
+  --voter <VOTER_ADDRESS> \
+  --choice "Freelancer" \
+  --reason "evidence supports delivery"
+
+# resolve_dispute(dispute_id)
+stellar contract invoke \
+  --id <DISPUTE_CONTRACT_ID> \
+  --source-account "$SOURCE_ACCOUNT" \
+  --network "$STELLAR_NETWORK" \
+  -- \
+  resolve_dispute \
+  --dispute_id 1
+```
+
+## Troubleshooting
+
+- wasm target missing:
+  - `rustup target add wasm32-unknown-unknown`
+- missing env variables:
+  - ensure `contracts/.env` exists and includes all required keys
+- unknown network/account:
+  - verify Stellar CLI network and identity config
+- missing deployed IDs:
+  - update `contracts/ADDRESSES.md` after deployments

--- a/contracts/scripts/deploy_dispute.sh
+++ b/contracts/scripts/deploy_dispute.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTRACTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(cd "${CONTRACTS_DIR}/.." && pwd)"
+
+if [[ -f "${CONTRACTS_DIR}/.env" ]]; then
+  # shellcheck disable=SC1091
+  source "${CONTRACTS_DIR}/.env"
+fi
+
+required_vars=(STELLAR_NETWORK SOURCE_ACCOUNT TOKEN_ADDRESS)
+for var_name in "${required_vars[@]}"; do
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "Error: ${var_name} is required. Set it in contracts/.env or your shell."
+    exit 1
+  fi
+done
+
+if ! command -v stellar >/dev/null 2>&1; then
+  echo "Error: stellar CLI is required but not found in PATH."
+  exit 1
+fi
+
+cd "${CONTRACTS_DIR}"
+
+echo "Building dispute contract..."
+cargo build --release --target wasm32-unknown-unknown -p stellar-market-dispute
+
+WASM_PATH="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release/stellar_market_dispute.wasm"
+if [[ ! -f "${WASM_PATH}" ]]; then
+  echo "Error: expected wasm artifact not found at ${WASM_PATH}"
+  exit 1
+fi
+
+echo "Deploying dispute contract to network '${STELLAR_NETWORK}'..."
+CONTRACT_ID="$(
+  stellar contract deploy \
+    --wasm "${WASM_PATH}" \
+    --source-account "${SOURCE_ACCOUNT}" \
+    --network "${STELLAR_NETWORK}"
+)"
+
+echo ""
+echo "Dispute contract deployed successfully."
+echo "Contract ID: ${CONTRACT_ID}"
+echo "Record this in ${ROOT_DIR}/contracts/ADDRESSES.md"

--- a/contracts/scripts/deploy_escrow.sh
+++ b/contracts/scripts/deploy_escrow.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTRACTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(cd "${CONTRACTS_DIR}/.." && pwd)"
+
+if [[ -f "${CONTRACTS_DIR}/.env" ]]; then
+  # shellcheck disable=SC1091
+  source "${CONTRACTS_DIR}/.env"
+fi
+
+required_vars=(STELLAR_NETWORK SOURCE_ACCOUNT TOKEN_ADDRESS)
+for var_name in "${required_vars[@]}"; do
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "Error: ${var_name} is required. Set it in contracts/.env or your shell."
+    exit 1
+  fi
+done
+
+if ! command -v stellar >/dev/null 2>&1; then
+  echo "Error: stellar CLI is required but not found in PATH."
+  exit 1
+fi
+
+cd "${CONTRACTS_DIR}"
+
+echo "Building escrow contract..."
+cargo build --release --target wasm32-unknown-unknown -p stellar-market-escrow
+
+WASM_PATH="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release/stellar_market_escrow.wasm"
+if [[ ! -f "${WASM_PATH}" ]]; then
+  echo "Error: expected wasm artifact not found at ${WASM_PATH}"
+  exit 1
+fi
+
+echo "Deploying escrow contract to network '${STELLAR_NETWORK}'..."
+CONTRACT_ID="$(
+  stellar contract deploy \
+    --wasm "${WASM_PATH}" \
+    --source-account "${SOURCE_ACCOUNT}" \
+    --network "${STELLAR_NETWORK}"
+)"
+
+echo ""
+echo "Escrow contract deployed successfully."
+echo "Contract ID: ${CONTRACT_ID}"
+echo "Record this in ${ROOT_DIR}/contracts/ADDRESSES.md"

--- a/contracts/scripts/deploy_reputation.sh
+++ b/contracts/scripts/deploy_reputation.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTRACTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(cd "${CONTRACTS_DIR}/.." && pwd)"
+
+if [[ -f "${CONTRACTS_DIR}/.env" ]]; then
+  # shellcheck disable=SC1091
+  source "${CONTRACTS_DIR}/.env"
+fi
+
+required_vars=(STELLAR_NETWORK SOURCE_ACCOUNT TOKEN_ADDRESS)
+for var_name in "${required_vars[@]}"; do
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "Error: ${var_name} is required. Set it in contracts/.env or your shell."
+    exit 1
+  fi
+done
+
+if ! command -v stellar >/dev/null 2>&1; then
+  echo "Error: stellar CLI is required but not found in PATH."
+  exit 1
+fi
+
+cd "${CONTRACTS_DIR}"
+
+echo "Building reputation contract..."
+cargo build --release --target wasm32-unknown-unknown -p stellar-market-reputation
+
+WASM_PATH="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release/stellar_market_reputation.wasm"
+if [[ ! -f "${WASM_PATH}" ]]; then
+  echo "Error: expected wasm artifact not found at ${WASM_PATH}"
+  exit 1
+fi
+
+echo "Deploying reputation contract to network '${STELLAR_NETWORK}'..."
+CONTRACT_ID="$(
+  stellar contract deploy \
+    --wasm "${WASM_PATH}" \
+    --source-account "${SOURCE_ACCOUNT}" \
+    --network "${STELLAR_NETWORK}"
+)"
+
+echo ""
+echo "Reputation contract deployed successfully."
+echo "Contract ID: ${CONTRACT_ID}"
+echo "Record this in ${ROOT_DIR}/contracts/ADDRESSES.md"


### PR DESCRIPTION
Closes #19

---


Added contributor deployment tooling for Soroban contracts: per-contract deploy scripts, contracts env template, address registry file, and a contracts README with build/test/deploy/invoke instructions (no live deployment performed).