### PR TITLE
fix: use user-selected role during registration instead of hardcoded …

### DIFF
--- a/backend/src/routes/__tests__/auth.register.test.ts
+++ b/backend/src/routes/__tests__/auth.register.test.ts
@@ -1,0 +1,199 @@
+import request from "supertest";
+import express from "express";
+
+// Mock otplib (ESM module, must be mocked before import)
+jest.mock("otplib", () => ({
+  generateSecret: jest.fn(() => "MOCKSECRET"),
+  generateSync: jest.fn(() => "123456"),
+  verifySync: jest.fn(),
+  generateURI: jest.fn(),
+}));
+
+// Mock qrcode
+jest.mock("qrcode", () => ({
+  toDataURL: jest.fn().mockResolvedValue("data:image/png;base64,mockqr"),
+}));
+
+// Mock bcryptjs
+jest.mock("bcryptjs", () => ({
+  hash: jest.fn().mockResolvedValue("hashed_password"),
+  compare: jest.fn(),
+}));
+
+// Mock jsonwebtoken
+jest.mock("jsonwebtoken", () => ({
+  sign: jest.fn().mockReturnValue("mock_token"),
+  verify: jest.fn(),
+}));
+
+// Mock Prisma
+jest.mock("@prisma/client", () => {
+  const mockPrisma = {
+    user: {
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => mockPrisma),
+    __mockPrisma: mockPrisma,
+    UserRole: {
+      ADMIN: "ADMIN",
+      CLIENT: "CLIENT",
+      FREELANCER: "FREELANCER",
+    },
+  };
+});
+
+// Mock config
+jest.mock("../../config", () => ({
+  config: {
+    jwtSecret: "test_secret",
+  },
+}));
+
+// Mock email utils
+jest.mock("../../utils/email", () => ({
+  sendPasswordResetEmail: jest.fn(),
+  sendVerificationEmail: jest.fn(),
+}));
+
+// Mock encryption utils
+jest.mock("../../utils/encryption", () => ({
+  encrypt: jest.fn((text: string) => `encrypted:${text}`),
+  decrypt: jest.fn((text: string) => text.replace("encrypted:", "")),
+}));
+
+// Mock token utils
+jest.mock("../../utils/token", () => ({
+  generateToken: jest.fn(),
+  hashToken: jest.fn(),
+}));
+
+import authRoutes from "../auth.routes";
+
+const { __mockPrisma: mockPrisma } = jest.requireMock(
+  "@prisma/client",
+) as any;
+
+const app = express();
+app.use(express.json());
+app.use("/auth", authRoutes);
+
+describe("POST /auth/register - Role Selection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const basePayload = {
+    email: "test@example.com",
+    password: "StrongPass1",
+    stellarAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    name: "TestUser",
+  };
+
+  it("should create a user with role FREELANCER when role is FREELANCER", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    mockPrisma.user.create.mockResolvedValue({
+      id: "user1",
+      walletAddress: basePayload.stellarAddress,
+      username: basePayload.name,
+      email: basePayload.email,
+      role: "FREELANCER",
+    });
+
+    const res = await request(app)
+      .post("/auth/register")
+      .send({ ...basePayload, role: "FREELANCER" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.role).toBe("FREELANCER");
+    expect(mockPrisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          role: "FREELANCER",
+        }),
+      }),
+    );
+  });
+
+  it("should create a user with role CLIENT when role is CLIENT", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    mockPrisma.user.create.mockResolvedValue({
+      id: "user2",
+      walletAddress: basePayload.stellarAddress,
+      username: basePayload.name,
+      email: basePayload.email,
+      role: "CLIENT",
+    });
+
+    const res = await request(app)
+      .post("/auth/register")
+      .send({ ...basePayload, role: "CLIENT" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.role).toBe("CLIENT");
+    expect(mockPrisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          role: "CLIENT",
+        }),
+      }),
+    );
+  });
+
+  it("should default to FREELANCER when role is not provided", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    mockPrisma.user.create.mockResolvedValue({
+      id: "user3",
+      walletAddress: basePayload.stellarAddress,
+      username: basePayload.name,
+      email: basePayload.email,
+      role: "FREELANCER",
+    });
+
+    const res = await request(app)
+      .post("/auth/register")
+      .send(basePayload); // no role field
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.role).toBe("FREELANCER");
+    expect(mockPrisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          role: "FREELANCER",
+        }),
+      }),
+    );
+  });
+
+  it("should reject invalid role values", async () => {
+    const res = await request(app)
+      .post("/auth/register")
+      .send({ ...basePayload, role: "ADMIN" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("should return the role in the API response", async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    mockPrisma.user.create.mockResolvedValue({
+      id: "user4",
+      walletAddress: basePayload.stellarAddress,
+      username: basePayload.name,
+      email: basePayload.email,
+      role: "CLIENT",
+    });
+
+    const res = await request(app)
+      .post("/auth/register")
+      .send({ ...basePayload, role: "CLIENT" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user).toHaveProperty("role", "CLIENT");
+    expect(res.body).toHaveProperty("token");
+  });
+});

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -55,6 +55,7 @@ router.post(
    *                 password: password123
    *                 stellarAddress: GABCD123...
    *                 name: John Doe
+   *                 role: FREELANCER
    *     responses:
    *       201:
    *         description: User registered successfully
@@ -103,7 +104,7 @@ router.post(
   "/register",
   validate({ body: registerSchema }),
   asyncHandler(async (req: Request, res: Response) => {
-    const { stellarAddress, email, name, password } = req.body;
+    const { stellarAddress, email, name, password, role } = req.body;
 
     const existingUser = await prisma.user.findFirst({
       where: {
@@ -127,7 +128,7 @@ router.post(
         email,
         username: name,
         password: hashedPassword,
-        role: "FREELANCER",
+        role: role ?? "FREELANCER",
       },
     });
 

--- a/backend/src/schemas/auth.ts
+++ b/backend/src/schemas/auth.ts
@@ -9,6 +9,7 @@ export const registerSchema = z.object({
     .string()
     .min(2, "Name must be at least 2 characters long")
     .max(100, "Name must be less than 100 characters"),
+  role: z.enum(["CLIENT", "FREELANCER"]).default("FREELANCER"),
 });
 
 export const loginSchema = z.object({

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -93,6 +93,7 @@ export default function AuthForm({ type }: AuthFormProps) {
             email: formData.email,
             password: formData.password,
             stellarAddress: address,
+            role: formData.role,
           }),
         });
 


### PR DESCRIPTION
…FREELANCER

Fixes #131

- Add 'role' field to registerSchema with enum validation (CLIENT | FREELANCER) and default of FREELANCER
- Destructure role from req.body in auth.routes.ts register endpoint and use it instead of the hardcoded 'FREELANCER' value
- Add role to the registration request body in frontend AuthForm.tsx so the user's selection is sent to the API
- Update Swagger example to include role field
- Add 5 unit tests covering: CLIENT role, FREELANCER role, default when omitted, rejection of invalid values, and role in API response