### PR TITLE
Fix GET /api/jobs/:jobId/applications authorization (client-only access)

### DIFF
--- a/backend/src/routes/__tests__/application.routes.test.ts
+++ b/backend/src/routes/__tests__/application.routes.test.ts
@@ -1,0 +1,142 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { config } from "../../config";
+import applicationRouter from "../application.routes";
+
+// ─── Prisma & NotificationService mocks ───────────────────────────────────────
+jest.mock("@prisma/client", () => {
+  const mockPrisma = {
+    job: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    application: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  return {
+    PrismaClient: jest.fn(() => mockPrisma) as any,
+    NotificationType: {
+      JOB_APPLIED: "JOB_APPLIED",
+      APPLICATION_ACCEPTED: "APPLICATION_ACCEPTED",
+    } as any,
+  };
+});
+
+jest.mock("../../services/notification.service", () => ({
+  NotificationService: {
+    sendNotification: jest.fn().mockResolvedValue({ id: "mock-notif-id" }),
+  },
+}));
+
+import { PrismaClient } from "@prisma/client";
+const prismaMock = new PrismaClient() as any;
+const jobMock = prismaMock.job;
+const applicationMock = prismaMock.application;
+
+// ─── App setup ────────────────────────────────────────────────────────────────
+const app = express();
+app.use(express.json());
+app.use("/api", applicationRouter);
+
+// ─── Stable test UUIDs (RFC 4122 v4 format) ──────────────────────────────────
+const JOB_ID = "00000000-0000-4000-8000-000000000100";
+const CLIENT_A_ID = "00000000-0000-4000-8000-000000000001";
+const CLIENT_B_ID = "00000000-0000-4000-8000-000000000002";
+
+function authHeader(userId = CLIENT_A_ID) {
+  const token = jwt.sign({ userId }, config.jwtSecret, { expiresIn: "1h" });
+  return { Authorization: `Bearer ${token}` };
+}
+
+afterEach(() => jest.clearAllMocks());
+
+describe("GET /api/jobs/:jobId/applications", () => {
+  it("returns 401 with no auth token", async () => {
+    const res = await request(app).get(`/api/jobs/${JOB_ID}/applications`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when job does not exist", async () => {
+    jobMock.findUnique.mockResolvedValueOnce(null);
+
+    const res = await request(app)
+      .get(`/api/jobs/${JOB_ID}/applications`)
+      .set(authHeader());
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Job not found." });
+    expect(jobMock.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: JOB_ID },
+        select: { clientId: true },
+      }),
+    );
+    expect(applicationMock.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when authenticated user is not job owner", async () => {
+    jobMock.findUnique.mockResolvedValueOnce({ clientId: CLIENT_B_ID });
+
+    const res = await request(app)
+      .get(`/api/jobs/${JOB_ID}/applications`)
+      .set(authHeader(CLIENT_A_ID));
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: "Not authorized to view applicants for this job.",
+    });
+    expect(applicationMock.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns applicants list when authenticated user is job owner", async () => {
+    jobMock.findUnique.mockResolvedValueOnce({ clientId: CLIENT_A_ID });
+    applicationMock.findMany.mockResolvedValueOnce([
+      {
+        id: "00000000-0000-4000-8000-000000000200",
+        jobId: JOB_ID,
+        freelancerId: "00000000-0000-4000-8000-000000000300",
+        proposal: "x".repeat(60),
+        estimatedDuration: 7,
+        bidAmount: 100,
+        status: "PENDING",
+        createdAt: new Date().toISOString(),
+        freelancer: {
+          id: "00000000-0000-4000-8000-000000000300",
+          username: "freelancer",
+          avatarUrl: null,
+          bio: "bio",
+        },
+      },
+    ]);
+    applicationMock.count.mockResolvedValueOnce(1);
+
+    const res = await request(app)
+      .get(`/api/jobs/${JOB_ID}/applications`)
+      .set(authHeader(CLIENT_A_ID));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      total: 1,
+      page: 1,
+      totalPages: 1,
+    });
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(applicationMock.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { jobId: JOB_ID },
+        orderBy: { createdAt: "desc" },
+        skip: 0,
+        take: 10,
+      }),
+    );
+  });
+});
+

--- a/backend/src/routes/application.routes.ts
+++ b/backend/src/routes/application.routes.ts
@@ -95,6 +95,19 @@ router.get(
     const { page, limit, status } = req.query as any;
     const skip = (page - 1) * limit;
 
+    const job = await prisma.job.findUnique({
+      where: { id: jobId },
+      select: { clientId: true },
+    });
+    if (!job) {
+      return res.status(404).json({ error: "Job not found." });
+    }
+    if (job.clientId !== req.userId) {
+      return res
+        .status(403)
+        .json({ error: "Not authorized to view applicants for this job." });
+    }
+
     const where: any = { jobId };
     if (status) {
       where.status = status;

--- a/backend/src/schemas/job.ts
+++ b/backend/src/schemas/job.ts
@@ -55,7 +55,16 @@ export const getJobsQuerySchema = paginationSchema.extend({
 
 export const getJobByIdParamSchema = z.object({
   id: z.string().uuid(),
-});
+})
+  .or(
+    z.object({
+      jobId: z.string().uuid(),
+    }),
+  )
+  .transform((params) => {
+    const id = "id" in params ? params.id : params.jobId;
+    return { id, jobId: id };
+  });
 
 export const updateJobStatusSchema = z.object({
   status: jobStatusSchema,


### PR DESCRIPTION

## Overview
This PR fixes an authorization flaw in `GET /api/jobs/:jobId/applications` where any authenticated user could view all applicants (proposals, bids, and freelancer profiles) for any job. The endpoint now verifies job ownership so only the job’s client can access the applications list.

## Related Issue
Closes #143

## Changes

### 🔒 Authorization
- **[MODIFY]** `backend/src/routes/application.routes.ts`
  - Added a job ownership check before returning applications.
  - Returns `404` if the job doesn’t exist.
  - Returns `403` if the authenticated user is not the job owner.

### ✅ Validation Compatibility
- **[MODIFY]** `backend/src/schemas/job.ts`
  - Updated job-id param validation to support routes using `:jobId` (and `:id`) consistently.

### 🧪 Tests
- **[ADD]** `backend/src/routes/__tests__/application.routes.test.ts`
  - Added coverage for `401` (unauthenticated), `404` (job not found), `403` (non-owner), and `200` (owner).

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Only the job’s client receives the applicants list | ✅ |
| Any other authenticated user receives 403 | ✅ |
| Unauthenticated users still receive 401 | ✅ |
| The client’s own job returns applicants correctly | ✅ |

## How to Test

```bash
# 1. Confirm you're on the branch
git branch --show-current

# 2. Run backend tests
cd backend
npm test
```

## Screenshots
<img width="694" height="414" alt="image" src="https://github.com/user-attachments/assets/fc4deaef-70d2-4900-867d-7fe0f357525f" />
