### PR TITLE
Fix: Correct AuthContext endpoint from /auth/me to /users/me

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -65,10 +65,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     setToken(storedToken);
 
     try {
-      const response = await axios.get(`${API}/auth/me`, {
+      const response = await axios.get(`${API}/users/me`, {
         headers: { Authorization: `Bearer ${storedToken}` },
       });
-      const userData = response.data.user;
+      const userData = response.data;
       setUser(userData);
       localStorage.setItem(USER_KEY, JSON.stringify(userData));
     } catch (error) {


### PR DESCRIPTION
## Problem
AuthContext was calling `GET /api/auth/me` on every page load to validate the session, but this endpoint does not exist. The correct endpoint is `GET /api/users/me`.

This caused a 404 error on every page refresh, which triggered the catch block to call `logout()`, kicking users back to the login page.

## Changes
- Changed endpoint from `/auth/me` to `/users/me` in the `refreshUser` function
- Fixed response data access from `response.data.user` to `response.data` to match the actual API response structure

## Testing
- ✅ Users remain logged in after page refresh
- ✅ No 404 errors in network tab on page load
- ✅ Session validation works correctly
- ✅ User data is properly fetched and stored

Closes #130