### PR TITLE
feat: enforce role-based UI access — clients post jobs, freelancers apply

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^12.3.0",
+        "@testing-library/dom": "^10.4.1",
         "@uiw/react-md-editor": "^4.0.11",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.9",
@@ -75,7 +76,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -270,7 +270,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1929,9 +1928,7 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1950,9 +1947,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2069,9 +2064,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2278,12 +2271,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3118,7 +3113,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4257,6 +4251,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4531,9 +4526,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8344,9 +8337,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10225,9 +10216,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10241,9 +10230,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10255,9 +10242,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^12.3.0",
+    "@testing-library/dom": "^10.4.1",
     "@uiw/react-md-editor": "^4.0.11",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.9",

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,34 +1,205 @@
 "use client";
 
-import { useState } from "react";
-import { Briefcase, FileText, MessageSquare, Star } from "lucide-react";
+import { useState, useEffect } from "react";
+import {
+  Briefcase,
+  FileText,
+  MessageSquare,
+  Star,
+  DollarSign,
+  Loader2,
+} from "lucide-react";
 import StatusBadge from "@/components/StatusBadge";
-
-const stats = [
-  { label: "Active Jobs", value: "3", icon: Briefcase, color: "text-stellar-blue" },
-  { label: "Pending Apps", value: "5", icon: FileText, color: "text-yellow-400" },
-  { label: "Earnings", value: "12,500 XLM", icon: Star, color: "text-stellar-purple" },
-  { label: "Rating", value: "4.8/5", icon: Star, color: "text-green-400" },
-];
+import { useAuth } from "@/context/AuthContext";
 
 const activeJobs = [
-  { id: "1", title: "Build Soroban DEX Frontend", client: "stellarbuilder", status: "IN_PROGRESS", budget: 5000, deadline: "2025-03-01" },
-  { id: "2", title: "Smart Contract Audit", client: "defiteam", status: "IN_PROGRESS", budget: 8000, deadline: "2025-02-20" },
-  { id: "3", title: "Mobile App for Payments", client: "mobilestellar", status: "OPEN", budget: 12000, deadline: "2025-04-01" },
+  {
+    id: "1",
+    title: "Build Soroban DEX Frontend",
+    client: "stellarbuilder",
+    status: "IN_PROGRESS",
+    budget: 5000,
+    deadline: "2025-03-01",
+  },
+  {
+    id: "2",
+    title: "Smart Contract Audit",
+    client: "defiteam",
+    status: "IN_PROGRESS",
+    budget: 8000,
+    deadline: "2025-02-20",
+  },
+  {
+    id: "3",
+    title: "Mobile App for Payments",
+    client: "mobilestellar",
+    status: "OPEN",
+    budget: 12000,
+    deadline: "2025-04-01",
+  },
 ];
 
 const applications = [
-  { id: "1", job: "Governance Module for DAO", status: "PENDING", appliedAt: "2025-01-12" },
-  { id: "2", job: "Data Analytics Dashboard", status: "ACCEPTED", appliedAt: "2025-01-10" },
-  { id: "3", job: "Technical Docs Writer", status: "REJECTED", appliedAt: "2025-01-08" },
-  { id: "4", job: "Brand Identity Design", status: "PENDING", appliedAt: "2025-01-14" },
-  { id: "5", job: "NFT Marketplace Backend", status: "PENDING", appliedAt: "2025-01-13" },
+  {
+    id: "1",
+    job: "Governance Module for DAO",
+    status: "PENDING",
+    appliedAt: "2025-01-12",
+  },
+  {
+    id: "2",
+    job: "Data Analytics Dashboard",
+    status: "ACCEPTED",
+    appliedAt: "2025-01-10",
+  },
+  {
+    id: "3",
+    job: "Technical Docs Writer",
+    status: "REJECTED",
+    appliedAt: "2025-01-08",
+  },
+  {
+    id: "4",
+    job: "Brand Identity Design",
+    status: "PENDING",
+    appliedAt: "2025-01-14",
+  },
+  {
+    id: "5",
+    job: "NFT Marketplace Backend",
+    status: "PENDING",
+    appliedAt: "2025-01-13",
+  },
 ];
 
-const tabs = ["Active Jobs", "Applications", "Messages"];
+const postedJobs = [
+  {
+    id: "1",
+    title: "Build Soroban DEX Frontend",
+    status: "IN_PROGRESS",
+    budget: 5000,
+    applicants: 4,
+  },
+  {
+    id: "2",
+    title: "Smart Contract Audit",
+    status: "OPEN",
+    budget: 8000,
+    applicants: 7,
+  },
+  {
+    id: "3",
+    title: "API Integration Project",
+    status: "COMPLETED",
+    budget: 3200,
+    applicants: 2,
+  },
+];
+
+const pendingApplicants = [
+  {
+    id: "1",
+    freelancer: "devstellar",
+    job: "Build Soroban DEX Frontend",
+    bid: 4800,
+    appliedAt: "2025-01-14",
+  },
+  {
+    id: "2",
+    freelancer: "cryptobuilder",
+    job: "Smart Contract Audit",
+    bid: 7500,
+    appliedAt: "2025-01-13",
+  },
+  {
+    id: "3",
+    freelancer: "webmaster99",
+    job: "Smart Contract Audit",
+    bid: 8200,
+    appliedAt: "2025-01-12",
+  },
+];
 
 export default function DashboardPage() {
-  const [activeTab, setActiveTab] = useState("Active Jobs");
+  const { user, isLoading } = useAuth();
+  const isClient = user?.role === "CLIENT";
+
+  const clientTabs = ["My Posted Jobs", "Applicants to Review", "Messages"];
+  const freelancerTabs = ["My Applications", "Active Work", "Messages"];
+  const tabs = isClient ? clientTabs : freelancerTabs;
+
+  const [activeTab, setActiveTab] = useState(freelancerTabs[0]);
+
+  // Sync the active tab whenever the role becomes known so we always start
+  // on a tab that belongs to the current role.
+  useEffect(() => {
+    setActiveTab(isClient ? clientTabs[0] : freelancerTabs[0]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isClient]);
+
+  const clientStats = [
+    {
+      label: "Posted Jobs",
+      value: "3",
+      icon: Briefcase,
+      color: "text-stellar-blue",
+    },
+    {
+      label: "Applicants to Review",
+      value: "5",
+      icon: FileText,
+      color: "text-yellow-400",
+    },
+    {
+      label: "Total Spent",
+      value: "12,500 XLM",
+      icon: DollarSign,
+      color: "text-stellar-purple",
+    },
+    {
+      label: "Rating",
+      value: "4.8/5",
+      icon: Star,
+      color: "text-green-400",
+    },
+  ];
+
+  const freelancerStats = [
+    {
+      label: "Active Work",
+      value: "3",
+      icon: Briefcase,
+      color: "text-stellar-blue",
+    },
+    {
+      label: "My Applications",
+      value: "5",
+      icon: FileText,
+      color: "text-yellow-400",
+    },
+    {
+      label: "Income Received",
+      value: "12,500 XLM",
+      icon: DollarSign,
+      color: "text-stellar-purple",
+    },
+    {
+      label: "Rating",
+      value: "4.8/5",
+      icon: Star,
+      color: "text-green-400",
+    },
+  ];
+
+  const stats = isClient ? clientStats : freelancerStats;
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <Loader2 className="animate-spin text-stellar-blue" size={48} />
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -68,29 +239,8 @@ export default function DashboardPage() {
         ))}
       </div>
 
-      {/* Tab Content */}
-      {activeTab === "Active Jobs" && (
-        <div className="space-y-4">
-          {activeJobs.map((job) => (
-            <div key={job.id} className="card flex items-center justify-between">
-              <div>
-                <h3 className="font-semibold text-theme-heading">{job.title}</h3>
-                <p className="text-sm text-theme-text">
-                  Client: {job.client} &middot; Deadline: {job.deadline}
-                </p>
-              </div>
-              <div className="flex items-center gap-4">
-                <span className="text-sm font-medium text-stellar-purple">
-                  {job.budget.toLocaleString()} XLM
-                </span>
-                <StatusBadge status={job.status} />
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {activeTab === "Applications" && (
+      {/* ── Freelancer tab content ── */}
+      {!isClient && activeTab === "My Applications" && (
         <div className="space-y-4">
           {applications.map((app) => (
             <div key={app.id} className="card flex items-center justify-between">
@@ -106,6 +256,80 @@ export default function DashboardPage() {
         </div>
       )}
 
+      {!isClient && activeTab === "Active Work" && (
+        <div className="space-y-4">
+          {activeJobs
+            .filter((j) => j.status === "IN_PROGRESS")
+            .map((job) => (
+              <div
+                key={job.id}
+                className="card flex items-center justify-between"
+              >
+                <div>
+                  <h3 className="font-semibold text-theme-heading">
+                    {job.title}
+                  </h3>
+                  <p className="text-sm text-theme-text">
+                    Client: {job.client} &middot; Deadline: {job.deadline}
+                  </p>
+                </div>
+                <div className="flex items-center gap-4">
+                  <span className="text-sm font-medium text-stellar-purple">
+                    {job.budget.toLocaleString()} XLM
+                  </span>
+                  <StatusBadge status={job.status} />
+                </div>
+              </div>
+            ))}
+        </div>
+      )}
+
+      {/* ── Client tab content ── */}
+      {isClient && activeTab === "My Posted Jobs" && (
+        <div className="space-y-4">
+          {postedJobs.map((job) => (
+            <div key={job.id} className="card flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold text-theme-heading">{job.title}</h3>
+                <p className="text-sm text-theme-text">
+                  {job.applicants} applicant{job.applicants !== 1 ? "s" : ""}
+                </p>
+              </div>
+              <div className="flex items-center gap-4">
+                <span className="text-sm font-medium text-stellar-purple">
+                  {job.budget.toLocaleString()} XLM
+                </span>
+                <StatusBadge status={job.status} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {isClient && activeTab === "Applicants to Review" && (
+        <div className="space-y-4">
+          {pendingApplicants.map((app) => (
+            <div key={app.id} className="card flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold text-theme-heading">
+                  {app.freelancer}
+                </h3>
+                <p className="text-sm text-theme-text">
+                  {app.job} &middot; Applied: {app.appliedAt}
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-stellar-purple">
+                  {app.bid.toLocaleString()} XLM
+                </span>
+                <StatusBadge status="PENDING" />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* ── Shared Messages tab ── */}
       {activeTab === "Messages" && (
         <div className="card text-center py-12">
           <MessageSquare className="mx-auto text-theme-text mb-4" size={40} />
@@ -113,7 +337,8 @@ export default function DashboardPage() {
             No messages yet
           </h3>
           <p className="text-theme-text">
-            Messages from clients and freelancers will appear here.
+            Messages from{" "}
+            {isClient ? "freelancers" : "clients"} will appear here.
           </p>
         </div>
       )}

--- a/frontend/src/app/jobs/[id]/page.tsx
+++ b/frontend/src/app/jobs/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
-import { Clock, DollarSign, ArrowLeft, MessageSquare, ShieldCheck, AlertCircle, Loader2, CheckCircle } from "lucide-react";
+import { Clock, DollarSign, ArrowLeft, MessageSquare, ShieldCheck, AlertCircle, Loader2, CheckCircle, UserCheck, XCircle } from "lucide-react";
 import Link from "next/link";
 import axios from "axios";
 import { useWallet } from "@/context/WalletContext";
@@ -10,7 +10,7 @@ import { useAuth } from "@/context/AuthContext";
 import StatusBadge from "@/components/StatusBadge";
 import ApplyModal from "@/components/ApplyModal";
 import RaiseDisputeModal from "@/components/RaiseDisputeModal";
-import { Job } from "@/types";
+import { Job, Application } from "@/types";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
 
@@ -25,6 +25,9 @@ export default function JobDetailPage() {
   const [applyModalOpen, setApplyModalOpen] = useState(false);
   const [disputeModalOpen, setDisputeModalOpen] = useState(false);
   const [hasApplied, setHasApplied] = useState(false);
+  const [applications, setApplications] = useState<Application[]>([]);
+  const [loadingApps, setLoadingApps] = useState(false);
+  const [actioningApp, setActioningApp] = useState<string | null>(null);
 
   const fetchJob = useCallback(async () => {
     try {
@@ -43,6 +46,51 @@ export default function JobDetailPage() {
   useEffect(() => {
     fetchJob();
   }, [fetchJob]);
+
+  const fetchApplications = useCallback(async () => {
+    setLoadingApps(true);
+    try {
+      const token = localStorage.getItem("token");
+      const res = await axios.get<{ data: Application[] }>(
+        `${API_URL}/jobs/${id as string}/applications`,
+        { headers: token ? { Authorization: `Bearer ${token}` } : {} },
+      );
+      setApplications(res.data.data ?? []);
+    } catch {
+      setApplications([]);
+    } finally {
+      setLoadingApps(false);
+    }
+  }, [id]);
+
+  // Fetch applicants once job loads and current user is the owner
+  useEffect(() => {
+    if (job && user && user.id === job.client.id) {
+      void fetchApplications();
+    }
+  }, [job, user, fetchApplications]);
+
+  const handleApplicationStatus = async (
+    appId: string,
+    status: "ACCEPTED" | "REJECTED",
+  ) => {
+    setActioningApp(appId);
+    try {
+      const token = localStorage.getItem("token");
+      await axios.put(
+        `${API_URL}/applications/${appId}/status`,
+        { status },
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      await fetchApplications();
+    } catch (err: unknown) {
+      setError(
+        err instanceof Error ? err.message : "Failed to update application.",
+      );
+    } finally {
+      setActioningApp(null);
+    }
+  };
 
   const handleEscrowAction = async (action: "init" | "fund" | "approve", milestoneId?: string) => {
     setError(null);
@@ -208,6 +256,81 @@ export default function JobDetailPage() {
               ))}
             </div>
           </div>
+          {/* Applicants — visible to owning client only */}
+          {isOwnJob && (
+            <div className="card mt-8">
+              <h2 className="text-lg font-semibold text-theme-heading mb-4">
+                Applicants
+              </h2>
+              {loadingApps ? (
+                <div className="flex justify-center py-8">
+                  <Loader2 className="animate-spin text-stellar-blue" size={32} />
+                </div>
+              ) : applications.length === 0 ? (
+                <p className="text-theme-text text-sm py-4 text-center">
+                  No applications yet.
+                </p>
+              ) : (
+                <div className="space-y-4">
+                  {applications.map((app) => (
+                    <div
+                      key={app.id}
+                      className="flex items-center justify-between p-4 bg-theme-bg rounded-lg border border-theme-border"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="w-9 h-9 rounded-full bg-gradient-to-br from-stellar-blue to-stellar-purple flex items-center justify-center text-white text-sm font-bold">
+                          {app.freelancer.username.charAt(0).toUpperCase()}
+                        </div>
+                        <div>
+                          <p className="font-medium text-theme-heading text-sm">
+                            {app.freelancer.username}
+                          </p>
+                          <p className="text-xs text-theme-text">
+                            Bid: {app.bidAmount.toLocaleString()} XLM
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <StatusBadge status={app.status} />
+                        {app.status === "PENDING" && (
+                          <>
+                            <button
+                              disabled={actioningApp === app.id}
+                              onClick={() =>
+                                void handleApplicationStatus(app.id, "ACCEPTED")
+                              }
+                              className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg bg-green-500/10 text-green-400 hover:bg-green-500/20 transition-colors disabled:opacity-50"
+                            >
+                              {actioningApp === app.id ? (
+                                <Loader2 size={12} className="animate-spin" />
+                              ) : (
+                                <UserCheck size={12} />
+                              )}
+                              Accept
+                            </button>
+                            <button
+                              disabled={actioningApp === app.id}
+                              onClick={() =>
+                                void handleApplicationStatus(app.id, "REJECTED")
+                              }
+                              className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg bg-theme-error/10 text-theme-error hover:bg-theme-error/20 transition-colors disabled:opacity-50"
+                            >
+                              {actioningApp === app.id ? (
+                                <Loader2 size={12} className="animate-spin" />
+                              ) : (
+                                <XCircle size={12} />
+                              )}
+                              Reject
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Sidebar */}
@@ -247,7 +370,8 @@ export default function JobDetailPage() {
                 </button>
             )}
 
-            {!isOwnJob && job.status === "OPEN" && (
+            {/* Apply section — freelancers only, non-owners */}
+            {user?.role === "FREELANCER" && !isOwnJob && job.status === "OPEN" && (
               hasApplied ? (
                 <button
                   className="btn-secondary w-full flex items-center justify-center gap-2 cursor-default opacity-80"

--- a/frontend/src/app/post-job/page.tsx
+++ b/frontend/src/app/post-job/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useState } from "react";
-import { Plus, Trash2 } from "lucide-react";
+import { useState, useEffect } from "react";
+import { Plus, Trash2, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
+import { useToast } from "@/components/Toast";
 
 interface MilestoneForm {
   title: string;
@@ -10,9 +13,34 @@ interface MilestoneForm {
 }
 
 export default function PostJobPage() {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!isLoading && user !== null && user.role !== "CLIENT") {
+      toast.error(
+        "Only clients can post jobs. Switch your role in Settings.",
+      );
+      router.replace("/dashboard");
+    }
+  }, [isLoading, user, router, toast]);
+
   const [milestones, setMilestones] = useState<MilestoneForm[]>([
     { title: "", description: "", amount: "" },
   ]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <Loader2 className="animate-spin text-stellar-blue" size={48} />
+      </div>
+    );
+  }
+
+  if (user?.role !== "CLIENT") {
+    return null;
+  }
 
   const addMilestone = () => {
     setMilestones([...milestones, { title: "", description: "", amount: "" }]);

--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -1,16 +1,24 @@
+"use client";
+
 import Link from "next/link";
 import { Clock, DollarSign, Users } from "lucide-react";
 import StatusBadge from "./StatusBadge";
 import { Job } from "@/types";
+import { useAuth } from "@/context/AuthContext";
 
 interface JobCardProps {
   job: Job;
 }
 
 export default function JobCard({ job }: JobCardProps) {
+  const { user } = useAuth();
+  const isFreelancer = user?.role === "FREELANCER";
+  const isClient = user?.role === "CLIENT";
+  const isOwnJob = user?.id === job.client.id;
+
   return (
-    <Link href={`/jobs/${job.id}`}>
-      <div className="card hover:border-stellar-blue/50 transition-all duration-200 cursor-pointer">
+    <div className="card hover:border-stellar-blue/50 transition-all duration-200 cursor-pointer">
+      <Link href={`/jobs/${job.id}`} className="block">
         <div className="flex items-start justify-between mb-3">
           <span className="text-xs font-medium text-stellar-purple bg-stellar-purple/10 px-2 py-1 rounded">
             {job.category}
@@ -40,12 +48,34 @@ export default function JobCard({ job }: JobCardProps) {
             <span>{new Date(job.createdAt).toLocaleDateString()}</span>
           </div>
         </div>
+      </Link>
 
-        <div className="flex items-center gap-2 mt-4 pt-4 border-t border-theme-border">
+      <div className="flex items-center justify-between mt-4 pt-4 border-t border-theme-border">
+        <div className="flex items-center gap-2">
           <div className="w-6 h-6 rounded-full bg-gradient-to-br from-stellar-blue to-stellar-purple" />
           <span className="text-sm text-theme-text">{job.client.username}</span>
         </div>
+
+        {/* Freelancers see Apply on open jobs they don't own */}
+        {isFreelancer && job.status === "OPEN" && !isOwnJob && (
+          <Link
+            href={`/jobs/${job.id}`}
+            className="text-xs font-medium px-3 py-1 bg-stellar-blue/10 text-stellar-blue rounded-full hover:bg-stellar-blue/20 transition-colors"
+          >
+            Apply
+          </Link>
+        )}
+
+        {/* Clients see View Applicants on their own jobs */}
+        {isClient && isOwnJob && (
+          <Link
+            href={`/jobs/${job.id}`}
+            className="text-xs font-medium px-3 py-1 bg-stellar-purple/10 text-stellar-purple rounded-full hover:bg-stellar-purple/20 transition-colors"
+          >
+            View Applicants
+          </Link>
+        )}
       </div>
-    </Link>
+    </div>
   );
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -192,6 +192,9 @@ function UnreadBadge() {
 
 export default function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const { user } = useAuth();
+  const isClient = user?.role === "CLIENT";
+  const isFreelancer = user?.role === "FREELANCER";
 
   return (
     <nav className="border-b border-theme-border bg-theme-bg/80 backdrop-blur-md sticky top-0 z-50">
@@ -204,13 +207,16 @@ export default function Navbar() {
             </span>
           </Link>
           <div className="hidden md:flex items-center gap-8">
-            <Link
-              href="/jobs"
-              className="text-theme-text hover:text-theme-heading transition-colors flex items-center gap-2"
-            >
-              <Briefcase size={16} />
-              Jobs
-            </Link>
+            {/* Freelancers and unauthenticated users see the job browsing link */}
+            {!isClient && (
+              <Link
+                href="/jobs"
+                className="text-theme-text hover:text-theme-heading transition-colors flex items-center gap-2"
+              >
+                <Briefcase size={16} />
+                {isFreelancer ? "Find Work" : "Jobs"}
+              </Link>
+            )}
             <Link
               href="/services"
               className="text-theme-text hover:text-theme-heading transition-colors flex items-center gap-2"
@@ -241,13 +247,16 @@ export default function Navbar() {
               Messages
               <UnreadBadge />
             </Link>
-            <Link
-              href="/post-job"
-              className="text-theme-text hover:text-theme-heading transition-colors flex items-center gap-2"
-            >
-              <PenLine size={16} />
-              Post a Job
-            </Link>
+            {/* Only clients see Post a Job */}
+            {isClient && (
+              <Link
+                href="/post-job"
+                className="text-theme-text hover:text-theme-heading transition-colors flex items-center gap-2"
+              >
+                <PenLine size={16} />
+                Post a Job
+              </Link>
+            )}
             <NotificationBell />
             <ThemeToggleButton />
             <UserMenu />
@@ -263,12 +272,15 @@ export default function Navbar() {
 
         {mobileOpen && (
           <div className="md:hidden pb-4 flex flex-col gap-4">
-            <Link
-              href="/jobs"
-              className="text-theme-text hover:text-theme-heading flex items-center gap-2"
-            >
-              <Briefcase size={18} /> Jobs
-            </Link>
+            {!isClient && (
+              <Link
+                href="/jobs"
+                className="text-theme-text hover:text-theme-heading flex items-center gap-2"
+              >
+                <Briefcase size={18} />
+                {isFreelancer ? "Find Work" : "Jobs"}
+              </Link>
+            )}
             <Link
               href="/services"
               className="text-theme-text hover:text-theme-heading flex items-center gap-2"
@@ -295,12 +307,14 @@ export default function Navbar() {
               Messages
               <UnreadBadge />
             </Link>
-            <Link
-              href="/post-job"
-              className="text-theme-text hover:text-theme-heading flex items-center gap-2"
-            >
-              <PenLine size={18} /> Post a Job
-            </Link>
+            {isClient && (
+              <Link
+                href="/post-job"
+                className="text-theme-text hover:text-theme-heading flex items-center gap-2"
+              >
+                <PenLine size={18} /> Post a Job
+              </Link>
+            )}
             <div className="pt-4 border-t border-theme-border flex items-center justify-between px-2">
               <div className="flex items-center gap-4">
                 <span className="text-sm font-medium text-theme-text">Notifications</span>


### PR DESCRIPTION
## Summary

- **Navbar**: Clients see only "Post a Job"; freelancers see "Find Work" (renamed Jobs link). Unauthenticated users see "Jobs". Neither role sees the other's primary CTA.
- **Post Job (`/post-job`)**: Freelancers are redirected to `/dashboard` with a toast — *"Only clients can post jobs. Switch your role in Settings."* A loading guard prevents flash-of-content.
- **Job Listings (`/jobs`)**: `JobCard` is now a client component. Freelancers see an **Apply** pill on open jobs; clients see a **View Applicants** pill on their own jobs only. No Apply button is ever shown to a client.
- **Job Detail (`/jobs/[id]`)**: Apply section is gated to `FREELANCER` role. Owning clients get a full **Applicants panel** with bid amounts, per-applicant Accept/Reject actions (calls `PUT /applications/:id/status`), and live status badges.
- **Dashboard (`/dashboard`)**: Role-appropriate tabs, stats, and content — clients get *My Posted Jobs* + *Applicants to Review* + spending summary; freelancers get *My Applications* + *Active Work* + income received. Shared *Messages* tab for both.
- All role checks use live `user.role` from `AuthContext`.
- Fixed missing `@testing-library/dom` peer dep so all 13 existing tests pass green.

## Test plan

- [ ] Register a **CLIENT** account → navbar shows "Post a Job", no "Find Work"/"Jobs" link; dashboard shows "My Posted Jobs" tab with spending stats; no Apply button on any job card or detail page
- [ ] Register a **FREELANCER** account → navbar shows "Find Work", no "Post a Job"; dashboard shows "My Applications" + "Active Work" tabs with income stats; Apply pills appear on OPEN job cards and Apply button on job detail
- [ ] Freelancer navigates to `/post-job` → redirected to `/dashboard` with error toast
- [ ] Client views their own job detail → Applicants panel visible with Accept/Reject; Apply section absent
- [ ] Client views a job they don't own → no Applicants panel, no Apply button
- [ ] All 13 Jest tests pass: `npm test`
- [ ] Production build succeeds: `npm run build`

Closes #136