### PR TITLE
Fix dispute re-open cooldown and restrict escrow funding to job client

### DIFF
--- a/contracts/dispute/src/lib.rs
+++ b/contracts/dispute/src/lib.rs
@@ -35,6 +35,7 @@ pub enum DisputeError {
     ConflictOfInterest = 10,
     ContractPaused = 11,
     NotAdmin = 12,
+    DisputeCooldown = 13,
 }
 
 #[contracttype]
@@ -106,6 +107,7 @@ enum DataKey {
     Dispute(u64),
     DisputeCount,
     Votes(u64),
+    LastDisputeClosedAt(u64),
     HasVoted(u64, Address),
     ReputationContract,
     MinVoterReputation,
@@ -144,6 +146,7 @@ const MIN_VOTER_REPUTATION: u32 = 300;
 
 /// Default reputation points slashed from the losing party after a resolved dispute.
 const DEFAULT_SLASH_AMOUNT: u64 = 50;
+const DISPUTE_COOLDOWN_SECS: u64 = 86_400;
 
 const MIN_TTL_THRESHOLD: u32 = 1_000;
 const MIN_TTL_EXTEND_TO: u32 = 10_000;
@@ -159,6 +162,14 @@ fn bump_dispute_ttl(env: &Env, dispute_id: u64) {
 fn bump_votes_ttl(env: &Env, dispute_id: u64) {
     env.storage().persistent().extend_ttl(
         &DataKey::Votes(dispute_id),
+        MIN_TTL_THRESHOLD,
+        MIN_TTL_EXTEND_TO,
+    );
+}
+
+fn bump_last_dispute_closed_ttl(env: &Env, job_id: u64) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::LastDisputeClosedAt(job_id),
         MIN_TTL_THRESHOLD,
         MIN_TTL_EXTEND_TO,
     );
@@ -467,6 +478,18 @@ impl DisputeContract {
             return Err(DisputeError::InvalidParty);
         }
 
+        if let Some(last_closed_at) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, u64>(&DataKey::LastDisputeClosedAt(job_id))
+        {
+            let now = env.ledger().timestamp();
+            if now <= last_closed_at.saturating_add(DISPUTE_COOLDOWN_SECS) {
+                return Err(DisputeError::DisputeCooldown);
+            }
+            bump_last_dispute_closed_ttl(&env, job_id);
+        }
+
         let mut count: u64 = env
             .storage()
             .instance()
@@ -769,6 +792,11 @@ impl DisputeContract {
                     (dispute.job_id, loser, slash_amount),
                 );
             }
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::LastDisputeClosedAt(dispute.job_id), &env.ledger().timestamp());
+            bump_last_dispute_closed_ttl(&env, dispute.job_id);
         }
 
         env.storage()

--- a/contracts/dispute/src/test.rs
+++ b/contracts/dispute/src/test.rs
@@ -1027,3 +1027,136 @@ fn test_no_slash_on_escalated_dispute() {
     });
     assert!(!has_slash, "StakeSlashed event should NOT be emitted for escalated disputes");
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")] // DisputeCooldown
+fn test_raise_dispute_blocked_by_job_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let dispute_contract_id = env.register_contract(None, DisputeContract);
+    let client = DisputeContractClient::new(&env, &dispute_contract_id);
+    let escrow_contract_id = env.register_contract(None, DummyEscrow);
+    let reputation_contract_id = env.register_contract(None, MockReputationContract);
+    let admin = Address::generate(&env);
+
+    let user_client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+
+    client.initialize(&admin, &reputation_contract_id, &300, &escrow_contract_id);
+
+    let dispute_id = client.raise_dispute(
+        &7u64,
+        &user_client,
+        &freelancer,
+        &user_client,
+        &String::from_str(&env, "Initial dispute"),
+        &3u32,
+        &None,
+    );
+
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    let voter3 = Address::generate(&env);
+
+    client.cast_vote(
+        &dispute_id,
+        &voter1,
+        &VoteChoice::Client,
+        &String::from_str(&env, "V1"),
+    );
+    client.cast_vote(
+        &dispute_id,
+        &voter2,
+        &VoteChoice::Client,
+        &String::from_str(&env, "V2"),
+    );
+    client.cast_vote(
+        &dispute_id,
+        &voter3,
+        &VoteChoice::Freelancer,
+        &String::from_str(&env, "V3"),
+    );
+
+    let _ = client.resolve_dispute(&dispute_id, &escrow_contract_id);
+
+    // Re-opening the same job dispute immediately must fail.
+    client.raise_dispute(
+        &7u64,
+        &user_client,
+        &freelancer,
+        &user_client,
+        &String::from_str(&env, "Retry too soon"),
+        &3u32,
+        &None,
+    );
+}
+
+#[test]
+fn test_raise_dispute_allowed_after_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let dispute_contract_id = env.register_contract(None, DisputeContract);
+    let client = DisputeContractClient::new(&env, &dispute_contract_id);
+    let escrow_contract_id = env.register_contract(None, DummyEscrow);
+    let reputation_contract_id = env.register_contract(None, MockReputationContract);
+    let admin = Address::generate(&env);
+
+    let user_client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+
+    client.initialize(&admin, &reputation_contract_id, &300, &escrow_contract_id);
+
+    let first_dispute_id = client.raise_dispute(
+        &9u64,
+        &user_client,
+        &freelancer,
+        &user_client,
+        &String::from_str(&env, "Initial dispute"),
+        &3u32,
+        &None,
+    );
+
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    let voter3 = Address::generate(&env);
+
+    client.cast_vote(
+        &first_dispute_id,
+        &voter1,
+        &VoteChoice::Client,
+        &String::from_str(&env, "V1"),
+    );
+    client.cast_vote(
+        &first_dispute_id,
+        &voter2,
+        &VoteChoice::Client,
+        &String::from_str(&env, "V2"),
+    );
+    client.cast_vote(
+        &first_dispute_id,
+        &voter3,
+        &VoteChoice::Freelancer,
+        &String::from_str(&env, "V3"),
+    );
+
+    let _ = client.resolve_dispute(&first_dispute_id, &escrow_contract_id);
+
+    // Cooldown is 86_400 seconds.
+    env.ledger().with_mut(|l| l.timestamp = 1000 + 86_401);
+
+    let second_dispute_id = client.raise_dispute(
+        &9u64,
+        &user_client,
+        &freelancer,
+        &freelancer,
+        &String::from_str(&env, "Retry after cooldown"),
+        &3u32,
+        &None,
+    );
+
+    assert_eq!(second_dispute_id, 2);
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -364,7 +364,6 @@ impl EscrowContract {
 
     /// Fund the escrow for a job. The client transfers the total amount to this contract.
     pub fn fund_job(env: Env, job_id: u64, client: Address) -> Result<(), EscrowError> {
-        client.require_auth();
         require_not_paused(&env)?;
 
         let mut job: Job = env
@@ -373,6 +372,9 @@ impl EscrowContract {
             .get(&get_job_key(job_id))
             .ok_or(EscrowError::JobNotFound)?;
         bump_job_ttl(&env, job_id);
+
+        // Require auth from the persisted job owner to prevent third-party funding.
+        job.client.require_auth();
 
         if job.client != client {
             return Err(EscrowError::Unauthorized);

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -1308,6 +1308,36 @@ fn test_fund_job_when_paused() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #2)")] // Unauthorized
+fn test_fund_job_rejects_non_client_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &admin, &100u32, &604800u64);
+
+    let job_client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let token = env.register_contract(None, MockToken);
+    let milestones = vec![&env, (String::from_str(&env, "Task 1"), 100_i128, 2000_u64)];
+
+    let job_id = client.create_job(
+        &job_client,
+        &freelancer,
+        &token,
+        &milestones,
+        &2500_u64,
+        &GRACE_PERIOD,
+    );
+
+    client.fund_job(&job_id, &attacker);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #15)")] // ContractPaused
 fn test_submit_milestone_when_paused() {
     let env = Env::default();


### PR DESCRIPTION
## Summary
This PR fixes two smart-contract security issues in `contracts/dispute` and `contracts/escrow`:

1. Adds per-job dispute cooldown enforcement after resolution to prevent immediate re-opening/flooding.
2. Strengthens escrow funding authorization so only the persisted job owner can authorize funding.

## What Changed
- **Dispute contract** (`contracts/dispute/src/lib.rs`)
  - Added `DisputeError::DisputeCooldown`.
  - Added persistent storage key `LastDisputeClosedAt(job_id)`.
  - Added `DISPUTE_COOLDOWN_SECS` (86,400 seconds).
  - Gated `raise_dispute` to reject new disputes when the cooldown window has not elapsed.
  - On non-escalated `resolve_dispute`, record close timestamp for the job.

- **Escrow contract** (`contracts/escrow/src/lib.rs`)
  - Updated `fund_job` to require authorization from `job.client` loaded from storage.
  - Kept explicit ownership check (`job.client != client`) returning `Unauthorized`.

- **Tests**
  - Added dispute tests:
    - `test_raise_dispute_blocked_by_job_cooldown`
    - `test_raise_dispute_allowed_after_cooldown`
  - Added escrow regression test:
    - `test_fund_job_rejects_non_client_caller`

## Why
- Prevents griefing/vote-farming via repeated dispute opens on the same job immediately after close.
- Prevents third-party wallets from attempting to fund jobs they do not own.

## Validation
- VS Code diagnostics on modified files report no errors.
- Note: local Rust test execution could not be run in this environment because `cargo` is not installed in shell (`command not found: cargo`).

Closes #265
Closes #266
