### PR TITLE
fix(reputation): scale referral bonus to unit weight (#320)

### DIFF
--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -219,6 +219,8 @@ fn is_signer(env: &Env, address: &Address) -> bool {
 const MIN_REVIEW_STAKE_DEFAULT: i128 = 10_000_000; // 1.0 unit (7 decimals)
 const RATE_LIMIT_LEDGERS_DEFAULT: u32 = 120; // ~10 minutes
 const DEFAULT_REFERRAL_BONUS: u64 = 5; // Equivalates to a 5-star review bonus
+/// Weight used when crediting referral bonus to reputation (not min review stake).
+const REFERRAL_BONUS_REPUTATION_WEIGHT: u64 = 1;
 const ONE_YEAR_IN_SECONDS: u64 = 31_536_000;
 
 const MIN_TTL_THRESHOLD: u32 = 1_000;
@@ -590,20 +592,16 @@ impl ReputationContract {
                 MIN_TTL_EXTEND_TO,
             );
 
-            // Credit the reputation score equivalent to the bonus rating
-            // Effectively a high-weight default review.
-            // We now store this as a record for decay calculation.
+            // Credit reputation as one virtual review at REFERRAL_BONUS_REPUTATION_WEIGHT
+            // with rating `bonus_rating` (avoids min_stake scaling, which inflated totals).
+            // Stored as a record for decay calculation.
             let bonus_rating = env
                 .storage()
                 .instance()
                 .get::<DataKey, u64>(&DataKey::ReferralBonus)
                 .unwrap_or(DEFAULT_REFERRAL_BONUS);
-            let min_stake = env
-                .storage()
-                .instance()
-                .get::<DataKey, i128>(&DataKey::MinStake)
-                .unwrap_or(MIN_REVIEW_STAKE_DEFAULT) as u64;
-            let earned_score = bonus_rating * min_stake;
+            let weight = REFERRAL_BONUS_REPUTATION_WEIGHT;
+            let earned_score = bonus_rating * weight;
 
             let bonuses_key = DataKey::ReferralBonusList(referrer.clone());
             let mut bonuses: Vec<ReferralBonusRecord> = env
@@ -614,7 +612,7 @@ impl ReputationContract {
 
             bonuses.push_back(ReferralBonusRecord {
                 amount: earned_score,
-                weight: min_stake,
+                weight,
                 timestamp: env.ledger().timestamp(),
             });
 
@@ -639,7 +637,7 @@ impl ReputationContract {
                 });
 
             reputation.total_score += earned_score;
-            reputation.total_weight += min_stake;
+            reputation.total_weight += weight;
 
             env.storage().persistent().set(&rep_key, &reputation);
             bump_reputation_ttl(env, &referrer);
@@ -1074,10 +1072,7 @@ impl ReputationContract {
             };
 
             if weight > 0 && bonus.weight > 0 {
-                // amount is already rating * weight in process_referral_bonus
-                // but wait, earned_score = bonus_rating * min_stake;
-                // so if we decay the weight, we should decay the score too.
-                // Score = bonus_rating * decayed_weight
+                // amount = bonus_rating * bonus.weight at grant time; decay weight in sync.
                 let bonus_rating = bonus.amount / bonus.weight;
                 total_score += bonus_rating * weight;
                 total_weight += weight;

--- a/contracts/reputation/src/test.rs
+++ b/contracts/reputation/src/test.rs
@@ -1310,13 +1310,13 @@ fn test_referral_bonus_granted_on_first_job() {
     let stats = reputation_client.get_referral_stats(&referrer);
     assert_eq!(stats.total_referrals, 1);
 
-    // Earned bonus = DEFAULT_REFERRAL_BONUS (5) * MIN_STAKE (10_000_000)
-    assert_eq!(stats.earned_bonus, 5 * MIN_STAKE as u64);
+    // Earned bonus uses fixed reputation weight (1), not min review stake.
+    assert_eq!(stats.earned_bonus, 5u64);
 
     // Check Referrer's Reputation (they should have received the bonus reputation payload natively)
     let rep = reputation_client.get_reputation(&referrer);
-    assert_eq!(rep.total_score, 5 * MIN_STAKE as u64);
-    assert_eq!(rep.total_weight, MIN_STAKE as u64);
+    assert_eq!(rep.total_score, 5u64);
+    assert_eq!(rep.total_weight, 1u64);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Fixes referral reputation inflation: `process_referral_bonus` used `min_stake` as both score multiplier and weight, making one referral dominate tiers.
- Referral bonus is now credited as `bonus_rating * 1` with weight `1`, equivalent to one minimum-weight review in the aggregate, matching issue #320.

## Implementation Notes
- `contracts/reputation/src/lib.rs`: `REFERRAL_BONUS_REPUTATION_WEIGHT`, `process_referral_bonus` uses fixed weight; decay path unchanged (`amount / weight` still yields configured bonus rating).
- `contracts/reputation/src/test.rs`: `test_referral_bonus_granted_on_first_job` expectations updated.

## Validation
- `cd stellar-market/contracts && cargo check -p stellar-market-reputation` — pass.
- `cd stellar-market/contracts && cargo build -p stellar-market-reputation --target wasm32-unknown-unknown --release` — pass.
- `cargo test -p stellar-market-reputation --lib` — 0 tests (test module not declared in `lib.rs` on current layout).
- Merge dry-run `feat/issue-320-referral-bonus-weight` into `upstream/main`: automatic merge went well.

## Repro Steps for Maintainer
1. Deploy or simulate `submit_review` after a referred user’s first completed job with default config.
2. Observe referrer `get_reputation`: `total_weight` should be small (1 per bonus), not `min_stake`.

## Risks / Follow-ups
- If CI later enables `mod test`, confirm referral snapshots are refreshed if applicable.

Closes #320