### PR TITLE
feat(auth): recovery codes on 2FA enable and regenerate (#336)

### DIFF
--- a/backend/src/routes/__tests__/auth.2fa.test.ts
+++ b/backend/src/routes/__tests__/auth.2fa.test.ts
@@ -88,7 +88,7 @@ afterEach(() => jest.clearAllMocks());
 
 // ─── POST /api/auth/2fa/setup ────────────────────────────────────────────────
 describe("POST /api/auth/2fa/setup", () => {
-  it("returns QR code, secret, and backup codes", async () => {
+  it("returns QR code and secret (recovery codes are issued only after TOTP verify)", async () => {
     userMock.findUnique.mockResolvedValue({ ...baseUser });
     userMock.update.mockResolvedValueOnce({ ...baseUser });
 
@@ -99,7 +99,13 @@ describe("POST /api/auth/2fa/setup", () => {
     expect(res.status).toBe(200);
     expect(res.body.qrCode).toContain("data:image/png");
     expect(res.body.secret).toBeDefined();
-    expect(res.body.backupCodes).toHaveLength(8);
+    expect(res.body.backupCodes).toBeUndefined();
+    expect(res.body.recoveryCodes).toBeUndefined();
+    expect(userMock.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ backupCodes: [] }),
+      }),
+    );
   });
 
   it("returns 400 if 2FA is already enabled", async () => {
@@ -138,9 +144,11 @@ describe("POST /api/auth/2fa/verify", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.message).toBe("2FA has been enabled successfully.");
-    expect(userMock.update).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { twoFactorEnabled: true } }),
-    );
+    expect(res.body.recoveryCodes).toHaveLength(10);
+    expect(res.body.recoveryCodes.every((c: string) => /^[a-f0-9]{8}$/.test(c))).toBe(true);
+    const updateArg = userMock.update.mock.calls[0][0];
+    expect(updateArg.data.twoFactorEnabled).toBe(true);
+    expect(updateArg.data.backupCodes).toHaveLength(10);
   });
 
   it("returns 400 with invalid code", async () => {
@@ -167,6 +175,78 @@ describe("POST /api/auth/2fa/verify", () => {
       .send({ code: mockTotpCode });
 
     expect(res.status).toBe(400);
+  });
+});
+
+// ─── POST /api/auth/2fa/enable (alias of verify) ─────────────────────────────
+describe("POST /api/auth/2fa/enable", () => {
+  it("enables 2FA and returns recovery codes like verify", async () => {
+    userMock.findUnique.mockResolvedValue({
+      ...baseUser,
+      twoFactorSecret: `encrypted:${MOCK_SECRET}`,
+    });
+    userMock.update.mockResolvedValueOnce({ ...baseUser, twoFactorEnabled: true });
+
+    const res = await request(app)
+      .post("/api/auth/2fa/enable")
+      .set(authHeader())
+      .send({ code: mockTotpCode });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("2FA has been enabled successfully.");
+    expect(res.body.recoveryCodes).toHaveLength(10);
+  });
+});
+
+// ─── POST /api/auth/2fa/regenerate ───────────────────────────────────────────
+describe("POST /api/auth/2fa/regenerate", () => {
+  it("returns new recovery codes when TOTP is valid", async () => {
+    userMock.findUnique.mockResolvedValue({
+      ...baseUser,
+      twoFactorEnabled: true,
+      twoFactorSecret: `encrypted:${MOCK_SECRET}`,
+      backupCodes: ["oldhash"],
+    });
+    userMock.update.mockResolvedValueOnce({ ...baseUser, twoFactorEnabled: true });
+
+    const res = await request(app)
+      .post("/api/auth/2fa/regenerate")
+      .set(authHeader())
+      .send({ code: mockTotpCode });
+
+    expect(res.status).toBe(200);
+    expect(res.body.recoveryCodes).toHaveLength(10);
+    expect(res.body.message).toContain("regenerated");
+    const updateArg = userMock.update.mock.calls[0][0];
+    expect(updateArg.data.backupCodes).toHaveLength(10);
+  });
+
+  it("returns 400 with invalid TOTP", async () => {
+    userMock.findUnique.mockResolvedValue({
+      ...baseUser,
+      twoFactorEnabled: true,
+      twoFactorSecret: `encrypted:${MOCK_SECRET}`,
+    });
+
+    const res = await request(app)
+      .post("/api/auth/2fa/regenerate")
+      .set(authHeader())
+      .send({ code: "000000" });
+
+    expect(res.status).toBe(400);
+    expect(userMock.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 if 2FA is not enabled", async () => {
+    userMock.findUnique.mockResolvedValue({ ...baseUser });
+
+    const res = await request(app)
+      .post("/api/auth/2fa/regenerate")
+      .set(authHeader())
+      .send({ code: mockTotpCode });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("2FA is not enabled.");
   });
 });
 

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -3,7 +3,7 @@ import { PrismaClient } from "@prisma/client";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import crypto from "crypto";
-import { generateSecret, generateSync, verifySync, generateURI } from "otplib";
+import { generateSecret, verifySync, generateURI } from "otplib";
 import QRCode from "qrcode";
 import { config } from "../config";
 import { validate } from "../middleware/validation";
@@ -33,6 +33,19 @@ const router = Router();
 const prisma = new PrismaClient();
 
 const RESET_TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
+/** Single-use recovery codes issued when 2FA is enabled or regenerated (bcrypt-hashed in DB). */
+const RECOVERY_CODE_COUNT = 10;
+
+async function generateRecoveryCodeSets(): Promise<{ plain: string[]; hashed: string[] }> {
+  const plain: string[] = [];
+  const hashed: string[] = [];
+  for (let i = 0; i < RECOVERY_CODE_COUNT; i++) {
+    const code = crypto.randomBytes(4).toString("hex");
+    plain.push(code);
+    hashed.push(await bcrypt.hash(code, 10));
+  }
+  return { plain, hashed };
+}
 
 // Register a new user
 router.post(
@@ -230,20 +243,11 @@ router.post(
     const secret = generateSecret();
     const encryptedSecret = encrypt(secret);
 
-    // Generate 8 backup codes
-    const backupCodesPlain: string[] = [];
-    const backupCodesHashed: string[] = [];
-    for (let i = 0; i < 8; i++) {
-      const code = crypto.randomBytes(4).toString("hex"); // 8-char hex code
-      backupCodesPlain.push(code);
-      backupCodesHashed.push(await bcrypt.hash(code, 10));
-    }
-
     await prisma.user.update({
       where: { id: req.userId },
       data: {
         twoFactorSecret: encryptedSecret,
-        backupCodes: backupCodesHashed,
+        backupCodes: [],
       },
     });
 
@@ -258,14 +262,63 @@ router.post(
     res.json({
       qrCode: qrCodeDataUrl,
       secret,
-      backupCodes: backupCodesPlain,
     });
   }),
 );
 
-// POST /2fa/verify — Verify TOTP code and enable 2FA
+// POST /2fa/verify — Verify TOTP code, enable 2FA, return one-time recovery codes
+const twoFactorEnableHandler = asyncHandler(async (req: AuthRequest, res: Response) => {
+  const user = await prisma.user.findUnique({ where: { id: req.userId } });
+  if (!user) {
+    return res.status(404).json({ error: "User not found." });
+  }
+
+  if (user.twoFactorEnabled) {
+    return res.status(400).json({ error: "2FA is already enabled." });
+  }
+
+  if (!user.twoFactorSecret) {
+    return res.status(400).json({ error: "2FA setup not initiated. Call /2fa/setup first." });
+  }
+
+  const secret = decrypt(user.twoFactorSecret);
+  const result = verifySync({ token: req.body.code, secret });
+
+  if (!result.valid) {
+    return res.status(400).json({ error: "Invalid verification code." });
+  }
+
+  const { plain: recoveryCodes, hashed } = await generateRecoveryCodeSets();
+
+  await prisma.user.update({
+    where: { id: req.userId },
+    data: { twoFactorEnabled: true, backupCodes: hashed },
+  });
+
+  res.json({
+    message: "2FA has been enabled successfully.",
+    recoveryCodes,
+  });
+});
+
 router.post(
   "/2fa/verify",
+  authenticate,
+  validate({ body: twoFactorVerifySchema }),
+  twoFactorEnableHandler,
+);
+
+// POST /2fa/enable — Alias for verify (TOTP confirmation + recovery codes on first enable)
+router.post(
+  "/2fa/enable",
+  authenticate,
+  validate({ body: twoFactorVerifySchema }),
+  twoFactorEnableHandler,
+);
+
+// POST /2fa/regenerate — New recovery codes (requires current TOTP); invalidates existing codes
+router.post(
+  "/2fa/regenerate",
   authenticate,
   validate({ body: twoFactorVerifySchema }),
   asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -274,27 +327,27 @@ router.post(
       return res.status(404).json({ error: "User not found." });
     }
 
-    if (user.twoFactorEnabled) {
-      return res.status(400).json({ error: "2FA is already enabled." });
-    }
-
-    if (!user.twoFactorSecret) {
-      return res.status(400).json({ error: "2FA setup not initiated. Call /2fa/setup first." });
+    if (!user.twoFactorEnabled || !user.twoFactorSecret) {
+      return res.status(400).json({ error: "2FA is not enabled." });
     }
 
     const secret = decrypt(user.twoFactorSecret);
     const result = verifySync({ token: req.body.code, secret });
-
     if (!result.valid) {
       return res.status(400).json({ error: "Invalid verification code." });
     }
 
+    const { plain: recoveryCodes, hashed } = await generateRecoveryCodeSets();
+
     await prisma.user.update({
       where: { id: req.userId },
-      data: { twoFactorEnabled: true },
+      data: { backupCodes: hashed },
     });
 
-    res.json({ message: "2FA has been enabled successfully." });
+    res.json({
+      message: "Recovery codes have been regenerated. Store them securely; old codes no longer work.",
+      recoveryCodes,
+    });
   }),
 );
 
@@ -335,7 +388,7 @@ router.post(
   }),
 );
 
-// POST /2fa/validate — Validate TOTP or backup code during login
+// POST /2fa/validate — Validate TOTP or recovery code during login
 router.post(
   "/2fa/validate",
   validate({ body: twoFactorValidateSchema }),
@@ -380,9 +433,10 @@ router.post(
       }
     }
 
-    // Try backup codes
+    // Try recovery (backup) codes — 8-char hex, distinct from 6-digit TOTP
+    const recoveryInput = code.trim().toLowerCase();
     for (let i = 0; i < user.backupCodes.length; i++) {
-      const match = await bcrypt.compare(code, user.backupCodes[i]);
+      const match = await bcrypt.compare(recoveryInput, user.backupCodes[i]);
       if (match) {
         // Consume the backup code
         const updatedCodes = [...user.backupCodes];

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -46,13 +46,16 @@ export default function SettingsPage() {
   const [twoFASetupData, setTwoFASetupData] = useState<{
     qrCode: string;
     secret: string;
-    backupCodes: string[];
   } | null>(null);
+  /** Shown once after enable or regenerate; plain codes only exist in memory until dismissed. */
+  const [recoveryCodesPending, setRecoveryCodesPending] = useState<string[] | null>(null);
   const [verifyCode, setVerifyCode] = useState("");
   const [disablePassword, setDisablePassword] = useState("");
   const [showDisableModal, setShowDisableModal] = useState(false);
+  const [showRegenerateModal, setShowRegenerateModal] = useState(false);
+  const [regenerateTotp, setRegenerateTotp] = useState("");
   const [twoFALoading, setTwoFALoading] = useState(false);
-  const [copiedBackup, setCopiedBackup] = useState(false);
+  const [copiedRecovery, setCopiedRecovery] = useState(false);
 
   // Redirect if not authenticated
   useEffect(() => {
@@ -288,11 +291,11 @@ export default function SettingsPage() {
     }
   }
 
-  function copyBackupCodes() {
-    if (twoFASetupData) {
-      navigator.clipboard.writeText(twoFASetupData.backupCodes.join("\n"));
-      setCopiedBackup(true);
-      setTimeout(() => setCopiedBackup(false), 2000);
+  function copyRecoveryCodes() {
+    if (recoveryCodesPending?.length) {
+      navigator.clipboard.writeText(recoveryCodesPending.join("\n"));
+      setCopiedRecovery(true);
+      setTimeout(() => setCopiedRecovery(false), 2000);
     }
   }
 
@@ -609,7 +612,41 @@ export default function SettingsPage() {
             Security
           </h2>
 
-          {twoFAEnabled && !twoFASetupData ? (
+          {recoveryCodesPending && recoveryCodesPending.length > 0 ? (
+            <div className="space-y-4 rounded-lg border border-amber-600/40 bg-amber-950/30 p-4">
+              <p className="text-amber-200 text-sm font-medium">
+                Save these recovery codes now. Each code works once instead of your authenticator at login. They will not be shown again.
+              </p>
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-dark-muted text-xs">Recovery codes</p>
+                <button
+                  type="button"
+                  onClick={copyRecoveryCodes}
+                  className="flex items-center gap-1 text-xs text-stellar-blue hover:underline shrink-0"
+                >
+                  {copiedRecovery ? <Check size={12} /> : <Copy size={12} />}
+                  {copiedRecovery ? "Copied!" : "Copy all"}
+                </button>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                {recoveryCodesPending.map((code, i) => (
+                  <code
+                    key={i}
+                    className="block p-2 bg-dark-bg border border-dark-border rounded text-center text-sm text-dark-text font-mono"
+                  >
+                    {code}
+                  </code>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={() => setRecoveryCodesPending(null)}
+                className="btn-primary text-sm"
+              >
+                I have stored my recovery codes safely
+              </button>
+            </div>
+          ) : twoFAEnabled && !twoFASetupData ? (
             /* 2FA is ON */
             <div className="space-y-4">
               <div className="flex items-center gap-3 p-4 bg-green-900/20 border border-green-700/30 rounded-lg">
@@ -617,7 +654,40 @@ export default function SettingsPage() {
                 <p className="text-green-300 text-sm">Two-factor authentication is enabled.</p>
               </div>
 
-              {showDisableModal ? (
+              {showRegenerateModal ? (
+                <form onSubmit={handleRegenerateRecovery} className="space-y-3 rounded-lg border border-dark-border p-4">
+                  <p className="text-dark-muted text-sm">
+                    Enter a 6-digit code from your authenticator. This replaces all existing recovery codes.
+                  </p>
+                  <input
+                    type="text"
+                    value={regenerateTotp}
+                    onChange={(e) => setRegenerateTotp(e.target.value.replace(/\D/g, "").slice(0, 6))}
+                    className="input-field text-center tracking-widest"
+                    placeholder="000000"
+                    maxLength={6}
+                    required
+                    autoComplete="one-time-code"
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      type="submit"
+                      disabled={twoFALoading || regenerateTotp.length !== 6}
+                      className="flex items-center gap-2 px-4 py-2 bg-stellar-blue hover:bg-stellar-blue/90 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+                    >
+                      {twoFALoading ? <Loader2 size={14} className="animate-spin" /> : <ShieldCheck size={14} />}
+                      Generate new codes
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setShowRegenerateModal(false); setRegenerateTotp(""); }}
+                      className="px-4 py-2 border border-dark-border text-dark-text rounded-lg text-sm hover:bg-dark-bg transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              ) : showDisableModal ? (
                 <form onSubmit={handleDisable2FA} className="space-y-3">
                   <p className="text-dark-muted text-sm">Enter your password to disable 2FA:</p>
                   <input
@@ -647,13 +717,24 @@ export default function SettingsPage() {
                   </div>
                 </form>
               ) : (
-                <button
-                  onClick={() => setShowDisableModal(true)}
-                  className="flex items-center gap-2 px-4 py-2 border border-red-600/50 text-red-400 rounded-lg text-sm hover:bg-red-900/20 transition-colors"
-                >
-                  <ShieldOff size={14} />
-                  Disable 2FA
-                </button>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowRegenerateModal(true)}
+                    className="flex items-center gap-2 px-4 py-2 border border-stellar-blue/50 text-stellar-blue rounded-lg text-sm hover:bg-stellar-blue/10 transition-colors"
+                  >
+                    <ShieldCheck size={14} />
+                    Regenerate recovery codes
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setShowDisableModal(true)}
+                    className="flex items-center gap-2 px-4 py-2 border border-red-600/50 text-red-400 rounded-lg text-sm hover:bg-red-900/20 transition-colors"
+                  >
+                    <ShieldOff size={14} />
+                    Disable 2FA
+                  </button>
+                </div>
               )}
             </div>
           ) : twoFASetupData ? (
@@ -677,29 +758,9 @@ export default function SettingsPage() {
                 </code>
               </div>
 
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <p className="text-dark-muted text-xs">Backup codes (save these securely):</p>
-                  <button
-                    type="button"
-                    onClick={copyBackupCodes}
-                    className="flex items-center gap-1 text-xs text-stellar-blue hover:underline"
-                  >
-                    {copiedBackup ? <Check size={12} /> : <Copy size={12} />}
-                    {copiedBackup ? "Copied!" : "Copy all"}
-                  </button>
-                </div>
-                <div className="grid grid-cols-2 gap-2">
-                  {twoFASetupData.backupCodes.map((code, i) => (
-                    <code
-                      key={i}
-                      className="block p-2 bg-dark-bg border border-dark-border rounded text-center text-sm text-dark-text font-mono"
-                    >
-                      {code}
-                    </code>
-                  ))}
-                </div>
-              </div>
+              <p className="text-dark-muted text-xs">
+                After you verify with a 6-digit app code, you will receive one-time recovery codes to download or copy. Store them offline.
+              </p>
 
               <form onSubmit={handleVerify2FA} className="space-y-3">
                 <label className="block text-sm font-medium text-dark-heading">

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -115,7 +115,7 @@ export default function AuthForm({ type }: AuthFormProps) {
           <ShieldCheck size={48} className="mx-auto mb-4 text-stellar-blue" />
           <h1 className="text-3xl font-bold text-dark-heading mb-2">Two-Factor Authentication</h1>
           <p className="text-dark-muted">
-            Enter the 6-digit code from your authenticator app, or use a backup code.
+            Enter the 6-digit code from your authenticator app, or an 8-character recovery code.
           </p>
         </div>
 
@@ -135,9 +135,10 @@ export default function AuthForm({ type }: AuthFormProps) {
                 value={totpCode}
                 onChange={(e) => setTotpCode(e.target.value)}
                 className="w-full pl-10 pr-4 py-2 bg-dark-bg border border-dark-border rounded-lg focus:ring-2 focus:ring-stellar-blue outline-none transition-all text-dark-text text-center tracking-widest"
-                placeholder="000000"
+                placeholder="000000 or recovery"
                 autoFocus
                 autoComplete="one-time-code"
+                maxLength={32}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Recovery codes are generated only after TOTP confirms 2FA (verify/enable), bcrypt-stored in `backupCodes`, shown once as `recoveryCodes`.
- Added `POST /auth/2fa/enable` (alias of verify) and `POST /auth/2fa/regenerate` (TOTP + new codes).
- Settings + login copy aligned with recovery-code flow.

## Validation
- `cd stellar-market/backend && npm test -- src/routes/__tests__/auth.2fa.test.ts` — 21 passed
- Merge dry-run vs `upstream/main` — clean

## Repro
1. `POST /api/auth/2fa/setup` (authenticated) → QR + secret, no `recoveryCodes`.
2. `POST /api/auth/2fa/verify` with valid TOTP → `recoveryCodes` length 10.
3. Login → `2fa/validate` with one plaintext code → code consumed in DB.

Closes #336