### PR TITLE
feat(events): integrate Stellar Horizon SSE event streaming 

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,12 @@ SMTP_PORT=587
 SMTP_USER="your-email@gmail.com"
 SMTP_PASS="your-app-password"
 SMTP_FROM="StellarMarket <noreply@stellarmarket.com>"
+
+# Stellar / Soroban configuration
+STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+STELLAR_RPC_URL="https://soroban-testnet.stellar.org"
+STELLAR_HORIZON_URL="https://horizon-testnet.stellar.org"
+ESCROW_CONTRACT_ID=""
+DISPUTE_CONTRACT_ID=""
+REPUTATION_CONTRACT_ID=""
+NATIVE_TOKEN_ID=""

--- a/backend/prisma/migrations/20260425000000_add_sync_state_badge/migration.sql
+++ b/backend/prisma/migrations/20260425000000_add_sync_state_badge/migration.sql
@@ -1,0 +1,35 @@
+-- AlterEnum: add BADGE_AWARDED to NotificationType
+ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'BADGE_AWARDED';
+
+-- CreateEnum
+DO $$ BEGIN
+  CREATE TYPE "BadgeTier" AS ENUM ('BRONZE', 'SILVER', 'GOLD', 'PLATINUM');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- CreateTable: SyncState (singleton row for event-stream cursor)
+CREATE TABLE IF NOT EXISTS "SyncState" (
+    "id"                TEXT NOT NULL DEFAULT 'default',
+    "lastIndexedLedger" INTEGER NOT NULL DEFAULT 0,
+    "updatedAt"         TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "SyncState_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: Badge
+CREATE TABLE IF NOT EXISTS "Badge" (
+    "id"            TEXT NOT NULL,
+    "userId"        TEXT NOT NULL,
+    "tier"          "BadgeTier" NOT NULL,
+    "awardedLedger" INTEGER NOT NULL,
+    "createdAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Badge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "Badge_userId_tier_key" ON "Badge"("userId", "tier");
+CREATE INDEX IF NOT EXISTS "Badge_userId_idx" ON "Badge"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Badge" ADD CONSTRAINT "Badge_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -72,6 +72,14 @@ enum NotificationType {
   DISPUTE_RAISED
   DISPUTE_RESOLVED
   NEW_MESSAGE
+  BADGE_AWARDED
+}
+
+enum BadgeTier {
+  BRONZE
+  SILVER
+  GOLD
+  PLATINUM
 }
 
 enum DisputeStatus {
@@ -128,6 +136,7 @@ model User {
   votesCast          DisputeVote[]  @relation("VotesCast")
   savedJobs          SavedJob[]     @relation("SavedJobs")
   reportsGiven       Report[]       @relation("ReportsGiven")
+  badges             Badge[]
 }
 
 model Job {
@@ -398,4 +407,23 @@ model Report {
   @@index([targetType])
   @@index([status])
   @@index([createdAt])
+}
+
+model SyncState {
+  id                String   @id @default("default")
+  lastIndexedLedger Int      @default(0)
+  updatedAt         DateTime @updatedAt
+}
+
+model Badge {
+  id            String    @id @default(cuid())
+  userId        String
+  tier          BadgeTier
+  awardedLedger Int
+  createdAt     DateTime  @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, tier])
+  @@index([userId])
 }

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -11,8 +11,10 @@ export const config = {
   stellar: {
     networkPassphrase: process.env.STELLAR_NETWORK_PASSPHRASE || "Test SDF Network ; September 2015",
     rpcUrl: process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org",
+    horizonUrl: process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org",
     escrowContractId: process.env.ESCROW_CONTRACT_ID || "",
     disputeContractId: process.env.DISPUTE_CONTRACT_ID || "",
+    reputationContractId: process.env.REPUTATION_CONTRACT_ID || "",
     nativeTokenId: process.env.NATIVE_TOKEN_ID || "CDLZFC3SYJYDZT7K67VZ75YJBMKBAV27Z6Y6Z6Z6Z6Z6Z6Z6Z6Z6Z6Z6Z", // Native XLM on Testnet
   },
   smtp: {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import { sanitizeInput } from "./middleware/sanitize";
 import { errorHandler } from "./middleware/error";
 import { initSocket } from "./socket";
 import { startExpiryJob } from "./jobs/expiry.job";
+import { startHorizonListener, stopHorizonListener } from "./services/horizon-listener.service";
 
 const app = express();
 import { swaggerUi, swaggerSpec } from "./config/swagger";
@@ -79,13 +80,14 @@ app.use(errorHandler);
 httpServer.listen(config.port, () => {
   console.log(`StellarMarket API running on port ${config.port}`);
   startExpiryJob();
+  startHorizonListener();
 });
 
-// Graceful shutdown
-process.on("SIGTERM", async () => {
-  console.log("SIGTERM received, shutting down gracefully...");
+async function gracefulShutdown(signal: string): Promise<void> {
+  console.log(`${signal} received, shutting down gracefully...`);
 
-  // Flush any pending notification batches
+  stopHorizonListener();
+
   const { NotificationService } =
     await import("./services/notification.service");
   await NotificationService.flushAllBatches();
@@ -94,20 +96,9 @@ process.on("SIGTERM", async () => {
     console.log("Server closed");
     process.exit(0);
   });
-});
+}
 
-process.on("SIGINT", async () => {
-  console.log("SIGINT received, shutting down gracefully...");
-
-  // Flush any pending notification batches
-  const { NotificationService } =
-    await import("./services/notification.service");
-  await NotificationService.flushAllBatches();
-
-  httpServer.close(() => {
-    console.log("Server closed");
-    process.exit(0);
-  });
-});
+process.on("SIGTERM", () => void gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => void gracefulShutdown("SIGINT"));
 
 export { app, httpServer };

--- a/backend/src/services/horizon-listener.service.ts
+++ b/backend/src/services/horizon-listener.service.ts
@@ -1,0 +1,474 @@
+import { rpc, scValToNative } from "@stellar/stellar-sdk";
+import { PrismaClient, BadgeTier } from "@prisma/client";
+import { config } from "../config";
+import { NotificationService } from "./notification.service";
+
+const prisma = new PrismaClient();
+const server = new rpc.Server(config.stellar.rpcUrl);
+
+const POLL_INTERVAL_MS = 5_000;
+const MAX_EVENTS_PER_POLL = 200;
+const SYNC_STATE_ID = "default";
+
+type SorobanEvent = Awaited<ReturnType<typeof server.getEvents>>["events"][number];
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function topicToStrings(event: SorobanEvent): string[] {
+  return event.topic.map((t) => String(scValToNative(t) ?? ""));
+}
+
+/** Handles both plain-string and single-element-array Soroban enum variants. */
+function enumVariant(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (Array.isArray(raw) && raw.length > 0) return String(raw[0]);
+  return String(raw ?? "");
+}
+
+function bigintToStr(v: unknown): string {
+  return typeof v === "bigint" ? v.toString() : String(v ?? "");
+}
+
+function toBadgeTier(raw: unknown): BadgeTier | null {
+  const v = enumVariant(raw).toUpperCase();
+  if (v === "BRONZE") return BadgeTier.BRONZE;
+  if (v === "SILVER") return BadgeTier.SILVER;
+  if (v === "GOLD") return BadgeTier.GOLD;
+  if (v === "PLATINUM") return BadgeTier.PLATINUM;
+  return null;
+}
+
+// ─── sync-state persistence ───────────────────────────────────────────────────
+
+async function getLastIndexedLedger(): Promise<number> {
+  const row = await prisma.syncState.upsert({
+    where: { id: SYNC_STATE_ID },
+    update: {},
+    create: { id: SYNC_STATE_ID, lastIndexedLedger: 0 },
+  });
+  return row.lastIndexedLedger;
+}
+
+async function setLastIndexedLedger(ledger: number): Promise<void> {
+  await prisma.syncState.upsert({
+    where: { id: SYNC_STATE_ID },
+    update: { lastIndexedLedger: ledger },
+    create: { id: SYNC_STATE_ID, lastIndexedLedger: ledger },
+  });
+}
+
+// ─── event handlers ───────────────────────────────────────────────────────────
+
+/**
+ * escrow / created — (job_count: u64, client: Address, freelancer: Address)
+ *
+ * The on-chain job was successfully created.  Find the matching DB row by
+ * contractJobId and confirm its escrow status is UNFUNDED.  Handles the case
+ * where the backend was down when the frontend submitted the transaction.
+ */
+async function handleJobCreated(event: SorobanEvent): Promise<void> {
+  const data = scValToNative(event.value) as unknown[];
+  if (!Array.isArray(data) || data.length < 1) return;
+
+  const onChainJobId = bigintToStr(data[0]);
+
+  await prisma.job.updateMany({
+    where: {
+      contractJobId: onChainJobId,
+      escrowStatus: { not: "FUNDED" },
+    },
+    data: { escrowStatus: "UNFUNDED" },
+  });
+
+  console.log(`[HorizonListener] JobCreated — contractJobId=${onChainJobId}`);
+}
+
+/**
+ * escrow / funded — (job_id: u64, client: Address)
+ *
+ * Escrow has been funded.  Transition the job to IN_PROGRESS / FUNDED.
+ */
+async function handleJobFunded(event: SorobanEvent): Promise<void> {
+  const data = scValToNative(event.value) as unknown[];
+  if (!Array.isArray(data) || data.length < 1) return;
+
+  const onChainJobId = bigintToStr(data[0]);
+
+  await prisma.job.updateMany({
+    where: {
+      contractJobId: onChainJobId,
+      escrowStatus: "UNFUNDED",
+    },
+    data: { escrowStatus: "FUNDED", status: "IN_PROGRESS" },
+  });
+
+  console.log(`[HorizonListener] JobFunded — contractJobId=${onChainJobId}`);
+}
+
+/**
+ * escrow / pmt_released — (job_id: u64, freelancer: Address, amount: i128)
+ *
+ * All milestone payments released; job is complete.
+ */
+async function handlePaymentReleased(event: SorobanEvent): Promise<void> {
+  const data = scValToNative(event.value) as unknown[];
+  if (!Array.isArray(data) || data.length < 1) return;
+
+  const onChainJobId = bigintToStr(data[0]);
+
+  const updated = await prisma.job.updateMany({
+    where: {
+      contractJobId: onChainJobId,
+      status: { not: "COMPLETED" },
+    },
+    data: { escrowStatus: "COMPLETED", status: "COMPLETED" },
+  });
+
+  if (updated.count > 0) {
+    // Notify both parties
+    const job = await prisma.job.findFirst({
+      where: { contractJobId: onChainJobId },
+      select: { clientId: true, freelancerId: true, title: true },
+    });
+    if (job) {
+      const notifyIds = [job.clientId, job.freelancerId].filter(Boolean) as string[];
+      await Promise.all(
+        notifyIds.map((userId) =>
+          NotificationService.sendNotification({
+            userId,
+            type: "MILESTONE_APPROVED",
+            title: "Payment Released",
+            message: `All payments for "${job.title}" have been released on-chain.`,
+            metadata: { contractJobId: onChainJobId },
+            skipBatching: true,
+          })
+        )
+      );
+    }
+  }
+
+  console.log(`[HorizonListener] PaymentReleased — contractJobId=${onChainJobId}`);
+}
+
+/**
+ * dispute / raised — (dispute_id: u64, job_id: u64, initiator: Address)
+ *
+ * A dispute was opened on-chain.  Upsert the DB Dispute record and set the
+ * job status to DISPUTED.
+ */
+async function handleDisputeOpened(event: SorobanEvent): Promise<void> {
+  const data = scValToNative(event.value) as unknown[];
+  if (!Array.isArray(data) || data.length < 3) return;
+
+  const onChainDisputeId = bigintToStr(data[0]);
+  const onChainJobId = bigintToStr(data[1]);
+
+  // Find the job in DB by contractJobId
+  const job = await prisma.job.findFirst({
+    where: { contractJobId: onChainJobId },
+    select: { id: true, clientId: true, freelancerId: true, dispute: true },
+  });
+
+  if (!job) {
+    console.warn(`[HorizonListener] DisputeOpened — no DB job for contractJobId=${onChainJobId}`);
+    return;
+  }
+
+  // Mark job as DISPUTED
+  await prisma.job.update({
+    where: { id: job.id },
+    data: { status: "DISPUTED", escrowStatus: "DISPUTED" },
+  });
+
+  // Upsert dispute record — idempotent via onChainDisputeId unique constraint
+  await prisma.dispute.upsert({
+    where: { onChainDisputeId },
+    update: { status: "OPEN" },
+    create: {
+      jobId: job.id,
+      onChainDisputeId,
+      clientId: job.clientId,
+      freelancerId: job.freelancerId ?? job.clientId,
+      initiatorId: job.clientId,
+      reason: "Raised on-chain",
+      status: "OPEN",
+    },
+  });
+
+  // Notify both parties
+  const notifyIds = [job.clientId, job.freelancerId].filter(Boolean) as string[];
+  await Promise.all(
+    notifyIds.map((userId) =>
+      NotificationService.sendNotification({
+        userId,
+        type: "DISPUTE_RAISED",
+        title: "Dispute Opened",
+        message: "A dispute has been opened on-chain for your job.",
+        metadata: { onChainDisputeId, contractJobId: onChainJobId },
+      })
+    )
+  );
+
+  console.log(`[HorizonListener] DisputeOpened — onChainDisputeId=${onChainDisputeId}`);
+}
+
+/**
+ * dispute / resolved — (dispute_id: u64, dispute_status: DisputeStatus)
+ *
+ * Voting concluded and the dispute has been resolved on-chain.
+ */
+async function handleDisputeResolved(event: SorobanEvent): Promise<void> {
+  const data = scValToNative(event.value) as unknown[];
+  if (!Array.isArray(data) || data.length < 2) return;
+
+  const onChainDisputeId = bigintToStr(data[0]);
+  const rawStatus = enumVariant(data[1]);
+
+  // Map on-chain DisputeStatus variants to DB DisputeStatus + job outcomes
+  let dbDisputeStatus: "OPEN" | "IN_PROGRESS" | "RESOLVED" = "RESOLVED";
+  let jobStatus: "COMPLETED" | "CANCELLED" | null = null;
+  let outcome: string = rawStatus;
+
+  if (rawStatus === "ResolvedForClient") {
+    jobStatus = "CANCELLED";
+    outcome = "CLIENT_WINS";
+  } else if (rawStatus === "ResolvedForFreelancer") {
+    jobStatus = "COMPLETED";
+    outcome = "FREELANCER_WINS";
+  } else if (rawStatus === "RefundedBoth") {
+    jobStatus = "CANCELLED";
+    outcome = "REFUND_BOTH";
+  } else if (rawStatus === "Escalated") {
+    dbDisputeStatus = "IN_PROGRESS";
+    outcome = "ESCALATED";
+  }
+
+  const dispute = await prisma.dispute.findUnique({
+    where: { onChainDisputeId },
+    select: { id: true, jobId: true, clientId: true, freelancerId: true },
+  });
+
+  if (!dispute) {
+    console.warn(`[HorizonListener] DisputeResolved — no DB dispute for onChainDisputeId=${onChainDisputeId}`);
+    return;
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.dispute.update({
+      where: { id: dispute.id },
+      data: {
+        status: dbDisputeStatus,
+        outcome,
+        resolvedAt: dbDisputeStatus === "RESOLVED" ? new Date() : null,
+      },
+    });
+
+    if (jobStatus) {
+      await tx.job.update({
+        where: { id: dispute.jobId },
+        data: {
+          status: jobStatus,
+          escrowStatus: jobStatus === "COMPLETED" ? "COMPLETED" : "CANCELLED",
+        },
+      });
+    }
+  });
+
+  // Notify both parties
+  const notifyIds = [dispute.clientId, dispute.freelancerId].filter(Boolean) as string[];
+  await Promise.all(
+    notifyIds.map((userId) =>
+      NotificationService.sendNotification({
+        userId,
+        type: "DISPUTE_RESOLVED",
+        title: "Dispute Resolved",
+        message: `The dispute has been resolved on-chain: ${outcome}.`,
+        metadata: { onChainDisputeId, outcome },
+      })
+    )
+  );
+
+  console.log(`[HorizonListener] DisputeResolved — onChainDisputeId=${onChainDisputeId} outcome=${outcome}`);
+}
+
+/**
+ * reput / badge — (user_address: Address, tier: ReputationTier)
+ *
+ * A reputation badge was awarded on-chain.  Upsert the DB Badge record and
+ * notify the user.
+ */
+async function handleBadgeAwarded(event: SorobanEvent): Promise<void> {
+  const data = scValToNative(event.value) as unknown[];
+  if (!Array.isArray(data) || data.length < 2) return;
+
+  const walletAddress = String(data[0] ?? "");
+  const tier = toBadgeTier(data[1]);
+
+  if (!walletAddress || !tier) return;
+
+  const user = await prisma.user.findUnique({
+    where: { walletAddress },
+    select: { id: true },
+  });
+
+  if (!user) {
+    console.warn(`[HorizonListener] BadgeAwarded — no user for wallet=${walletAddress}`);
+    return;
+  }
+
+  const result = await prisma.badge.upsert({
+    where: { userId_tier: { userId: user.id, tier } },
+    update: {},
+    create: {
+      userId: user.id,
+      tier,
+      awardedLedger: event.ledger,
+    },
+  });
+
+  // Only notify on first award (upsert created a new row means awardedLedger changed)
+  if (result.awardedLedger === event.ledger) {
+    await NotificationService.sendNotification({
+      userId: user.id,
+      type: "BADGE_AWARDED",
+      title: `${tier.charAt(0) + tier.slice(1).toLowerCase()} Badge Earned!`,
+      message: `Congratulations! You earned a ${tier.toLowerCase()} reputation badge on-chain.`,
+      metadata: { tier, awardedLedger: event.ledger },
+      skipBatching: true,
+    });
+  }
+
+  console.log(`[HorizonListener] BadgeAwarded — wallet=${walletAddress} tier=${tier}`);
+}
+
+// ─── event dispatch ───────────────────────────────────────────────────────────
+
+async function processEvent(event: SorobanEvent): Promise<void> {
+  const [contract, name] = topicToStrings(event);
+
+  try {
+    if (contract === "escrow") {
+      if (name === "created") return await handleJobCreated(event);
+      if (name === "funded") return await handleJobFunded(event);
+      if (name === "pmt_released") return await handlePaymentReleased(event);
+    }
+
+    if (contract === "dispute") {
+      if (name === "raised") return await handleDisputeOpened(event);
+      if (name === "resolved") return await handleDisputeResolved(event);
+    }
+
+    if (contract === "reput") {
+      if (name === "badge") return await handleBadgeAwarded(event);
+    }
+  } catch (err) {
+    console.error(
+      `[HorizonListener] Error processing event ${contract}/${name} at ledger ${event.ledger}:`,
+      err
+    );
+  }
+}
+
+// ─── polling loop ─────────────────────────────────────────────────────────────
+
+async function poll(): Promise<void> {
+  const contractIds = [
+    config.stellar.escrowContractId,
+    config.stellar.disputeContractId,
+    config.stellar.reputationContractId,
+  ].filter(Boolean);
+
+  if (contractIds.length === 0) {
+    return;
+  }
+
+  const lastLedger = await getLastIndexedLedger();
+
+  let startLedger: number;
+  try {
+    const latest = await server.getLatestLedger();
+    if (lastLedger === 0) {
+      // First run — start from the current tip so we don't replay all history
+      startLedger = latest.sequence;
+      await setLastIndexedLedger(startLedger);
+      console.log(`[HorizonListener] First run — starting from ledger ${startLedger}`);
+      return;
+    }
+    startLedger = lastLedger + 1;
+
+    if (startLedger > latest.sequence) {
+      return; // nothing new
+    }
+  } catch (err) {
+    console.error("[HorizonListener] Failed to fetch latest ledger:", err);
+    return;
+  }
+
+  let events: SorobanEvent[] = [];
+  let maxEventLedger = lastLedger;
+
+  try {
+    const result = await server.getEvents({
+      startLedger,
+      filters: [{ type: "contract", contractIds }],
+      limit: MAX_EVENTS_PER_POLL,
+    });
+    events = result.events;
+  } catch (err: any) {
+    // Soroban RPC returns an error when startLedger is before the retention window.
+    // Reset to the latest ledger so we don't loop on the same bad cursor.
+    const msg: string = err?.message ?? "";
+    if (msg.includes("startLedger") || msg.includes("ledger")) {
+      console.warn("[HorizonListener] startLedger out of retention window, resetting cursor");
+      try {
+        const latest = await server.getLatestLedger();
+        await setLastIndexedLedger(latest.sequence);
+      } catch (_) {}
+    } else {
+      console.error("[HorizonListener] getEvents error:", err);
+    }
+    return;
+  }
+
+  for (const event of events) {
+    await processEvent(event);
+    if (event.ledger > maxEventLedger) maxEventLedger = event.ledger;
+  }
+
+  if (maxEventLedger > lastLedger) {
+    await setLastIndexedLedger(maxEventLedger);
+  }
+}
+
+// ─── public API ───────────────────────────────────────────────────────────────
+
+let intervalId: NodeJS.Timeout | null = null;
+
+export function startHorizonListener(): void {
+  if (intervalId) return;
+
+  const contractIds = [
+    config.stellar.escrowContractId,
+    config.stellar.disputeContractId,
+    config.stellar.reputationContractId,
+  ].filter(Boolean);
+
+  if (contractIds.length === 0) {
+    console.log("[HorizonListener] No contract IDs configured — skipping");
+    return;
+  }
+
+  console.log("[HorizonListener] Starting — polling every", POLL_INTERVAL_MS / 1_000, "s");
+  console.log("[HorizonListener] Watching contracts:", contractIds);
+
+  poll();
+  intervalId = setInterval(() => void poll(), POLL_INTERVAL_MS);
+}
+
+export function stopHorizonListener(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+    console.log("[HorizonListener] Stopped");
+  }
+}


### PR DESCRIPTION
 Problem
                                                                                
  The backend had no mechanism to learn about on-chain state changes
  independently. It relied entirely on the frontend making webhook calls after
  submitting transactions. Any server restart or transaction that happened while
   no user was active caused permanent state drift — jobs stayed UNFUNDED after
  funding, disputes were never opened in the DB, badges were never awarded.

  What this PR does

  Adds a polling event listener (HorizonListenerService) that subscribes to the
  Soroban RPC event stream for the escrow, dispute, and reputation contracts. On
   every startup it replays all missed events from the last successfully
  processed ledger, then continues streaming in real time.

  New service: horizon-listener.service.ts

  - Polls rpc.Server.getEvents() every 5 seconds, filtered by contract ID
  - Reads lastIndexedLedger from the new SyncState table on startup and replays
  from lastIndexedLedger + 1 — this is the catch-up mechanism
  - Resets the cursor gracefully if the stored ledger falls outside the RPC
  retention window (e.g. after extended downtime)                               
  - Skips silently if no contract IDs are configured (safe in dev environments)
                                                                                
  Six idempotent event handlers
                                                                                
  ┌────────────────┬────────────────────────────────────────────────────────┐   
  │     Event      │                                                        │
  │  (contract /   │                       DB effect                        │   
  │     topic)     │                                                        │
  ├────────────────┼────────────────────────────────────────────────────────┤
  │ escrow /       │ Confirms escrowStatus = UNFUNDED on matching job       │
  │ created        │                                                        │
  ├────────────────┼────────────────────────────────────────────────────────┤
  │ escrow /       │ Sets escrowStatus = FUNDED, status = IN_PROGRESS       │
  │ funded         │                                                        │
  ├────────────────┼────────────────────────────────────────────────────────┤
  │ escrow /       │ Sets escrowStatus = COMPLETED, status = COMPLETED;     │
  │ pmt_released   │ notifies both parties                                  │
  ├────────────────┼────────────────────────────────────────────────────────┤
  │ dispute /      │ Upserts Dispute row by onChainDisputeId; sets job      │
  │ raised         │ status = DISPUTED; notifies both parties               │   
  ├────────────────┼────────────────────────────────────────────────────────┤
  │                │ Maps all four on-chain outcomes (ClientWins →          │   
  │ dispute /      │ CANCELLED, FreelancerWins → COMPLETED, RefundBoth →    │
  │ resolved       │ CANCELLED, Escalated → IN_PROGRESS) to DB state;       │
  │                │ notifies both parties                                  │
  ├────────────────┼────────────────────────────────────────────────────────┤
  │ reput / badge  │ Upserts Badge by (userId, tier); sends immediate       │
  │                │ notification to user                                   │   
  └────────────────┴────────────────────────────────────────────────────────┘
                                                                                
  All handlers are safe to run multiple times on the same event — no duplicate  
  records or notifications.
                                                                                
  DB migration (20260425000000_add_sync_state_badge)                            
  
  - SyncState — singleton table (id = "default") storing lastIndexedLedger INT  
  - BadgeTier enum — BRONZE / SILVER / GOLD / PLATINUM
  - Badge table — tracks on-chain badge awards per user with @@unique([userId,  
  tier])                                                                        
  - BADGE_AWARDED added to the NotificationType enum


closes #278 