### PR TITLE
fix: move helmet() before Swagger UI and validate escrow address in r…

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -34,6 +34,8 @@ const corsOptions: cors.CorsOptions = {
 };
 
 // Security middleware
+app.use(helmet());
+
 // Swagger UI setup (disabled in production)
 if (process.env.NODE_ENV !== "production") {
   app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
@@ -42,7 +44,6 @@ if (process.env.NODE_ENV !== "production") {
     res.send(swaggerSpec);
   });
 }
-app.use(helmet());
 app.use(cors(corsOptions));
 app.use(express.json({ limit: "1mb" }));
 app.use(express.urlencoded({ extended: true, limit: "1mb" }));

--- a/contracts/dispute/src/lib.rs
+++ b/contracts/dispute/src/lib.rs
@@ -700,7 +700,6 @@ impl DisputeContract {
     pub fn resolve_dispute(
         env: Env,
         dispute_id: u64,
-        escrow: Address,
     ) -> Result<DisputeStatus, DisputeError> {
         require_not_paused(&env)?;
 
@@ -710,6 +709,13 @@ impl DisputeContract {
             .get(&DataKey::Dispute(dispute_id))
             .ok_or(DisputeError::DisputeNotFound)?;
         bump_dispute_ttl(&env, dispute_id);
+
+        // Retrieve the trusted escrow contract address from storage
+        let escrow: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::EscrowContract)
+            .ok_or(DisputeError::NotInitialized)?;
 
         if dispute.status == DisputeStatus::ResolvedForClient
             || dispute.status == DisputeStatus::ResolvedForFreelancer

--- a/contracts/dispute/src/test.rs
+++ b/contracts/dispute/src/test.rs
@@ -259,7 +259,7 @@ fn test_vote_and_resolve() {
         &String::from_str(&env, "Incomplete work"),
     );
 
-    let result = client.resolve_dispute(&dispute_id, &escrow_contract_id);
+    let result = client.resolve_dispute(&dispute_id);
     assert_eq!(result, DisputeStatus::ResolvedForFreelancer);
 }
 
@@ -299,7 +299,7 @@ fn test_resolve_without_enough_votes() {
         &String::from_str(&env, "Reason"),
     );
 
-    client.resolve_dispute(&dispute_id, &escrow_contract_id);
+    client.resolve_dispute(&dispute_id);
 }
 
 #[test]
@@ -357,7 +357,7 @@ fn test_tie_break_favor_client() {
         &String::from_str(&env, "F2"),
     );
 
-    let status = client.resolve_dispute(&dispute_id, &escrow_contract_id);
+    let status = client.resolve_dispute(&dispute_id);
     assert_eq!(status, DisputeStatus::ResolvedForClient);
 }
 
@@ -416,7 +416,7 @@ fn test_tie_break_favor_freelancer() {
         &String::from_str(&env, "F2"),
     );
 
-    let status = client.resolve_dispute(&dispute_id, &escrow_contract_id);
+    let status = client.resolve_dispute(&dispute_id);
     assert_eq!(status, DisputeStatus::ResolvedForFreelancer);
 }
 
@@ -475,7 +475,7 @@ fn test_tie_break_refund_both() {
         &String::from_str(&env, "F2"),
     );
 
-    let status = client.resolve_dispute(&dispute_id, &escrow_contract_id);
+    let status = client.resolve_dispute(&dispute_id);
     assert_eq!(status, DisputeStatus::RefundedBoth);
 }
 
@@ -534,7 +534,7 @@ fn test_tie_break_escalate() {
         &String::from_str(&env, "F2"),
     );
 
-    let status = client.resolve_dispute(&dispute_id, &escrow_contract_id);
+    let status = client.resolve_dispute(&dispute_id);
     assert_eq!(status, DisputeStatus::Escalated);
 }
 
@@ -593,7 +593,7 @@ fn test_tie_break_default_refund_both() {
         &String::from_str(&env, "F2"),
     );
 
-    let status = client.resolve_dispute(&dispute_id, &escrow_contract_id);
+    let status = client.resolve_dispute(&dispute_id);
     assert_eq!(status, DisputeStatus::RefundedBoth);
 }
 
@@ -827,7 +827,7 @@ fn test_resolve_dispute_when_paused() {
 
     client.pause(&admin);
 
-    client.resolve_dispute(&dispute_id, &escrow_contract_id);
+    client.resolve_dispute(&dispute_id);
 }
 
 #[test]
@@ -940,7 +940,7 @@ fn test_client_wins_freelancer_stake_slashed() {
     let (client, _, escrow_id, _user_client, _freelancer, dispute_id) =
         setup_dispute_with_votes(&env, 3, 0);
 
-    let status = client.resolve_dispute(&dispute_id, &escrow_id);
+    let status = client.resolve_dispute(&dispute_id);
     assert_eq!(status, DisputeStatus::ResolvedForClient);
 
     // Verify StakeSlashed event was emitted — it is the last event
@@ -970,7 +970,7 @@ fn test_freelancer_wins_client_stake_slashed() {
     let (client, _, escrow_id, _user_client, _freelancer, dispute_id) =
         setup_dispute_with_votes(&env, 0, 3);
 
-    let status = client.resolve_dispute(&dispute_id, &escrow_id);
+    let status = client.resolve_dispute(&dispute_id);
     assert_eq!(status, DisputeStatus::ResolvedForFreelancer);
 
     let events = env.events().all();
@@ -1019,7 +1019,7 @@ fn test_no_slash_on_escalated_dispute() {
     client.cast_vote(&dispute_id, &voter3, &VoteChoice::Client, &String::from_str(&env, "C"));
     client.cast_vote(&dispute_id, &voter4, &VoteChoice::Freelancer, &String::from_str(&env, "F"));
 
-    let status = client.resolve_dispute(&dispute_id, &escrow_contract_id);
+    let status = client.resolve_dispute(&dispute_id);
     assert_eq!(status, DisputeStatus::Escalated);
 
     // No StakeSlashed event should be emitted for escalated disputes
@@ -1085,7 +1085,7 @@ fn test_raise_dispute_blocked_by_job_cooldown() {
         &String::from_str(&env, "V3"),
     );
 
-    let _ = client.resolve_dispute(&dispute_id, &escrow_contract_id);
+    let _ = client.resolve_dispute(&dispute_id);
 
     // Re-opening the same job dispute immediately must fail.
     client.raise_dispute(
@@ -1149,7 +1149,7 @@ fn test_raise_dispute_allowed_after_cooldown() {
         &String::from_str(&env, "V3"),
     );
 
-    let _ = client.resolve_dispute(&first_dispute_id, &escrow_contract_id);
+    let _ = client.resolve_dispute(&first_dispute_id);
 
     // Cooldown is 86_400 seconds.
     env.ledger().with_mut(|l| l.timestamp = 1000 + 86_401);

--- a/contracts/integration-tests/tests/integration_test.rs
+++ b/contracts/integration-tests/tests/integration_test.rs
@@ -300,7 +300,7 @@ fn test_dispute_resolved_for_freelancer() {
     assert_eq!(dispute.votes_for_client, 1);
 
     // Resolution is final in reputation-based voting (no appeals)
-    let result = dispute_client.resolve_dispute(&dispute_id_val, &escrow_id);
+    let result = dispute_client.resolve_dispute(&dispute_id_val);
     assert_eq!(result, DisputeStatus::ResolvedForFreelancer);
 
     // Funds are transferred immediately to freelancer
@@ -402,7 +402,7 @@ fn test_dispute_resolved_for_client() {
 
     // First resolution — not final yet (max_appeals=2, appeal_count=0).
     // Resolution is final in reputation-based voting (no appeals)
-    let result = dispute_client.resolve_dispute(&dispute_id_val, &escrow_id);
+    let result = dispute_client.resolve_dispute(&dispute_id_val);
     assert_eq!(result, DisputeStatus::ResolvedForClient);
 
     // Funds are refunded to client immediately
@@ -638,7 +638,7 @@ fn test_dispute_with_all_milestones_approved() {
     );
 
     // Resolution is final in reputation-based voting (no appeals)
-    let result = dispute_client.resolve_dispute(&dispute_id_val, &escrow_id);
+    let result = dispute_client.resolve_dispute(&dispute_id_val);
     assert_eq!(result, DisputeStatus::ResolvedForFreelancer);
 
     // Funds are transferred immediately to freelancer


### PR DESCRIPTION
closes #332
closes #323 
closes #315 
closes #312  

- Move helmet() middleware before Swagger UI setup to ensure security headers are applied to /api/docs and /api/openapi.json routes
- Replace escrow parameter in resolve_dispute with stored EscrowContract address lookup to prevent untrusted caller input
- Update all test files to match new resolve_dispute signature