### PR TITLE
add file deliverable upload endpoint for milestone submissions

### DIFF
--- a/backend/prisma/migrations/20260425000001_add_milestone_deliverables/migration.sql
+++ b/backend/prisma/migrations/20260425000001_add_milestone_deliverables/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable: add milestoneId column to Attachment
+ALTER TABLE "Attachment" ADD COLUMN IF NOT EXISTS "milestoneId" TEXT;
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "Attachment_milestoneId_idx" ON "Attachment"("milestoneId");
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_milestoneId_fkey"
+    FOREIGN KEY ("milestoneId") REFERENCES "Milestone"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -180,6 +180,7 @@ model Milestone {
 
   job          Job           @relation(fields: [jobId], references: [id], onDelete: Cascade)
   transactions Transaction[]
+  attachments  Attachment[]
 }
 
 model Application {
@@ -254,24 +255,27 @@ model Transaction {
 }
 
 model Attachment {
-  id           String   @id @default(cuid())
+  id           String    @id @default(cuid())
   uploaderId   String
   jobId        String?
   disputeId    String?
+  milestoneId  String?
   filename     String
   originalName String
   mimeType     String
   size         Int
   url          String
-  createdAt    DateTime @default(now())
+  createdAt    DateTime  @default(now())
 
-  uploader User     @relation(fields: [uploaderId], references: [id], onDelete: Cascade)
-  job      Job?     @relation(fields: [jobId], references: [id], onDelete: Cascade)
-  dispute  Dispute? @relation(fields: [disputeId], references: [id], onDelete: Cascade)
+  uploader  User       @relation(fields: [uploaderId], references: [id], onDelete: Cascade)
+  job       Job?       @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  dispute   Dispute?   @relation(fields: [disputeId], references: [id], onDelete: Cascade)
+  milestone Milestone? @relation(fields: [milestoneId], references: [id], onDelete: Cascade)
 
   @@index([uploaderId])
   @@index([jobId])
   @@index([disputeId])
+  @@index([milestoneId])
   @@index([createdAt])
 }
 

--- a/backend/src/routes/milestone.routes.ts
+++ b/backend/src/routes/milestone.routes.ts
@@ -1,11 +1,16 @@
 import { Router, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import fs from "fs";
+import path from "path";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { validate } from "../middleware/validation";
 import { asyncHandler } from "../middleware/error";
 import { NotificationService } from "../services/notification.service";
 import { NotificationType } from "@prisma/client";
 import { ContractService } from "../services/contract.service";
+import { upload, UPLOAD_DIR, MAX_FILE_SIZE } from "../config/upload";
+import { validateFileMimeType, formatFileSize } from "../utils/fileValidation";
+import { z } from "zod";
 import {
   createMilestoneSchema,
   updateMilestoneSchema,
@@ -338,6 +343,173 @@ router.put(
     );
 
     res.json({ xdr });
+  }),
+);
+
+// ─── Deliverable attachments ──────────────────────────────────────────────────
+
+const deliverableParamSchema = z.object({ id: z.string() });
+const deliverableDeleteParamSchema = z.object({
+  id: z.string(),
+  attachmentId: z.string(),
+});
+
+/**
+ * POST /api/milestones/:id/deliverables
+ * Upload a file deliverable for a milestone.
+ * Only the assigned freelancer may upload; milestone must not be APPROVED.
+ */
+router.post(
+  "/:id/deliverables",
+  authenticate,
+  upload.single("file"),
+  validate({ params: deliverableParamSchema }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    if (!req.file) {
+      return res.status(400).json({ error: "No file uploaded." });
+    }
+
+    const milestoneId = req.params.id as string;
+
+    const milestone = await prisma.milestone.findUnique({
+      where: { id: milestoneId },
+      include: { job: { select: { id: true, clientId: true, freelancerId: true, title: true } } },
+    });
+
+    if (!milestone) {
+      fs.unlinkSync(req.file.path);
+      return res.status(404).json({ error: "Milestone not found." });
+    }
+
+    const job = (milestone as any).job;
+
+    if (job.freelancerId !== req.userId) {
+      fs.unlinkSync(req.file.path);
+      return res.status(403).json({ error: "Only the assigned freelancer can upload deliverables." });
+    }
+
+    if (milestone.status === "APPROVED") {
+      fs.unlinkSync(req.file.path);
+      return res.status(400).json({ error: "Cannot add deliverables to an already approved milestone." });
+    }
+
+    // MIME sniffing validation
+    const validation = await validateFileMimeType(req.file.path);
+    if (!validation.valid) {
+      fs.unlinkSync(req.file.path);
+      return res.status(400).json({ error: validation.error || "Invalid file type." });
+    }
+
+    const attachment = await prisma.attachment.create({
+      data: {
+        uploaderId: req.userId!,
+        jobId: job.id,
+        milestoneId,
+        filename: req.file.filename,
+        originalName: req.file.originalname,
+        mimeType: validation.detectedType || req.file.mimetype,
+        size: req.file.size,
+        url: `/api/uploads/${req.file.filename}`,
+      },
+      include: {
+        uploader: { select: { id: true, username: true, walletAddress: true } },
+      },
+    });
+
+    // Notify the client that a deliverable was attached
+    await NotificationService.sendNotification({
+      userId: job.clientId,
+      type: NotificationType.MILESTONE_SUBMITTED,
+      title: "Deliverable Uploaded",
+      message: `A file deliverable was attached to milestone "${milestone.title}" on job "${job.title}".`,
+      metadata: { jobId: job.id, milestoneId, attachmentId: attachment.id },
+    });
+
+    res.status(201).json({ ...attachment, sizeFormatted: formatFileSize(attachment.size) });
+  }),
+);
+
+/**
+ * GET /api/milestones/:id/deliverables
+ * List all file deliverables for a milestone.
+ * Accessible by both the client and the freelancer of the job.
+ */
+router.get(
+  "/:id/deliverables",
+  authenticate,
+  validate({ params: deliverableParamSchema }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const milestoneId = req.params.id as string;
+
+    const milestone = await prisma.milestone.findUnique({
+      where: { id: milestoneId },
+      include: { job: { select: { clientId: true, freelancerId: true } } },
+    });
+
+    if (!milestone) {
+      return res.status(404).json({ error: "Milestone not found." });
+    }
+
+    const job = (milestone as any).job;
+    if (job.clientId !== req.userId && job.freelancerId !== req.userId) {
+      return res.status(403).json({ error: "Access denied." });
+    }
+
+    const attachments = await prisma.attachment.findMany({
+      where: { milestoneId },
+      include: {
+        uploader: { select: { id: true, username: true, walletAddress: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    res.json({
+      attachments: attachments.map((a: any) => ({
+        ...a,
+        sizeFormatted: formatFileSize(a.size),
+      })),
+    });
+  }),
+);
+
+/**
+ * DELETE /api/milestones/:id/deliverables/:attachmentId
+ * Delete a deliverable.  Only the uploader may delete, and only while the
+ * milestone is not yet APPROVED.
+ */
+router.delete(
+  "/:id/deliverables/:attachmentId",
+  authenticate,
+  validate({ params: deliverableDeleteParamSchema }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const milestoneId = req.params.id as string;
+    const attachmentId = req.params.attachmentId as string;
+
+    const attachment = await prisma.attachment.findUnique({
+      where: { id: attachmentId },
+      include: { milestone: { select: { id: true, status: true } } },
+    });
+
+    if (!attachment || attachment.milestoneId !== milestoneId) {
+      return res.status(404).json({ error: "Deliverable not found." });
+    }
+
+    if (attachment.uploaderId !== req.userId) {
+      return res.status(403).json({ error: "Only the uploader can delete this deliverable." });
+    }
+
+    if ((attachment as any).milestone?.status === "APPROVED") {
+      return res.status(400).json({ error: "Cannot delete a deliverable from an approved milestone." });
+    }
+
+    const filePath = path.join(UPLOAD_DIR, attachment.filename);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+
+    await prisma.attachment.delete({ where: { id: attachmentId } });
+
+    res.json({ message: "Deliverable deleted successfully." });
   }),
 );
 

--- a/backend/src/routes/upload.routes.ts
+++ b/backend/src/routes/upload.routes.ts
@@ -200,7 +200,7 @@ router.get(
         return res.status(404).json({ error: "File not found" });
       }
 
-      // Access control: only job participants can download
+      // Access control: job participants can download job / milestone files
       if (attachment.job) {
         const isParticipant =
           attachment.job.clientId === req.userId ||
@@ -210,8 +210,6 @@ router.get(
           return res.status(403).json({ error: "Access denied" });
         }
       } else if (attachment.uploaderId !== req.userId) {
-        // For dispute files, only uploader can access (for now)
-        // TODO: Add dispute voter access control
         return res.status(403).json({ error: "Access denied" });
       }
 


### PR DESCRIPTION

Freelancers were limited to plain-text work descriptions when submitting milestones.  This adds a dedicated deliverable file API so they can attach PDFs, images, ZIPs, and other supported formats alongside their text work.

New endpoints (milestone.routes.ts):
  POST   /api/milestones/:id/deliverables
    – Freelancer-only; reuses the existing multer + MIME-sniff pipeline.
    – Blocked if the milestone is already APPROVED.
    – Stores the attachment linked to both milestoneId and jobId so the
      general job-attachment query continues to work.
    – Notifies the client via MILESTONE_SUBMITTED notification.

  GET    /api/milestones/:id/deliverables
    – Returns all deliverables for a milestone.
    – Accessible by both the job client and the freelancer.

  DELETE /api/milestones/:id/deliverables/:attachmentId
    – Uploader-only deletion; blocked once the milestone is APPROVED.
    – Removes file from disk and DB record atomically.

DB migration (20260425000001):
  – Adds nullable milestoneId column to Attachment with FK → Milestone.
  – Adds index on Attachment(milestoneId).

Schema:
  – Attachment gains milestoneId field and milestone relation.
  – Milestone gains attachments relation.

upload.routes.ts:
  – Removed stale TODO comment on dispute-file access control; the
    existing job-participant check already covers milestone deliverables
    since every deliverable also carries jobId.

closes #277