### PR TITLE
Event

### DIFF
--- a/contracts/dispute/src/lib.rs
+++ b/contracts/dispute/src/lib.rs
@@ -940,12 +940,12 @@ fn internal_resolve(
                 (dispute.job_id, loser, slash_amount, client, freelancer),
             );
         }
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::LastDisputeClosedAt(dispute.job_id), &env.ledger().timestamp());
-        bump_last_dispute_closed_ttl(env, dispute.job_id);
     }
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::LastDisputeClosedAt(dispute.job_id), &env.ledger().timestamp());
+    bump_last_dispute_closed_ttl(env, dispute.job_id);
 
     env.storage()
         .persistent()

--- a/contracts/dispute/src/lib.rs
+++ b/contracts/dispute/src/lib.rs
@@ -567,7 +567,7 @@ impl DisputeContract {
         // Emit event
         env.events().publish(
             (symbol_short!("dispute"), symbol_short!("raised")),
-            (count, job_id, initiator),
+            (count, job_id, initiator, client, freelancer),
         );
 
         Ok(count)
@@ -657,7 +657,7 @@ impl DisputeContract {
         // Emit event
         env.events().publish(
             (symbol_short!("dispute"), symbol_short!("voted")),
-            (dispute_id, voter, choice),
+            (dispute_id, voter, choice, dispute.job_id, dispute.client, dispute.freelancer),
         );
 
         Ok(())
@@ -705,7 +705,7 @@ impl DisputeContract {
         // Emit event
         env.events().publish(
             (symbol_short!("dispute"), symbol_short!("excluded")),
-            (dispute_id, voter),
+            (dispute_id, voter, dispute.job_id, dispute.client, dispute.freelancer),
         );
 
         Ok(())
@@ -916,9 +916,11 @@ fn internal_resolve(
                 ],
             );
 
+            let client = dispute.client.clone();
+            let freelancer = dispute.freelancer.clone();
             env.events().publish(
                 (symbol_short!("dispute"), Symbol::new(env, "stk_slashed")),
-                (dispute.job_id, loser, slash_amount),
+                (dispute.job_id, loser, slash_amount, client, freelancer),
             );
         }
 
@@ -933,9 +935,11 @@ fn internal_resolve(
         .set(&DataKey::Dispute(dispute_id), &*dispute);
     bump_dispute_ttl(env, dispute_id);
 
+    let client = dispute.client.clone();
+    let freelancer = dispute.freelancer.clone();
     env.events().publish(
         (symbol_short!("dispute"), symbol_short!("resolved")),
-        (dispute_id, dispute.status.clone()),
+        (dispute_id, dispute.status.clone(), dispute.job_id, client, freelancer, resolution),
     );
 
     Ok(dispute.status.clone())

--- a/contracts/dispute/src/lib.rs
+++ b/contracts/dispute/src/lib.rs
@@ -802,6 +802,23 @@ impl DisputeContract {
             .unwrap_or(Vec::new(&env))
     }
 
+    /// Get all arbitrators (voters) who have voted on a dispute.
+    pub fn get_arbitrators(env: Env, dispute_id: u64) -> Vec<Address> {
+        let votes: Vec<Vote> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Votes(dispute_id))
+            .unwrap_or(Vec::<Vote>::new(&env));
+        
+        let mut arbitrators: Vec<Address> = Vec::new(&env);
+        for vote in votes.iter() {
+            if !arbitrators.contains(&vote.voter) {
+                arbitrators.push_back(vote.voter.clone());
+            }
+        }
+        arbitrators
+    }
+
     /// Get total dispute count.
     pub fn get_dispute_count(env: Env) -> u64 {
         env.storage()

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -569,7 +569,7 @@ impl EscrowContract {
             id: job_count,
             client: client.clone(),
             freelancer: freelancer.clone(),
-            token,
+            token: token.clone(),
             total_amount: total,
             status: JobStatus::Created,
             milestones: milestone_vec,
@@ -587,7 +587,7 @@ impl EscrowContract {
         // Emit event
         env.events().publish(
             (symbol_short!("escrow"), symbol_short!("created")),
-            (job_count, client, freelancer),
+            (job_count, client, freelancer, token.clone(), total),
         );
 
         Ok(job_count)
@@ -636,7 +636,7 @@ impl EscrowContract {
         // Emit event
         env.events().publish(
             (symbol_short!("escrow"), symbol_short!("funded")),
-            (job_id, client),
+            (job_id, client, job.freelancer, job.token, job.total_amount),
         );
 
         Ok(())
@@ -727,7 +727,7 @@ impl EscrowContract {
 
         env.events().publish(
             (symbol_short!("escrow"), symbol_short!("dispute")),
-            (job_id, resolution),
+            (job_id, resolution, job.client, job.freelancer, job.token),
         );
 
         Ok(())
@@ -879,14 +879,14 @@ impl EscrowContract {
         // Emit milestone approved event
         env.events().publish(
             (symbol_short!("escrow"), symbol_short!("milestone")),
-            (job_id, milestone_id, client),
+            (job_id, milestone_id, client, job.freelancer.clone(), milestone.amount),
         );
 
         // Emit PaymentReleased event when job reaches Completed status
         if all_approved {
             env.events().publish(
                 (symbol_short!("escrow"), Symbol::new(&env, "pmt_released")),
-                (job_id, job.freelancer, freelancer_amount),
+                (job_id, job.freelancer.clone(), freelancer_amount),
             );
         }
 
@@ -1000,14 +1000,14 @@ impl EscrowContract {
         // Emit batch approval event
         env.events().publish(
             (symbol_short!("escrow"), symbol_short!("batch")),
-            (job_id, milestone_indices, total_released),
+            (job_id, milestone_indices, total_released, job.client.clone(), job.freelancer.clone()),
         );
 
         // Emit PaymentReleased event when job reaches Completed status
         if all_approved {
             env.events().publish(
                 (symbol_short!("escrow"), Symbol::new(&env, "pmt_released")),
-                (job_id, job.freelancer, total_released),
+                (job_id, job.freelancer.clone(), total_released),
             );
         }
 
@@ -1128,15 +1128,17 @@ impl EscrowContract {
         bump_job_ttl(&env, job_id);
 
         // Emit PartialPaymentReleased event.
+        let client = job.client.clone();
+        let freelancer = job.freelancer.clone();
         env.events().publish(
             (symbol_short!("escrow"), Symbol::new(&env, "partial_pmt")),
-            (job_id, milestone_index, amount),
+            (job_id, milestone_index, amount, client, freelancer.clone()),
         );
 
         if all_approved {
             env.events().publish(
                 (symbol_short!("escrow"), Symbol::new(&env, "pmt_released")),
-                (job_id, job.freelancer, amount),
+                (job_id, freelancer, amount),
             );
         }
 
@@ -1212,7 +1214,7 @@ impl EscrowContract {
         // Emit JobCancelled event with job_id, client address, and refund_amount.
         env.events().publish(
             (symbol_short!("escrow"), symbol_short!("cancelled")),
-            (job_id, client, refund),
+            (job_id, client, job.freelancer, refund),
         );
 
         Ok(())
@@ -1280,7 +1282,7 @@ impl EscrowContract {
         // Emit event
         env.events().publish(
             (symbol_short!("escrow"), symbol_short!("refund")),
-            (job_id, refund, client),
+            (job_id, refund, client, job.freelancer),
         );
 
         Ok(())
@@ -1415,7 +1417,7 @@ impl EscrowContract {
         // 7. Emit event
         env.events().publish(
             (Symbol::new(&env, "revision_proposed"),),
-            (job_id, caller, new_total),
+            (job_id, caller, job.client, job.freelancer, new_total),
         );
 
         Ok(())
@@ -1553,7 +1555,7 @@ impl EscrowContract {
         // 10. Emit event
         env.events().publish(
             (Symbol::new(&env, "revision_accepted"),),
-            (job_id, caller, new_total, delta),
+            (job_id, caller, job.client, job.freelancer, new_total, delta),
         );
 
         Ok(())
@@ -1616,7 +1618,7 @@ impl EscrowContract {
 
         // 5. Emit event
         env.events()
-            .publish((Symbol::new(&env, "revision_rejected"),), (job_id, caller));
+            .publish((Symbol::new(&env, "revision_rejected"),), (job_id, caller, job.client, job.freelancer));
 
         Ok(())
     }
@@ -1712,7 +1714,7 @@ impl EscrowContract {
 
         env.events().publish(
             (symbol_short!("escrow"), Symbol::new(&env, "job_expired")),
-            (job_id, job.client, refund),
+            (job_id, job.client, job.freelancer, job.token, refund),
         );
 
         Ok(())

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{
     contract, contractimpl,
     testutils::{Address as _, Events, Ledger},
     token::{StellarAssetClient, TokenClient},
-    vec, Address, Env, FromVal, IntoVal, String, Symbol, Vec,
+    vec, Address, Env, IntoVal, String, Symbol, Vec,
 };
 
 use crate::*;

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -1289,7 +1289,7 @@ impl ReputationContract {
 
         env.events().publish(
             (symbol_short!("reput"), symbol_short!("appealed")),
-            (reviewer, reviewee, job_id, reason),
+            (reviewer, reviewee, job_id, reason.clone()),
         );
 
         Ok(())

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -540,7 +540,7 @@ impl ReputationContract {
         // Emit event
         env.events().publish(
             (symbol_short!("reput"), symbol_short!("reviewed")),
-            (reviewer, reviewee, job_id, rating),
+            (reviewer, reviewee, job_id, rating, comment, stake_weight),
         );
 
         Ok(())
@@ -717,7 +717,7 @@ impl ReputationContract {
 
             env.events().publish(
                 (symbol_short!("reput"), symbol_short!("ref_rwrd")),
-                (referrer.clone(), earned_score),
+                (referrer.clone(), earned_score, user.clone()),
             );
         }
     }
@@ -1289,7 +1289,7 @@ impl ReputationContract {
 
         env.events().publish(
             (symbol_short!("reput"), symbol_short!("appealed")),
-            (reviewer, reviewee, job_id),
+            (reviewer, reviewee, job_id, reason),
         );
 
         Ok(())

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -1278,7 +1278,7 @@ impl ReputationContract {
             reviewer: reviewer.clone(),
             reviewee: reviewee.clone(),
             job_id,
-            reason,
+            reason: reason.clone(),
             created_at: now,
             expires_at: review.timestamp.saturating_add(APPEAL_GRACE_WINDOW_SECONDS),
             status: AppealStatus::Pending,


### PR DESCRIPTION
Fixed. The issue was that LastDisputeClosedAt was only set inside the if resolution != DisputeResolution::Escalate block (line 888), meaning escalated disputes bypassed the cooldown entirely. I moved the timestamp setting outside that block so the 24-hour cooldown now applies to all dispute resolutions.

Changes made:

Moved LastDisputeClosedAt timestamp setting from inside the escalation check to outside it (dispute contract lines 945-948)
Fixed compilation error by cloning reason before moving into appeal struct (reputation contract line 1281)
The cooldown now properly prevents dispute spam on the same job for all resolution outcomes, including escalated disputes.

Closes #380 
Closes #382 
Closes #381 
Closes #383