### PR TITLE
Fix/pagination milestone dispute fulltext search

### DIFF
--- a/backend/prisma/migrations/20260426000000_add_partially_paid_milestone_status/migration.sql
+++ b/backend/prisma/migrations/20260426000000_add_partially_paid_milestone_status/migration.sql
@@ -1,0 +1,4 @@
+-- Migration: Add PARTIALLY_PAID to MilestoneStatus enum
+-- Issue #413: Support partial payment milestone status from escrow contract
+
+ALTER TYPE "MilestoneStatus" ADD VALUE IF NOT EXISTS 'PARTIALLY_PAID';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -40,6 +40,7 @@ enum MilestoneStatus {
   SUBMITTED
   APPROVED
   REJECTED
+  PARTIALLY_PAID
 }
 
 enum ApplicationStatus {

--- a/backend/src/routes/job.routes.ts
+++ b/backend/src/routes/job.routes.ts
@@ -153,14 +153,21 @@ router.get(
     const { data, hit } = await cache(cacheKey, 30, async () => {
       const where: any = {};
 
-      // Full-text search using PostgreSQL tsvector/tsquery.
+      // Full-text search using PostgreSQL tsvector/tsquery with relevance ranking.
       // Falls back to Prisma contains (LIKE) if raw query fails.
       if (search) {
         try {
-          const ftsResults = await prisma.$queryRaw<{ id: string }[]>`
-            SELECT id FROM "Job"
+          const ftsResults = await prisma.$queryRaw<
+            { id: string; rank: number }[]
+          >`
+            SELECT id, ts_rank(
+              to_tsvector('english', title || ' ' || description),
+              plainto_tsquery('english', ${search})
+            ) AS rank
+            FROM "Job"
             WHERE to_tsvector('english', title || ' ' || description)
               @@ plainto_tsquery('english', ${search})
+            ORDER BY rank DESC
           `;
           const matchedIds = ftsResults.map((r) => r.id);
           where.id = matchedIds.length > 0 ? { in: matchedIds } : { in: [] };

--- a/frontend/src/components/MilestoneTimeline.tsx
+++ b/frontend/src/components/MilestoneTimeline.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CheckCircle, Loader2, PencilLine, ShieldCheck } from "lucide-react";
+import { CheckCircle, Loader2, PencilLine, ShieldCheck, DollarSign } from "lucide-react";
 
 import StatusBadge from "@/components/StatusBadge";
 import type { Milestone } from "@/types";
@@ -22,6 +22,9 @@ function getIndicatorClasses(status: Milestone["status"], approvedPulse: boolean
     return approvedPulse
       ? "bg-theme-success border-theme-success shadow-[0_0_0_4px_rgba(34,197,94,0.18)]"
       : "bg-theme-success border-theme-success";
+  }
+  if (status === "PARTIALLY_PAID") {
+    return "bg-amber-500 border-amber-500";
   }
   if (status === "SUBMITTED") {
     return "bg-theme-warning border-theme-warning";
@@ -84,6 +87,8 @@ export default function MilestoneTimeline({
                   >
                     {milestone.status === "APPROVED" ? (
                       <CheckCircle className="text-white" size={18} />
+                    ) : milestone.status === "PARTIALLY_PAID" ? (
+                      <DollarSign className="text-white" size={18} />
                     ) : (
                       index + 1
                     )}

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -23,7 +23,11 @@ export default function Pagination({ page, totalPages, total, limit, onPageChang
       </p>
       <div className="flex items-center gap-2">
         <button
-          onClick={() => onPageChange(page - 1)}
+          onClick={() => {
+            if (page > 1) {
+              onPageChange(page - 1);
+            }
+          }}
           disabled={page <= 1}
           className="p-2 rounded-lg border border-theme-border text-theme-text hover:border-stellar-blue disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
         >
@@ -33,7 +37,11 @@ export default function Pagination({ page, totalPages, total, limit, onPageChang
           Page {page} of {totalPages}
         </span>
         <button
-          onClick={() => onPageChange(page + 1)}
+          onClick={() => {
+            if (page < totalPages) {
+              onPageChange(page + 1);
+            }
+          }}
           disabled={page >= totalPages}
           className="p-2 rounded-lg border border-theme-border text-theme-text hover:border-stellar-blue disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
         >

--- a/frontend/src/components/RaiseDisputeModal.tsx
+++ b/frontend/src/components/RaiseDisputeModal.tsx
@@ -212,7 +212,7 @@ export default function RaiseDisputeModal({
             </button>
             <button
               type="submit"
-              disabled={!canSubmit}
+              disabled={processing || !canSubmit}
               className="btn-primary flex-1 bg-theme-error hover:bg-theme-error/90 border border-transparent text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {processing ? (

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -9,6 +9,7 @@ const statusColors: Record<string, string> = {
   APPROVED: "bg-theme-success/20 text-theme-success border-theme-success/30",
   REJECTED: "bg-theme-error/20 text-theme-error border-theme-error/30",
   ACCEPTED: "bg-theme-success/20 text-theme-success border-theme-success/30",
+  PARTIALLY_PAID: "bg-amber-500/20 text-amber-500 border-amber-500/30",
 };
 
 interface StatusBadgeProps {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -21,7 +21,7 @@ export interface Milestone {
   title: string;
   description: string;
   amount: number;
-  status: "PENDING" | "IN_PROGRESS" | "SUBMITTED" | "APPROVED" | "REJECTED";
+  status: "PENDING" | "IN_PROGRESS" | "SUBMITTED" | "APPROVED" | "REJECTED" | "PARTIALLY_PAID";
   order: number;
   onChainIndex?: number;
   contractDeadline?: string;


### PR DESCRIPTION
Closes #414 (Pagination.tsx): Added guard conditions to prevent onPageChange from firing when clicking Previous on page 1 or Next on the last page. The button was already visually disabled but the click handler could still execute.

Closes #410 (Backend full-text search): Updated the job routes to use ts_rank for relevance-based ordering of search results. The GIN index already existed from a previous migration.

Closes #413 (MilestoneTimeline.tsx): Added PARTIALLY_PAID status support including:

Prisma enum update
Database migration
Frontend type definition
Visual indicator (amber/yellow color with dollar sign icon)
StatusBadge styling
Closes #412 (RaiseDisputeModal.tsx): Added explicit processing check to the submit button's disabled state to ensure immediate disabling on click, preventing duplicate submissions.