### PR TITLE
Add skeleton loading state to JobCard images

### DIFF
--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { Clock, DollarSign, Users } from "lucide-react";
 import StatusBadge from "./StatusBadge";
 import EscrowStatusBadge from "./EscrowStatusBadge";
+import Skeleton from "./Skeleton";
 import { Job } from "@/types";
 import { useAuth } from "@/context/AuthContext";
 
@@ -13,6 +16,7 @@ interface JobCardProps {
 
 export default function JobCard({ job }: JobCardProps) {
   const { user } = useAuth();
+  const [imageLoading, setImageLoading] = useState(true);
   const isFreelancer = user?.role === "FREELANCER";
   const isClient = user?.role === "CLIENT";
   const isOwnJob = user?.id === job.client.id;
@@ -20,6 +24,22 @@ export default function JobCard({ job }: JobCardProps) {
   return (
     <div className="card hover:border-stellar-blue/50 transition-all duration-200 cursor-pointer">
       <Link href={`/jobs/${job.id}`} className="block">
+        {job.imageUrl && (
+          <div className="relative w-full h-48 mb-4 rounded-lg overflow-hidden">
+            {imageLoading && (
+              <Skeleton className="absolute inset-0 w-full h-full" />
+            )}
+            <Image
+              src={job.imageUrl}
+              alt={job.title}
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              onLoad={() => setImageLoading(false)}
+            />
+          </div>
+        )}
+
         <div className="flex items-start justify-between mb-3">
           <div className="flex flex-col gap-1">
             <span className="text-xs font-medium text-stellar-purple bg-stellar-purple/10 px-2 py-1 rounded w-fit">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -63,6 +63,7 @@ export interface Job {
   contractJobId?: string;
   escrowStatus: "UNFUNDED" | "FUNDED" | "COMPLETED" | "CANCELLED" | "DISPUTED";
   revisionProposal?: RevisionProposal | null;
+  imageUrl?: string;
   createdAt: string;
   updatedAt?: string;
   _count?: { applications: number };


### PR DESCRIPTION
## Description
This PR implements skeleton loading for job images in the JobCard component to prevent Cumulative Layout Shift (CLS) and improve Core Web Vitals.

## Changes
- Added skeleton placeholder that displays while job images are loading
- Implemented image loading state management with React useState
- Added `imageUrl` field to the Job TypeScript interface
- Used Next.js Image component with proper `onLoad` event handler
- Fixed-height container (h-48) prevents layout shift during image load

## Benefits
- Eliminates layout shift when images load asynchronously
- Improves Core Web Vitals (CLS score)
- Better perceived performance and user experience
- Uses existing Skeleton component from the component library

## Testing
- No TypeScript errors
- Backward compatible - cards without images work as before
- Ready for when job images are added to the system

Closes #417