### PR TITLE
feat(frontend): add dashboard earnings route and fix the other issues PR

### DIFF
--- a/frontend/src/app/dashboard/earnings-page.tsx
+++ b/frontend/src/app/dashboard/earnings-page.tsx
@@ -1,0 +1,593 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  TooltipProps,
+} from "recharts";
+import {
+  ArrowDownRight,
+  ArrowUpRight,
+  Calendar,
+  Filter,
+  Download,
+  Loader2,
+  AlertTriangle,
+} from "lucide-react";
+import axios from "axios";
+import { Transaction, TransactionResponse } from "@/types";
+import StatusBadge from "@/components/StatusBadge";
+import { useAuth } from "@/context/AuthContext";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000/api";
+
+interface EarningsStats {
+  totalEarnings: number;
+  totalSpent: number;
+  netBalance: number;
+  transactionCount: number;
+}
+
+interface ChartDataPoint {
+  date: string;
+  earnings: number;
+  spent: number;
+}
+
+const EarningsPage = () => {
+  const { user } = useAuth();
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [chartData, setChartData] = useState<ChartDataPoint[]>([]);
+  const [stats, setStats] = useState<EarningsStats>({
+    totalEarnings: 0,
+    totalSpent: 0,
+    netBalance: 0,
+    transactionCount: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filters
+  const [currentPage, setCurrentPage] = useState(1);
+  const [limit, setLimit] = useState(10);
+  const [typeFilter, setTypeFilter] = useState<string>("");
+  const [dateFrom, setDateFrom] = useState<string>("");
+  const [dateTo, setDateTo] = useState<string>("");
+  const [totalPages, setTotalPages] = useState(1);
+
+  // Fetch transactions
+  const fetchTransactions = useCallback(async () => {
+    if (!user) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams({
+        page: currentPage.toString(),
+        limit: limit.toString(),
+      });
+
+      if (typeFilter) params.append("type", typeFilter);
+      if (dateFrom) params.append("dateFrom", dateFrom);
+      if (dateTo) params.append("dateTo", dateTo);
+
+      const response = await axios.get<TransactionResponse>(
+        `${API}/transactions?${params.toString()}`,
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+        }
+      );
+
+      setTransactions(response.data.transactions);
+      setTotalPages(response.data.pagination.totalPages);
+
+      // Calculate stats
+      const stats = calculateStats(response.data.transactions);
+      setStats(stats);
+
+      // Generate chart data
+      const chartData = generateChartData(response.data.transactions);
+      setChartData(chartData);
+    } catch (err) {
+      console.error("Error fetching transactions:", err);
+      setError(
+        err instanceof axios.AxiosError
+          ? err.response?.data?.error || "Failed to fetch transactions"
+          : "An error occurred while fetching transactions"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [user, currentPage, limit, typeFilter, dateFrom, dateTo]);
+
+  useEffect(() => {
+    fetchTransactions();
+  }, [fetchTransactions]);
+
+  // Calculate statistics
+  const calculateStats = (transactions: Transaction[]): EarningsStats => {
+    let totalEarnings = 0;
+    let totalSpent = 0;
+
+    transactions.forEach((tx) => {
+      if (tx.type === "RELEASE" || tx.type === "DISPUTE_PAYOUT") {
+        if (tx.toAddress === user?.walletAddress) {
+          totalEarnings += tx.amount;
+        }
+      }
+
+      if (tx.type === "DEPOSIT") {
+        if (tx.fromAddress === user?.walletAddress) {
+          totalSpent += tx.amount;
+        }
+      }
+
+      if (tx.type === "REFUND") {
+        if (tx.toAddress === user?.walletAddress) {
+          totalEarnings += tx.amount;
+        }
+      }
+    });
+
+    return {
+      totalEarnings,
+      totalSpent,
+      netBalance: totalEarnings - totalSpent,
+      transactionCount: transactions.length,
+    };
+  };
+
+  // Generate chart data grouped by date
+  const generateChartData = (transactions: Transaction[]): ChartDataPoint[] => {
+    const dataMap = new Map<string, { earnings: number; spent: number }>();
+
+    transactions.forEach((tx) => {
+      const date = new Date(tx.createdAt).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      });
+
+      const current = dataMap.get(date) || { earnings: 0, spent: 0 };
+
+      if (tx.type === "RELEASE" || tx.type === "DISPUTE_PAYOUT") {
+        if (tx.toAddress === user?.walletAddress) {
+          current.earnings += tx.amount;
+        }
+      }
+
+      if (tx.type === "DEPOSIT") {
+        if (tx.fromAddress === user?.walletAddress) {
+          current.spent += tx.amount;
+        }
+      }
+
+      if (tx.type === "REFUND") {
+        if (tx.toAddress === user?.walletAddress) {
+          current.earnings += tx.amount;
+        }
+      }
+
+      dataMap.set(date, current);
+    });
+
+    return Array.from(dataMap, ([date, data]) => ({
+      date,
+      ...data,
+    })).reverse();
+  };
+
+  // Format currency
+  const formatCurrency = (amount: number): string => {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  };
+
+  // Get transaction type color
+  const getTransactionTypeColor = (
+    type: "DEPOSIT" | "RELEASE" | "REFUND" | "DISPUTE_PAYOUT"
+  ): "default" | "primary" | "success" | "warning" | "danger" => {
+    switch (type) {
+      case "RELEASE":
+        return "success";
+      case "DEPOSIT":
+        return "warning";
+      case "REFUND":
+        return "primary";
+      case "DISPUTE_PAYOUT":
+        return "danger";
+      default:
+        return "default";
+    }
+  };
+
+  // Handle filter reset
+  const resetFilters = () => {
+    setCurrentPage(1);
+    setTypeFilter("");
+    setDateFrom("");
+    setDateTo("");
+  };
+
+  return (
+    <div className="space-y-6 p-6 bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 min-h-screen">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-white">
+            Earnings
+          </h1>
+          <p className="text-slate-600 dark:text-slate-400 mt-2">
+            Track your payment history and earnings overview
+          </p>
+        </div>
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <div className="flex items-start gap-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-lg p-4">
+          <AlertTriangle className="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="font-medium text-red-800 dark:text-red-200">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Statistics Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <StatCard
+          label="Total Earnings"
+          value={formatCurrency(stats.totalEarnings)}
+          icon={<ArrowDownRight className="w-5 h-5" />}
+          color="success"
+        />
+        <StatCard
+          label="Total Spent"
+          value={formatCurrency(stats.totalSpent)}
+          icon={<ArrowUpRight className="w-5 h-5" />}
+          color="warning"
+        />
+        <StatCard
+          label="Net Balance"
+          value={formatCurrency(stats.netBalance)}
+          icon={
+            stats.netBalance >= 0 ? (
+              <ArrowUpRight className="w-5 h-5" />
+            ) : (
+              <ArrowDownRight className="w-5 h-5" />
+            )
+          }
+          color={stats.netBalance >= 0 ? "success" : "danger"}
+        />
+        <StatCard
+          label="Transactions"
+          value={stats.transactionCount.toString()}
+          icon={<Calendar className="w-5 h-5" />}
+          color="primary"
+        />
+      </div>
+
+      {/* Charts Section */}
+      {!loading && chartData.length > 0 && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Line Chart */}
+          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+              Earnings Trend
+            </h2>
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis />
+                <Tooltip
+                  formatter={(value) => formatCurrency(Number(value))}
+                  contentStyle={{
+                    backgroundColor: "#1e293b",
+                    border: "1px solid #475569",
+                    borderRadius: "8px",
+                    color: "#f1f5f9",
+                  }}
+                />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey="earnings"
+                  stroke="#10b981"
+                  name="Earnings"
+                  dot={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="spent"
+                  stroke="#f59e0b"
+                  name="Spent"
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          {/* Bar Chart */}
+          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+              Comparison
+            </h2>
+            <ResponsiveContainer width="100%" height={300}>
+              <BarChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis />
+                <Tooltip
+                  formatter={(value) => formatCurrency(Number(value))}
+                  contentStyle={{
+                    backgroundColor: "#1e293b",
+                    border: "1px solid #475569",
+                    borderRadius: "8px",
+                    color: "#f1f5f9",
+                  }}
+                />
+                <Legend />
+                <Bar dataKey="earnings" fill="#10b981" name="Earnings" />
+                <Bar dataKey="spent" fill="#f59e0b" name="Spent" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 shadow-sm">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center gap-2">
+            <Filter className="w-5 h-5" />
+            Filters
+          </h2>
+          {(typeFilter || dateFrom || dateTo) && (
+            <button
+              onClick={resetFilters}
+              className="px-3 py-1 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+              Transaction Type
+            </label>
+            <select
+              value={typeFilter}
+              onChange={(e) => {
+                setTypeFilter(e.target.value);
+                setCurrentPage(1);
+              }}
+              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+            >
+              <option value="">All Types</option>
+              <option value="RELEASE">Release</option>
+              <option value="DEPOSIT">Deposit</option>
+              <option value="REFUND">Refund</option>
+              <option value="DISPUTE_PAYOUT">Dispute Payout</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+              Date From
+            </label>
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={(e) => {
+                setDateFrom(e.target.value);
+                setCurrentPage(1);
+              }}
+              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+              Date To
+            </label>
+            <input
+              type="date"
+              value={dateTo}
+              onChange={(e) => {
+                setDateTo(e.target.value);
+                setCurrentPage(1);
+              }}
+              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Transactions Table */}
+      <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden shadow-sm">
+        <div className="p-6 border-b border-slate-200 dark:border-slate-700">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+            Payment History
+          </h2>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="w-6 h-6 text-slate-400 animate-spin" />
+          </div>
+        ) : transactions.length === 0 ? (
+          <div className="p-8 text-center">
+            <p className="text-slate-600 dark:text-slate-400">
+              No transactions found.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead className="bg-slate-50 dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-slate-600 dark:text-slate-400 uppercase tracking-wider">
+                      Type
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-slate-600 dark:text-slate-400 uppercase tracking-wider">
+                      Job
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-slate-600 dark:text-slate-400 uppercase tracking-wider">
+                      Amount
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-slate-600 dark:text-slate-400 uppercase tracking-wider">
+                      Date
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-slate-600 dark:text-slate-400 uppercase tracking-wider">
+                      Hash
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+                  {transactions.map((tx) => (
+                    <tr
+                      key={tx.id}
+                      className="hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
+                    >
+                      <td className="px-6 py-4">
+                        <StatusBadge
+                          status={tx.type}
+                          variant={getTransactionTypeColor(tx.type)}
+                        />
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex flex-col">
+                          {tx.job ? (
+                            <>
+                              <span className="text-sm font-medium text-slate-900 dark:text-white">
+                                {tx.job.title}
+                              </span>
+                              <span className="text-xs text-slate-600 dark:text-slate-400">
+                                ID: {tx.jobId.slice(0, 8)}...
+                              </span>
+                            </>
+                          ) : (
+                            <span className="text-sm text-slate-600 dark:text-slate-400">
+                              {tx.jobId.slice(0, 8)}...
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-6 py-4">
+                        <span className="text-sm font-semibold text-slate-900 dark:text-white">
+                          {formatCurrency(tx.amount)}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
+                        <span className="text-sm text-slate-600 dark:text-slate-400">
+                          {new Date(tx.createdAt).toLocaleDateString("en-US", {
+                            year: "numeric",
+                            month: "short",
+                            day: "numeric",
+                          })}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
+                        <a
+                          href={`https://stellar.expert/explorer/public/tx/${tx.txHash}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                          title={tx.txHash}
+                        >
+                          {tx.txHash.slice(0, 12)}...
+                        </a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Pagination */}
+            <div className="flex items-center justify-between px-6 py-4 border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900">
+              <div className="text-sm text-slate-600 dark:text-slate-400">
+                Page {currentPage} of {totalPages}
+              </div>
+
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
+                  disabled={currentPage === 1}
+                  className="px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-slate-100 dark:hover:bg-slate-600"
+                >
+                  Previous
+                </button>
+                <button
+                  onClick={() =>
+                    setCurrentPage(Math.min(totalPages, currentPage + 1))
+                  }
+                  disabled={currentPage === totalPages}
+                  className="px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-slate-100 dark:hover:bg-slate-600"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// Stat Card Component
+interface StatCardProps {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  color: "success" | "warning" | "primary" | "danger";
+}
+
+const StatCard = ({ label, value, icon, color }: StatCardProps) => {
+  const colorMap = {
+    success: "bg-green-50 dark:bg-green-950/20 text-green-600 dark:text-green-400",
+    warning:
+      "bg-amber-50 dark:bg-amber-950/20 text-amber-600 dark:text-amber-400",
+    primary: "bg-blue-50 dark:bg-blue-950/20 text-blue-600 dark:text-blue-400",
+    danger: "bg-red-50 dark:bg-red-950/20 text-red-600 dark:text-red-400",
+  };
+
+  return (
+    <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-slate-600 dark:text-slate-400">
+            {label}
+          </p>
+          <p className="text-2xl font-bold text-slate-900 dark:text-white mt-2">
+            {value}
+          </p>
+        </div>
+        <div className={`p-3 rounded-lg ${colorMap[color]}`}>{icon}</div>
+      </div>
+    </div>
+  );
+};
+
+export default EarningsPage;
+export { EarningsPage };

--- a/frontend/src/app/dashboard/earnings/page.tsx
+++ b/frontend/src/app/dashboard/earnings/page.tsx
@@ -1,0 +1,9 @@
+import dynamic from "next/dynamic";
+
+const EarningsPage = dynamic(() => import("../earnings-page"), {
+  loading: () => <div className="flex items-center justify-center p-8">Loading...</div>,
+});
+
+export default function EarningsRoute() {
+  return <EarningsPage />;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -206,3 +206,35 @@ export interface Dispute {
   respondent: User;
   votes: Vote[];
 }
+
+export interface Transaction {
+  id: string;
+  jobId: string;
+  milestoneId?: string;
+  fromAddress: string;
+  toAddress: string;
+  amount: number;
+  tokenAddress: string;
+  txHash: string;
+  type: "DEPOSIT" | "RELEASE" | "REFUND" | "DISPUTE_PAYOUT";
+  createdAt: string;
+  updatedAt?: string;
+  job?: {
+    id: string;
+    title: string;
+  };
+  milestone?: {
+    id: string;
+    title: string;
+  };
+}
+
+export interface TransactionResponse {
+  transactions: Transaction[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}


### PR DESCRIPTION
Closes #477
Closes #476
Closes #478
Closes #481

## Changes
- Added the `/dashboard/earnings` route and wired it to the new earnings page.
- Added the earnings dashboard UI with summary cards, charts, filters, and payment history.
- Added the missing `Transaction` and `TransactionResponse` types used by the earnings page.
- Fixed the other three in the repo
