### PR TITLE
feat(frontend): escrow badge, dispute timeline, evidence upload, arbitrator UI

### DIFF
--- a/frontend/src/components/ArbitratorVoteView.tsx
+++ b/frontend/src/components/ArbitratorVoteView.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useState } from "react";
+import { ExternalLink, Loader2, Scale } from "lucide-react";
+import type { Dispute } from "@/types";
+
+interface ArbitratorVoteViewProps {
+  dispute: Dispute;
+  walletAddress?: string;
+  onVoteSubmit: (choice: "CLIENT" | "FREELANCER", splitPercent?: number) => Promise<void>;
+}
+
+type VoteChoice = "CLIENT" | "FREELANCER" | "SPLIT";
+
+export default function ArbitratorVoteView({
+  dispute,
+  walletAddress,
+  onVoteSubmit,
+}: ArbitratorVoteViewProps) {
+  const [choice, setChoice] = useState<VoteChoice | null>(null);
+  const [clientPct, setClientPct] = useState(50);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const isArbitrator =
+    !!walletAddress && (dispute.arbitrators ?? []).includes(walletAddress);
+
+  const freelancerPct = 100 - clientPct;
+
+  const handleClientSlider = (val: number) => {
+    setClientPct(val);
+  };
+
+  const handleFreelancerSlider = (val: number) => {
+    setClientPct(100 - val);
+  };
+
+  const handleSubmit = async () => {
+    if (!choice) return;
+    setSubmitError(null);
+    setSubmitting(true);
+
+    try {
+      if (choice === "SPLIT") {
+        await onVoteSubmit("CLIENT", clientPct);
+      } else {
+        await onVoteSubmit(choice);
+      }
+    } catch (err: unknown) {
+      setSubmitError(
+        err instanceof Error ? err.message : "Failed to submit vote. Please try again.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Read-only panel for non-arbitrators
+  if (!isArbitrator) {
+    return (
+      <div className="card space-y-4">
+        <div className="flex items-center gap-2">
+          <Scale size={18} className="text-stellar-blue" />
+          <h3 className="font-semibold text-theme-heading">Dispute Details</h3>
+          <span className="ml-auto text-xs px-2 py-0.5 rounded-full bg-theme-border text-theme-text-muted border border-theme-border">
+            View Only
+          </span>
+        </div>
+
+        <div>
+          <p className="text-xs font-medium text-theme-text-muted uppercase tracking-wider mb-1">
+            Dispute Reason
+          </p>
+          <p className="text-sm text-theme-text">{dispute.reason}</p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="bg-theme-card border border-theme-border rounded-lg p-3 text-center">
+            <p className="text-xs text-theme-text-muted mb-1">Votes for Client</p>
+            <p className="text-2xl font-bold text-theme-heading">{dispute.votesForClient}</p>
+          </div>
+          <div className="bg-theme-card border border-theme-border rounded-lg p-3 text-center">
+            <p className="text-xs text-theme-text-muted mb-1">Votes for Freelancer</p>
+            <p className="text-2xl font-bold text-theme-heading">{dispute.votesForFreelancer}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Full arbitrator panel
+  return (
+    <div className="card space-y-5">
+      <div className="flex items-center gap-2">
+        <Scale size={18} className="text-stellar-blue" />
+        <h3 className="font-semibold text-theme-heading">Arbitrator Panel</h3>
+      </div>
+
+      {/* Evidence viewer */}
+      {dispute.evidence && dispute.evidence.length > 0 && (
+        <div>
+          <p className="text-xs font-medium text-theme-text-muted uppercase tracking-wider mb-2">
+            Submitted Evidence
+          </p>
+          <ul className="space-y-2">
+            {dispute.evidence.map((item) => (
+              <li
+                key={item.id}
+                className="flex items-center justify-between bg-theme-card border border-theme-border rounded-lg px-3 py-2"
+              >
+                <div>
+                  <p className="text-sm text-theme-heading truncate max-w-[200px]">
+                    {item.fileName}
+                  </p>
+                  <p className="text-[10px] text-theme-text-muted">{item.fileType}</p>
+                </div>
+                <a
+                  href={`https://ipfs.io/ipfs/${item.ipfsHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-xs text-stellar-blue hover:underline flex-shrink-0 ml-3"
+                >
+                  View <ExternalLink size={11} />
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Dispute reason */}
+      <div>
+        <p className="text-xs font-medium text-theme-text-muted uppercase tracking-wider mb-1">
+          Dispute Reason
+        </p>
+        <p className="text-sm text-theme-text">{dispute.reason}</p>
+      </div>
+
+      {/* Vote options */}
+      <div>
+        <p className="text-xs font-medium text-theme-text-muted uppercase tracking-wider mb-2">
+          Your Vote
+        </p>
+        <div className="space-y-2">
+          {(
+            [
+              { value: "CLIENT", label: "Client Wins" },
+              { value: "FREELANCER", label: "Freelancer Wins" },
+              { value: "SPLIT", label: "Split Award" },
+            ] as { value: VoteChoice; label: string }[]
+          ).map((opt) => (
+            <label
+              key={opt.value}
+              className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                choice === opt.value
+                  ? "border-stellar-blue bg-stellar-blue/10 text-theme-heading"
+                  : "border-theme-border bg-theme-card text-theme-text hover:border-stellar-blue/50"
+              }`}
+            >
+              <input
+                type="radio"
+                name="vote-choice"
+                value={opt.value}
+                checked={choice === opt.value}
+                onChange={() => setChoice(opt.value)}
+                disabled={submitting}
+                className="accent-stellar-blue"
+              />
+              <span className="text-sm font-medium">{opt.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Split sliders — shown only when SPLIT is selected */}
+      {choice === "SPLIT" && (
+        <div className="space-y-3 p-3 bg-theme-card border border-theme-border rounded-lg">
+          <p className="text-xs font-medium text-theme-text-muted uppercase tracking-wider">
+            Split Percentages
+          </p>
+
+          <div>
+            <div className="flex justify-between text-xs text-theme-text mb-1">
+              <span>Client</span>
+              <span className="font-semibold text-theme-heading">{clientPct}%</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={clientPct}
+              onChange={(e) => handleClientSlider(Number(e.target.value))}
+              disabled={submitting}
+              className="w-full accent-stellar-blue"
+            />
+          </div>
+
+          <div>
+            <div className="flex justify-between text-xs text-theme-text mb-1">
+              <span>Freelancer</span>
+              <span className="font-semibold text-theme-heading">{freelancerPct}%</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={freelancerPct}
+              onChange={(e) => handleFreelancerSlider(Number(e.target.value))}
+              disabled={submitting}
+              className="w-full accent-stellar-blue"
+            />
+          </div>
+
+          <p className="text-[10px] text-theme-text-muted">
+            Percentages always sum to 100. Adjusting one slider updates the other.
+          </p>
+        </div>
+      )}
+
+      {submitError && (
+        <p className="text-xs text-theme-error">{submitError}</p>
+      )}
+
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={!choice || submitting}
+        className="btn-primary w-full disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+      >
+        {submitting ? (
+          <>
+            <Loader2 size={16} className="animate-spin" />
+            Submitting Vote…
+          </>
+        ) : (
+          "Submit Vote"
+        )}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/DisputeTimeline.tsx
+++ b/frontend/src/components/DisputeTimeline.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { CheckCircle, Circle, FileText, Scale, Gavel, Clock } from "lucide-react";
+import type { Dispute } from "@/types";
+
+interface DisputeTimelineProps {
+  dispute: Dispute;
+}
+
+type TimelineEvent = {
+  id: string;
+  icon: React.ReactNode;
+  label: string;
+  detail?: string;
+  timestamp: string;
+  done: boolean;
+};
+
+export default function DisputeTimeline({ dispute }: DisputeTimelineProps) {
+  // Build events from dispute state
+  const events: TimelineEvent[] = [
+    {
+      id: "opened",
+      icon: <Scale size={16} />,
+      label: "Dispute Opened",
+      detail: `Initiated by ${dispute.initiator.username}`,
+      timestamp: dispute.createdAt,
+      done: true,
+    },
+    {
+      id: "evidence",
+      icon: <FileText size={16} />,
+      label: "Evidence Period",
+      detail: "Parties may submit supporting evidence",
+      timestamp: dispute.createdAt,
+      done: dispute.status !== "OPEN",
+    },
+    {
+      id: "voting",
+      icon: <Gavel size={16} />,
+      label: "Community Voting",
+      detail: `${dispute.votesForClient + dispute.votesForFreelancer} of ${dispute.minVotes} votes cast`,
+      timestamp: dispute.updatedAt,
+      done: dispute.status === "VOTING" || dispute.status === "RESOLVED_CLIENT" || dispute.status === "RESOLVED_FREELANCER",
+    },
+    {
+      id: "resolved",
+      icon: <CheckCircle size={16} />,
+      label: "Resolved",
+      detail:
+        dispute.status === "RESOLVED_CLIENT"
+          ? "Resolved in favour of client"
+          : dispute.status === "RESOLVED_FREELANCER"
+          ? "Resolved in favour of freelancer"
+          : undefined,
+      timestamp: dispute.updatedAt,
+      done: dispute.status === "RESOLVED_CLIENT" || dispute.status === "RESOLVED_FREELANCER",
+    },
+  ];
+
+  return (
+    <div className="card">
+      <h3 className="font-semibold text-theme-heading mb-4 flex items-center gap-2">
+        <Clock size={18} className="text-stellar-blue" />
+        Dispute Timeline
+      </h3>
+      <ol className="relative border-l border-theme-border ml-3">
+        {events.map((ev, idx) => (
+          <li key={ev.id} className={`mb-6 ml-6 ${idx === events.length - 1 ? "mb-0" : ""}`}>
+            <span
+              className={`absolute -left-3 flex items-center justify-center w-6 h-6 rounded-full border ${
+                ev.done
+                  ? "bg-stellar-blue border-stellar-blue text-white"
+                  : "bg-theme-bg-secondary border-theme-border text-theme-text"
+              }`}
+            >
+              {ev.done ? ev.icon : <Circle size={12} />}
+            </span>
+            <div>
+              <p className={`text-sm font-semibold ${ev.done ? "text-theme-heading" : "text-theme-text"}`}>
+                {ev.label}
+              </p>
+              {ev.detail && (
+                <p className="text-xs text-theme-text mt-0.5">{ev.detail}</p>
+              )}
+              {ev.done && (
+                <time className="text-[10px] text-theme-text-muted">
+                  {new Date(ev.timestamp).toLocaleString()}
+                </time>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/frontend/src/components/EscrowStatusBadge.tsx
+++ b/frontend/src/components/EscrowStatusBadge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 interface EscrowStatusBadgeProps {
-  status: "UNFUNDED" | "FUNDED" | "COMPLETED" | "CANCELLED" | "DISPUTED";
+  status: "UNFUNDED" | "FUNDED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED" | "DISPUTED";
 }
 
 const statusConfig: Record<string, { label: string; color: string }> = {
@@ -12,6 +12,10 @@ const statusConfig: Record<string, { label: string; color: string }> = {
   FUNDED: {
     label: "Funded",
     color: "bg-theme-success/20 text-theme-success border-theme-success/30",
+  },
+  IN_PROGRESS: {
+    label: "In Progress",
+    color: "bg-stellar-blue/20 text-stellar-blue border-stellar-blue/30",
   },
   DISPUTED: {
     label: "In Dispute",

--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -50,7 +50,7 @@ export default function JobCard({ job, index = 0 }: JobCardProps) {
             <span className="text-xs font-medium text-stellar-purple bg-stellar-purple/10 px-2 py-1 rounded w-fit">
               {job.category}
             </span>
-            {isClient && isOwnJob && (
+            {job.escrowStatus && (
               <EscrowStatusBadge status={job.escrowStatus} />
             )}
           </div>

--- a/frontend/src/components/RaiseDisputeModal.tsx
+++ b/frontend/src/components/RaiseDisputeModal.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useState } from "react";
-import { X, AlertCircle, Loader2 } from "lucide-react";
+import { useState, useRef } from "react";
+import { X, AlertCircle, Loader2, Paperclip, Upload } from "lucide-react";
 import axios, { AxiosError } from "axios";
 import { useWallet } from "@/context/WalletContext";
 import { Job } from "@/types";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
+
+const MAX_FILES = 5;
+const MAX_FILE_SIZE_MB = 10;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
 
 type RaiseDisputeModalProps = {
   job: Job;
@@ -28,9 +32,15 @@ export default function RaiseDisputeModal({
   const [error, setError] = useState<string | null>(null);
   const [reasonTouched, setReasonTouched] = useState(false);
 
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   if (!isOpen) return null;
 
-  // Check if escrow is funded
   const isEscrowFunded = job.escrowStatus === "FUNDED";
 
   const trimmedReason = reason.trim();
@@ -42,11 +52,40 @@ export default function RaiseDisputeModal({
         : null;
   const canSubmit = isEscrowFunded && !processing && !reasonError;
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFileError(null);
+    const incoming = Array.from(e.target.files || []);
+
+    const combined = [...selectedFiles, ...incoming];
+
+    if (combined.length > MAX_FILES) {
+      setFileError(`You may attach up to ${MAX_FILES} files.`);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    const oversized = incoming.find((f) => f.size > MAX_FILE_SIZE_BYTES);
+    if (oversized) {
+      setFileError(
+        `"${oversized.name}" exceeds the ${MAX_FILE_SIZE_MB} MB limit.`,
+      );
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    setSelectedFiles(combined);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const removeFile = (index: number) => {
+    setSelectedFiles((prev) => prev.filter((_, i) => i !== index));
+    setFileError(null);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setReasonTouched(true);
 
-    // Validate escrow status
     if (!isEscrowFunded) {
       setError("Escrow must be funded before a dispute can be raised.");
       return;
@@ -85,18 +124,62 @@ export default function RaiseDisputeModal({
       }
 
       // 3. Confirm
-      await axios.post(
+      const confirmRes = await axios.post(
         `${API_URL}/disputes/confirm-tx`,
         {
           hash: txResult.hash,
           type: "RAISE_DISPUTE",
           jobId: job.id,
-          onChainDisputeId: 1, // Simplified: production would parse from events
+          onChainDisputeId: 1,
           respondentId: res.data.respondentId,
           reason,
         },
         { headers: { Authorization: `Bearer ${token}` } },
       );
+
+      const newDisputeId: string | undefined =
+        confirmRes.data?.dispute?.id ?? confirmRes.data?.id;
+
+      // 4. Upload evidence files if any
+      if (selectedFiles.length > 0 && newDisputeId) {
+        setUploading(true);
+        setUploadProgress(0);
+
+        const formData = new FormData();
+        selectedFiles.forEach((file) => formData.append("files", file));
+
+        try {
+          await axios.post(
+            `${API_URL}/disputes/${newDisputeId}/evidence`,
+            formData,
+            {
+              headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "multipart/form-data",
+              },
+              onUploadProgress: (progressEvent) => {
+                if (progressEvent.total) {
+                  const pct = Math.round(
+                    (progressEvent.loaded * 100) / progressEvent.total,
+                  );
+                  setUploadProgress(pct);
+                }
+              },
+            },
+          );
+        } catch {
+          // Evidence upload failure is non-blocking — dispute already created
+          setError(
+            "Dispute created, but evidence upload failed. You can retry from the dispute page.",
+          );
+          setUploading(false);
+          onSuccess();
+          onClose();
+          return;
+        }
+
+        setUploading(false);
+      }
 
       onSuccess();
       onClose();
@@ -110,6 +193,7 @@ export default function RaiseDisputeModal({
       setError(errorMsg || "An error occurred");
     } finally {
       setProcessing(false);
+      setUploading(false);
     }
   };
 
@@ -201,6 +285,74 @@ export default function RaiseDisputeModal({
             </p>
           </div>
 
+          {/* Evidence upload section */}
+          <div>
+            <label className="block text-sm font-medium text-theme-heading mb-1">
+              Supporting Evidence{" "}
+              <span className="font-normal text-theme-text">(optional)</span>
+            </label>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={processing || selectedFiles.length >= MAX_FILES}
+              className="flex items-center gap-2 text-sm px-3 py-2 border border-dashed border-theme-border rounded-lg text-theme-text hover:border-stellar-blue hover:text-stellar-blue transition-colors disabled:opacity-50 disabled:cursor-not-allowed w-full justify-center"
+            >
+              <Paperclip size={14} />
+              {selectedFiles.length >= MAX_FILES
+                ? `Max ${MAX_FILES} files reached`
+                : `Attach files (up to ${MAX_FILES}, ${MAX_FILE_SIZE_MB} MB each)`}
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={handleFileChange}
+              disabled={processing}
+            />
+            {fileError && (
+              <p className="text-xs text-theme-error mt-1">{fileError}</p>
+            )}
+            {selectedFiles.length > 0 && (
+              <ul className="mt-2 space-y-1">
+                {selectedFiles.map((file, idx) => (
+                  <li
+                    key={idx}
+                    className="flex items-center justify-between text-xs bg-theme-card border border-theme-border rounded-md px-2 py-1.5"
+                  >
+                    <span className="truncate text-theme-text max-w-[260px]">
+                      {file.name}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => removeFile(idx)}
+                      disabled={processing}
+                      className="ml-2 text-theme-text-muted hover:text-theme-error transition-colors flex-shrink-0"
+                    >
+                      <X size={12} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* IPFS upload progress indicator */}
+          {uploading && (
+            <div className="space-y-1">
+              <div className="flex items-center gap-2 text-xs text-stellar-blue">
+                <Upload size={12} className="animate-bounce" />
+                Uploading evidence to IPFS… {uploadProgress}%
+              </div>
+              <div className="w-full bg-theme-border rounded-full h-1.5 overflow-hidden">
+                <div
+                  className="bg-stellar-blue h-1.5 rounded-full transition-all duration-200"
+                  style={{ width: `${uploadProgress}%` }}
+                />
+              </div>
+            </div>
+          )}
+
           <div className="flex gap-3 pt-2">
             <button
               type="button"
@@ -217,7 +369,8 @@ export default function RaiseDisputeModal({
             >
               {processing ? (
                 <span className="flex items-center gap-2 justify-center">
-                  <Loader2 className="animate-spin" size={16} /> Submitting...
+                  <Loader2 className="animate-spin" size={16} />{" "}
+                  {uploading ? "Uploading…" : "Submitting..."}
                 </span>
               ) : (
                 "Raise Dispute"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -74,7 +74,7 @@ export interface Job {
   freelancer?: User;
   milestones: Milestone[];
   contractJobId?: string;
-  escrowStatus: "UNFUNDED" | "FUNDED" | "COMPLETED" | "CANCELLED" | "DISPUTED";
+  escrowStatus: "UNFUNDED" | "FUNDED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED" | "DISPUTED";
   revisionProposal?: RevisionProposal | null;
   imageUrl?: string;
   createdAt: string;
@@ -188,6 +188,15 @@ export interface Vote {
   voter: User;
 }
 
+export interface DisputeEvidence {
+  id: string;
+  ipfsHash: string;
+  fileName: string;
+  fileType: string;
+  uploadedAt: string;
+  uploaderAddress: string;
+}
+
 export interface Dispute {
   id: string;
   jobId: string;
@@ -205,6 +214,8 @@ export interface Dispute {
   initiator: User;
   respondent: User;
   votes: Vote[];
+  evidence?: DisputeEvidence[];
+  arbitrators?: string[];
 }
 
 export interface Transaction {


### PR DESCRIPTION
## Summary

- **#557** — Extended `EscrowStatusBadge` with an `IN_PROGRESS` variant and removed the client-only guard in `JobCard` so all users see the escrow status badge on every job card.
- **#558** — Added IPFS evidence upload to `RaiseDisputeModal`: up to 5 files / 10 MB each, per-file validation, `onUploadProgress` progress bar, and non-blocking upload to the dispute evidence endpoint after dispute creation.
- **#559** — Created `DisputeTimeline` component: a vertical timeline rendering the four dispute lifecycle steps (Opened → Evidence Period → Community Voting → Resolved), driven by the dispute's current `status` field with locale-formatted timestamps.
- **#560** — Created `ArbitratorVoteView` component: wallet-address-gated panel that shows a read-only view to non-arbitrators and a full arbitrator UI (evidence/IPFS links, Client Wins / Freelancer Wins / Split Award radio buttons with coupled percentage sliders) to verified arbitrators.

## Test plan

- [ ] Job cards show escrow badge for all roles (freelancer, client, guest)
- [ ] `IN_PROGRESS` badge renders in blue
- [ ] Dispute modal: file validation blocks >5 files and >10 MB; upload progress bar shows after dispute is created
- [ ] `DisputeTimeline` renders correct steps highlighted for each dispute status
- [ ] `ArbitratorVoteView` shows read-only panel for non-arbitrators; vote form + sliders for arbitrators

Closes #557
Closes #558
Closes #559
Closes #560