### PR TITLE
feat: milestone reorder, reputation verifier interface, job filter/scroll tests

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1302,6 +1302,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-market-reputation-interface"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "stellar-strkey"
 version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["escrow", "reputation", "dispute", "integration-tests"]
+members = ["escrow", "reputation", "reputation_interface", "dispute", "integration-tests"]
 
 [workspace.dependencies]
 soroban-sdk = "21.7.5"

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -19,6 +19,7 @@ This directory contains Soroban smart contracts for:
 
 - `escrow/` - Escrow and milestone payment contract
 - `reputation/` - Reputation and stake-weighted reviews
+- `reputation_interface/` - Shared `ReputationVerifier` trait + `Badge` types for cross-contract reputation checks
 - `dispute/` - Dispute voting and resolution
 - `integration-tests/` - Cross-contract integration tests
 - `scripts/` - Deployment scripts
@@ -209,6 +210,34 @@ stellar contract invoke \
   -- \
   resolve_dispute \
   --dispute_id 1
+```
+
+## Cross-contract reputation interface
+
+`reputation_interface/` exposes a shared `ReputationVerifier` trait so contracts
+like escrow and dispute can gate actions on a user's reputation without
+duplicating reputation logic:
+
+```rust
+use stellar_market_reputation_interface::{Badge, ReputationVerifier};
+
+fn require_min_score<V: ReputationVerifier>(
+    verifier: &V,
+    env: &Env,
+    user: Address,
+    min: u32,
+) -> bool {
+    verifier.get_score(env, user.clone()) >= min
+        && verifier.has_badge(env, user, Badge::Silver)
+}
+```
+
+An on-chain implementor typically wraps the reputation contract's generated
+client and forwards each call cross-contract; tests can substitute a mock
+implementor (see `reputation_interface/src/lib.rs`). Build/test it with:
+
+```bash
+cargo test -p stellar-market-reputation-interface
 ```
 
 ## Troubleshooting

--- a/contracts/reputation_interface/Cargo.toml
+++ b/contracts/reputation_interface/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "stellar-market-reputation-interface"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/reputation_interface/src/lib.rs
+++ b/contracts/reputation_interface/src/lib.rs
@@ -1,0 +1,86 @@
+#![no_std]
+//! Shared cross-contract reputation interface for stellar-market.
+//!
+//! Other contracts (escrow, dispute) depend on this crate to verify a user's
+//! reputation without duplicating reputation logic. The reputation contract is
+//! expected to implement [`ReputationVerifier`]; consumers gate their actions
+//! by calling it through this trait rather than re-deriving scores/badges.
+
+use soroban_sdk::{contracttype, Address, Env};
+
+/// Achievement badges a user can earn, mirroring the reputation tiers exposed
+/// by the reputation contract.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Badge {
+    Bronze = 1,
+    Silver = 2,
+    Gold = 3,
+    Platinum = 4,
+}
+
+/// Cross-contract reputation verification interface.
+///
+/// Implementors expose a user's numeric reputation score and badge ownership so
+/// that gating logic (e.g. requiring a minimum score for high-value escrow
+/// creation) lives in one place. A typical on-chain implementor wraps a
+/// reputation contract client and forwards each call cross-contract.
+pub trait ReputationVerifier {
+    /// Returns the user's current reputation score.
+    fn get_score(&self, env: &Env, user: Address) -> u32;
+
+    /// Returns whether the user holds the given badge.
+    fn has_badge(&self, env: &Env, user: Address, badge: Badge) -> bool;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    /// A mock verifier downstream contracts can use to test gating logic
+    /// without deploying the full reputation contract.
+    struct MockVerifier {
+        score: u32,
+        highest_badge: Option<Badge>,
+    }
+
+    impl ReputationVerifier for MockVerifier {
+        fn get_score(&self, _env: &Env, _user: Address) -> u32 {
+            self.score
+        }
+
+        fn has_badge(&self, _env: &Env, _user: Address, badge: Badge) -> bool {
+            matches!(self.highest_badge, Some(b) if b >= badge)
+        }
+    }
+
+    #[test]
+    fn mock_verifier_reports_score_and_badges() {
+        let env = Env::default();
+        let user = Address::generate(&env);
+        let verifier = MockVerifier {
+            score: 72,
+            highest_badge: Some(Badge::Silver),
+        };
+
+        assert_eq!(verifier.get_score(&env, user.clone()), 72);
+        assert!(verifier.has_badge(&env, user.clone(), Badge::Bronze));
+        assert!(verifier.has_badge(&env, user.clone(), Badge::Silver));
+        assert!(!verifier.has_badge(&env, user, Badge::Gold));
+    }
+
+    #[test]
+    fn verifier_without_badges_holds_none() {
+        let env = Env::default();
+        let user = Address::generate(&env);
+        let verifier = MockVerifier {
+            score: 0,
+            highest_badge: None,
+        };
+
+        assert_eq!(verifier.get_score(&env, user.clone()), 0);
+        assert!(!verifier.has_badge(&env, user, Badge::Bronze));
+    }
+}

--- a/frontend/src/app/post-job/page.tsx
+++ b/frontend/src/app/post-job/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Trash2, Tag, Loader2 } from "lucide-react";
+import { Plus, Trash2, Tag, Loader2, ArrowUp, ArrowDown } from "lucide-react";
 import axios from "axios";
 import { z } from "zod";
 import { useForm, useFieldArray } from "react-hook-form";
@@ -80,10 +80,15 @@ export default function PostJobPage() {
       milestones: [{ title: "", description: "", amount: "", deadline: "" }],
     },
   });
-  const { fields, append, remove } = useFieldArray({
+  const { fields, append, remove, move } = useFieldArray({
     control,
     name: "milestones",
   });
+
+  const moveMilestone = (from: number, to: number) => {
+    if (to < 0 || to >= fields.length) return;
+    move(from, to);
+  };
   const milestones = watch("milestones");
 
   useEffect(() => {
@@ -395,15 +400,40 @@ export default function PostJobPage() {
                   <span className="text-sm font-medium text-stellar-purple">
                     Milestone {index + 1}
                   </span>
-                  {milestones.length > 1 && (
-                    <button
-                      type="button"
-                      onClick={() => removeMilestone(index)}
-                      className="text-red-400 hover:text-red-300 transition-colors"
-                    >
-                      <Trash2 size={16} />
-                    </button>
-                  )}
+                  <div className="flex items-center gap-2">
+                    {fields.length > 1 && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => moveMilestone(index, index - 1)}
+                          disabled={index === 0}
+                          aria-label={`Move milestone ${index + 1} up`}
+                          className="text-stellar-blue hover:text-stellar-purple transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                        >
+                          <ArrowUp size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => moveMilestone(index, index + 1)}
+                          disabled={index === fields.length - 1}
+                          aria-label={`Move milestone ${index + 1} down`}
+                          className="text-stellar-blue hover:text-stellar-purple transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                        >
+                          <ArrowDown size={16} />
+                        </button>
+                      </>
+                    )}
+                    {milestones.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => removeMilestone(index)}
+                        aria-label={`Remove milestone ${index + 1}`}
+                        className="text-red-400 hover:text-red-300 transition-colors"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    )}
+                  </div>
                 </div>
                 <div className="space-y-3">
                   <input

--- a/frontend/src/hooks/__tests__/useInfiniteScroll.test.tsx
+++ b/frontend/src/hooks/__tests__/useInfiniteScroll.test.tsx
@@ -1,0 +1,80 @@
+import { render, act } from "@testing-library/react";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+
+let ioCallback: IntersectionObserverCallback | null = null;
+let observeCount = 0;
+
+beforeEach(() => {
+  ioCallback = null;
+  observeCount = 0;
+
+  class MockIntersectionObserver {
+    constructor(cb: IntersectionObserverCallback) {
+      ioCallback = cb;
+    }
+    observe() {
+      observeCount += 1;
+    }
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  }
+
+  (global as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+    MockIntersectionObserver;
+});
+
+function Harness(props: {
+  onLoadMore: () => void;
+  hasMore: boolean;
+  isLoading: boolean;
+}) {
+  const { sentinelRef } = useInfiniteScroll(props);
+  return <div ref={sentinelRef} data-testid="sentinel" />;
+}
+
+function fireIntersection(isIntersecting: boolean) {
+  act(() => {
+    ioCallback?.(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+  });
+}
+
+describe("useInfiniteScroll (#545)", () => {
+  it("observes the sentinel on mount", () => {
+    render(<Harness onLoadMore={jest.fn()} hasMore isLoading={false} />);
+    expect(observeCount).toBe(1);
+  });
+
+  it("calls onLoadMore when the sentinel intersects and more pages remain", () => {
+    const onLoadMore = jest.fn();
+    render(<Harness onLoadMore={onLoadMore} hasMore isLoading={false} />);
+    fireIntersection(true);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not load more when there are no further pages", () => {
+    const onLoadMore = jest.fn();
+    render(<Harness onLoadMore={onLoadMore} hasMore={false} isLoading={false} />);
+    fireIntersection(true);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("does not load more while a fetch is already in progress", () => {
+    const onLoadMore = jest.fn();
+    render(<Harness onLoadMore={onLoadMore} hasMore isLoading />);
+    fireIntersection(true);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("ignores entries that are not intersecting", () => {
+    const onLoadMore = jest.fn();
+    render(<Harness onLoadMore={onLoadMore} hasMore isLoading={false} />);
+    fireIntersection(false);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/__tests__/useJobFilters.test.ts
+++ b/frontend/src/hooks/__tests__/useJobFilters.test.ts
@@ -1,0 +1,101 @@
+import {
+  parseFiltersFromParams,
+  filtersToParams,
+  type JobFilters,
+} from "@/hooks/useJobFilters";
+
+describe("job filter URL sync (#544)", () => {
+  describe("parseFiltersFromParams", () => {
+    it("returns defaults for empty params", () => {
+      expect(parseFiltersFromParams(new URLSearchParams())).toEqual({
+        search: "",
+        category: "All",
+        skills: [],
+        status: [],
+        minBudget: "",
+        maxBudget: "",
+        postedDate: "all",
+        sort: "newest",
+        page: 1,
+      });
+    });
+
+    it("parses every filter from query params", () => {
+      const f = parseFiltersFromParams(
+        new URLSearchParams(
+          "q=design&category=Web&skills=react,ts&status=open,review&min=100&max=500&posted=last7d&sort=budget_desc&page=3",
+        ),
+      );
+      expect(f).toEqual({
+        search: "design",
+        category: "Web",
+        skills: ["react", "ts"],
+        status: ["open", "review"],
+        minBudget: "100",
+        maxBudget: "500",
+        postedDate: "last7d",
+        sort: "budget_desc",
+        page: 3,
+      });
+    });
+
+    it("falls back to page 1 for a non-numeric page", () => {
+      expect(parseFiltersFromParams(new URLSearchParams("page=abc")).page).toBe(1);
+    });
+  });
+
+  describe("filtersToParams", () => {
+    const defaults: JobFilters = {
+      search: "",
+      category: "All",
+      skills: [],
+      status: [],
+      minBudget: "",
+      maxBudget: "",
+      postedDate: "all",
+      sort: "newest",
+      page: 1,
+    };
+
+    it("omits default values", () => {
+      expect(filtersToParams(defaults).toString()).toBe("");
+    });
+
+    it("serializes active filters", () => {
+      const params = filtersToParams({
+        ...defaults,
+        search: "design",
+        category: "Web",
+        skills: ["react", "ts"],
+        status: ["open"],
+        minBudget: "100",
+        maxBudget: "500",
+        sort: "budget_desc",
+        page: 2,
+      });
+      expect(params.get("q")).toBe("design");
+      expect(params.get("category")).toBe("Web");
+      expect(params.get("skills")).toBe("react,ts");
+      expect(params.get("status")).toBe("open");
+      expect(params.get("min")).toBe("100");
+      expect(params.get("max")).toBe("500");
+      expect(params.get("sort")).toBe("budget_desc");
+      expect(params.get("page")).toBe("2");
+    });
+  });
+
+  it("round-trips parse(serialize(filters))", () => {
+    const filters: JobFilters = {
+      search: "audit",
+      category: "Smart Contracts",
+      skills: ["rust", "soroban"],
+      status: ["open"],
+      minBudget: "50",
+      maxBudget: "",
+      postedDate: "last24h",
+      sort: "ending_soon",
+      page: 4,
+    };
+    expect(parseFiltersFromParams(filtersToParams(filters))).toEqual(filters);
+  });
+});

--- a/frontend/src/hooks/useJobFilters.ts
+++ b/frontend/src/hooks/useJobFilters.ts
@@ -27,7 +27,7 @@ const DEFAULTS: JobFilters = {
   page: 1,
 };
 
-function parseFiltersFromParams(searchParams: URLSearchParams): JobFilters {
+export function parseFiltersFromParams(searchParams: URLSearchParams): JobFilters {
   const skills = searchParams.get("skills");
   const status = searchParams.get("status");
   const page = parseInt(searchParams.get("page") || "1", 10);
@@ -45,7 +45,7 @@ function parseFiltersFromParams(searchParams: URLSearchParams): JobFilters {
   };
 }
 
-function filtersToParams(filters: JobFilters): URLSearchParams {
+export function filtersToParams(filters: JobFilters): URLSearchParams {
   const params = new URLSearchParams();
   if (filters.search) params.set("q", filters.search);
   if (filters.category !== "All") params.set("category", filters.category);


### PR DESCRIPTION
## Summary

### #546 — Milestone builder reorder
The job creation form (`post-job/page.tsx`) supported add/remove milestones but not reordering. Added keyboard-accessible **move up / move down** controls per milestone (via `useFieldArray`'s `move`), with disabled edges and aria-labels. (No drag-and-drop library is in the project, so accessible up/down controls provide the reorder capability.)

### #543 — Cross-contract reputation verification interface
Added a shared **`reputation_interface`** crate exposing:
- `trait ReputationVerifier { fn get_score(&self, env, user) -> u32; fn has_badge(&self, env, user, badge: Badge) -> bool; }`
- a shared `Badge` type (Bronze/Silver/Gold/Platinum, mirroring the reputation tiers)

Added the crate to the contracts workspace, documented usage in `contracts/README.md`, and included tests with a mock verifier. Consumers (escrow/dispute) can depend on this crate and gate actions through the trait instead of duplicating reputation logic; an on-chain implementor wraps the reputation contract's client. **2 tests pass.**

### #544 — Job listing filter/sort (already implemented; tested)
The listing page already builds filter/sort UI and syncs state to URL query params (`useJobFilters`), with an empty-state "Clear Filters" CTA. Exported the pure `parseFiltersFromParams` / `filtersToParams` helpers and added a unit test covering parse, serialize (defaults omitted), and a parse↔serialize round-trip. **6 tests pass.**

### #545 — Infinite scroll (already implemented; tested)
The listing already uses an `IntersectionObserver`-based `useInfiniteScroll` hook with dedup-on-append. Added a unit test covering: observes the sentinel, fires `onLoadMore` on intersect, and is correctly gated by `hasMore` / `isLoading` and non-intersecting entries. **5 tests pass.**

## Test plan
- [x] `cargo test -p stellar-market-reputation-interface` — 2/2 pass
- [x] `npx jest src/hooks/__tests__/useJobFilters.test.ts src/hooks/__tests__/useInfiniteScroll.test.tsx` — 11/11 pass
- [x] `npx tsc --noEmit` — touched frontend files compile cleanly

## Notes / scope
Per the lightweight scope: #544 and #545 were already implemented on `main`, so this PR adds verifying unit tests + exports the filter helpers rather than rebuilding them. For #543, the shared interface crate + trait + docs + mock tests are delivered; wiring the escrow contract to gate high-value escrow through the verifier (and a real-verifier integration test) is a sensible follow-up on top of this interface.

Closes #546
Closes #545
Closes #544
Closes #543