### PR TITLE
feat(earnings): time-series decomposition, Stellar reconciliation, and tax-period CSV export

### DIFF
--- a/EARNINGS_RECONCILIATION_IMPLEMENTATION.md
+++ b/EARNINGS_RECONCILIATION_IMPLEMENTATION.md
@@ -1,0 +1,67 @@
+# Freelancer Earnings — Reconciliation & Tax-Period Export
+
+Extends the freelancer earnings dashboard (#603, #477) with time-series
+decomposition, on-chain reconciliation against the Stellar ledger, and a
+tax-period CSV export. Closes #672.
+
+## Why
+
+The earnings page previously read from PostgreSQL only. With on-chain
+settlement, the ground truth is the Stellar ledger — not the database. This work
+lets freelancers verify that platform records match what actually settled and
+produces an export usable for tax filings.
+
+## Backend
+
+### `GET /api/freelancers/earnings` (extended)
+
+Now accepts optional `from`/`to` ISO dates and additionally returns:
+
+- `weeklyEarnings` — sparse weekly buckets (`DATE_TRUNC('week', ...)`); the
+  frontend fills zero-value gaps.
+- `categoryBreakdown` — earnings grouped by each job's `category` tag (derived,
+  not hardcoded) with per-category percentage.
+- `range` — the resolved `{ from, to }` window.
+
+### `GET /api/freelancers/earnings/reconcile?from=<ISO>&to=<ISO>`
+
+Fetches inbound payments to the freelancer's wallet from Horizon for the window
+and matches each to a DB earnings record by transaction hash or by the `jobId`
+carried in the transaction memo. Returns `matched`, `onChainOnly`, and `dbOnly`
+buckets plus a summary. `onChainOnly` entries indicate a DB sync failure and are
+logged as warnings; each carries a Horizon transaction URL. Returns `502` if
+Horizon is unreachable.
+
+### `GET /api/freelancers/earnings/export?from=<ISO>&to=<ISO>&format=csv`
+
+Streams a CSV with `date, job_title, client_name, amount_xlm, amount_usd,
+tx_hash, reconciliation_status`. USD equivalents use `XLM_USD_RATE` when set.
+Reconciliation status is computed best-effort against Horizon; if Horizon is
+unreachable rows are marked `unverified` and the export still succeeds.
+
+Horizon access is encapsulated in
+`src/services/earnings-reconciliation.service.ts`.
+
+## Frontend
+
+`src/app/dashboard/earnings-page.tsx`:
+
+- **Time-series chart** — Recharts `ComposedChart` with weekly bars and a 30-day
+  (4-week) trailing moving-average line. Gap-filling and the moving average live
+  in `earnings/earnings-utils.ts` (unit-tested); the moving average uses a
+  partial window for the first three weeks.
+- **Category breakdown** — horizontal bars derived from job category tags.
+- **Reconciliation panel** — matched-vs-unmatched summary with a warning banner
+  and "View unmatched" links to Horizon when on-chain payments are missing from
+  the DB.
+- **Date-range picker** — applies to the chart, category breakdown, and
+  reconciliation simultaneously.
+- **CSV export** — downloads via the new endpoint as a Blob URL (no page reload).
+
+## Tests
+
+- `backend/src/routes/__tests__/freelancer.earnings.test.ts` — reconciliation
+  bucket classification, memo-based matching, Horizon-failure handling, range
+  validation, role gating, and CSV export shape/escaping.
+- `frontend/src/app/dashboard/earnings/__tests__/earnings-utils.test.ts` —
+  zero-gap filling and partial-window moving average.

--- a/backend/src/routes/__tests__/freelancer.earnings.test.ts
+++ b/backend/src/routes/__tests__/freelancer.earnings.test.ts
@@ -1,0 +1,188 @@
+import express from "express";
+import request from "supertest";
+
+// ── Mock auth so the route trusts a fixed userId ──
+jest.mock("../../middleware/auth", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "freelancer-1";
+    next();
+  },
+}));
+
+// ── Mock the Horizon reconciliation service ──
+jest.mock("../../services/earnings-reconciliation.service", () => ({
+  fetchOnChainPayments: jest.fn(),
+}));
+
+// ── Mock Prisma ──
+jest.mock("@prisma/client", () => {
+  const actual = jest.requireActual("@prisma/client") as typeof import("@prisma/client");
+  const mockPrisma = {
+    user: { findUnique: jest.fn() },
+    transaction: { findMany: jest.fn() },
+    $queryRaw: jest.fn(),
+  };
+  return {
+    ...actual,
+    PrismaClient: jest.fn(() => mockPrisma),
+  };
+});
+
+import { PrismaClient } from "@prisma/client";
+import freelancerRouter from "../freelancer.routes";
+import { fetchOnChainPayments } from "../../services/earnings-reconciliation.service";
+
+const prismaMock = new PrismaClient() as any;
+const fetchOnChainMock = fetchOnChainPayments as jest.Mock;
+
+const app = express();
+app.use(express.json());
+app.use("/api/freelancers", freelancerRouter);
+// Minimal error handler mirroring the app's createError shape.
+app.use((err: any, _req: any, res: any, _next: any) => {
+  res.status(err.statusCode || 500).json({ error: err.message });
+});
+
+const freelancer = {
+  id: "freelancer-1",
+  role: "FREELANCER",
+  walletAddress: "GFREELANCER",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  prismaMock.user.findUnique.mockResolvedValue(freelancer);
+});
+
+describe("GET /api/freelancers/earnings/reconcile", () => {
+  it("classifies matched, on-chain-only, and db-only payments", async () => {
+    prismaMock.transaction.findMany.mockResolvedValue([
+      {
+        txHash: "HASH_MATCHED",
+        jobId: "job-1",
+        amount: 100,
+        createdAt: new Date("2026-01-10T00:00:00Z"),
+        job: { id: "job-1", title: "Build API", category: "Backend", client: { username: "acme" } },
+      },
+      {
+        txHash: "HASH_DB_ONLY",
+        jobId: "job-2",
+        amount: 50,
+        createdAt: new Date("2026-01-12T00:00:00Z"),
+        job: { id: "job-2", title: "Frontend", category: "Frontend", client: { username: "acme" } },
+      },
+    ]);
+
+    fetchOnChainMock.mockResolvedValue([
+      { txHash: "HASH_MATCHED", memoJobId: "job-1", amount: 100, assetCode: "XLM", createdAt: "2026-01-10T00:00:00Z", from: "GCLIENT" },
+      { txHash: "HASH_ONCHAIN_ONLY", memoJobId: "job-9", amount: 75, assetCode: "XLM", createdAt: "2026-01-11T00:00:00Z", from: "GCLIENT" },
+    ]);
+
+    const res = await request(app).get(
+      "/api/freelancers/earnings/reconcile?from=2026-01-01&to=2026-01-31",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toMatchObject({
+      onChainCount: 2,
+      dbCount: 2,
+      matchedCount: 1,
+      onChainOnlyCount: 1,
+      dbOnlyCount: 1,
+      allMatched: false,
+    });
+    expect(res.body.matched[0].txHash).toBe("HASH_MATCHED");
+    expect(res.body.onChainOnly[0].txHash).toBe("HASH_ONCHAIN_ONLY");
+    expect(res.body.onChainOnly[0].horizonUrl).toContain("HASH_ONCHAIN_ONLY");
+    expect(res.body.dbOnly[0].txHash).toBe("HASH_DB_ONLY");
+  });
+
+  it("matches by memo jobId when tx hashes differ", async () => {
+    prismaMock.transaction.findMany.mockResolvedValue([
+      {
+        txHash: "DB_HASH",
+        jobId: "job-1",
+        amount: 100,
+        createdAt: new Date("2026-01-10T00:00:00Z"),
+        job: { id: "job-1", title: "Build API", category: "Backend", client: { username: "acme" } },
+      },
+    ]);
+    fetchOnChainMock.mockResolvedValue([
+      { txHash: "CHAIN_HASH", memoJobId: "job-1", amount: 100, assetCode: "XLM", createdAt: "2026-01-10T00:00:00Z", from: "GCLIENT" },
+    ]);
+
+    const res = await request(app).get("/api/freelancers/earnings/reconcile");
+
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toMatchObject({ matchedCount: 1, onChainOnlyCount: 0, dbOnlyCount: 0, allMatched: true });
+  });
+
+  it("returns 502 when Horizon is unreachable", async () => {
+    prismaMock.transaction.findMany.mockResolvedValue([]);
+    fetchOnChainMock.mockRejectedValue(new Error("horizon down"));
+
+    const res = await request(app).get("/api/freelancers/earnings/reconcile");
+    expect(res.status).toBe(502);
+  });
+
+  it("rejects from after to with 400", async () => {
+    const res = await request(app).get(
+      "/api/freelancers/earnings/reconcile?from=2026-02-01&to=2026-01-01",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 for non-freelancers", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ ...freelancer, role: "CLIENT" });
+    const res = await request(app).get("/api/freelancers/earnings/reconcile");
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /api/freelancers/earnings/export", () => {
+  it("returns a downloadable CSV with all required fields", async () => {
+    prismaMock.transaction.findMany.mockResolvedValue([
+      {
+        txHash: "HASH_1",
+        jobId: "job-1",
+        amount: 120.5,
+        createdAt: new Date("2026-01-10T00:00:00Z"),
+        job: { id: "job-1", title: "Smart Contract, Dev", category: "Smart Contract", client: { username: "acme" } },
+      },
+    ]);
+    fetchOnChainMock.mockResolvedValue([
+      { txHash: "HASH_1", memoJobId: "job-1", amount: 120.5, assetCode: "XLM", createdAt: "2026-01-10T00:00:00Z", from: "GCLIENT" },
+    ]);
+
+    const res = await request(app).get(
+      "/api/freelancers/earnings/export?from=2026-01-01&to=2026-01-31",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/csv");
+    expect(res.headers["content-disposition"]).toContain("earnings-2026-01-01-to-2026-01-31.csv");
+    const [header, row] = res.text.split("\n");
+    expect(header).toBe("date,job_title,client_name,amount_xlm,amount_usd,tx_hash,reconciliation_status");
+    // Title contains a comma → must be quoted.
+    expect(row).toContain('"Smart Contract, Dev"');
+    expect(row).toContain("2026-01-10");
+    expect(row).toContain("matched");
+  });
+
+  it("marks rows unverified when Horizon is unreachable", async () => {
+    prismaMock.transaction.findMany.mockResolvedValue([
+      {
+        txHash: "HASH_1",
+        jobId: "job-1",
+        amount: 10,
+        createdAt: new Date("2026-01-10T00:00:00Z"),
+        job: { id: "job-1", title: "Job", category: "X", client: { username: "acme" } },
+      },
+    ]);
+    fetchOnChainMock.mockRejectedValue(new Error("down"));
+
+    const res = await request(app).get("/api/freelancers/earnings/export");
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("unverified");
+  });
+});

--- a/backend/src/routes/freelancer.routes.ts
+++ b/backend/src/routes/freelancer.routes.ts
@@ -7,13 +7,51 @@ import { validate } from "../middleware/validation";
 import { freelancerSearchQuerySchema, getUserByIdParamSchema } from "../schemas";
 import { searchFreelancers } from "../services/freelancer-search.service";
 import { ReputationService } from "../services/reputation.service";
+import { fetchOnChainPayments } from "../services/earnings-reconciliation.service";
+import { logger } from "../lib/logger";
+import { config } from "../config";
 
 const router = Router();
 const prisma = new PrismaClient();
 
+const EARNING_TX_TYPES = ["RELEASE", "DISPUTE_PAYOUT"] as const;
+
+/**
+ * Default reconciliation/export window: last 90 days.
+ * Used when the caller omits `from`/`to`.
+ */
+function defaultRange(): { from: Date; to: Date } {
+  const to = new Date();
+  const from = new Date(to);
+  from.setDate(from.getDate() - 90);
+  return { from, to };
+}
+
+const dateRangeQuerySchema = z
+  .object({
+    from: z.coerce.date().optional(),
+    to: z.coerce.date().optional(),
+  })
+  .refine((q) => !(q.from && q.to) || q.from <= q.to, {
+    message: "`from` must be on or before `to`",
+    path: ["from"],
+  });
+
+function escapeCsv(value: string | number | null | undefined): string {
+  const str = value === null || value === undefined ? "" : String(value);
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
 /**
  * GET /api/freelancers/earnings
- * Get earnings summary, monthly chart data, and paginated transaction history for the authenticated freelancer.
+ * Get earnings summary, monthly + weekly chart data, category breakdown, and
+ * paginated transaction history for the authenticated freelancer.
+ *
+ * Optional `from`/`to` (ISO dates) scope the weekly chart and category breakdown
+ * so the dashboard chart, category panel, and reconciliation panel share one range.
  */
 router.get(
   "/earnings",
@@ -22,6 +60,8 @@ router.get(
     query: z.object({
       page: z.coerce.number().int().min(1).default(1),
       limit: z.coerce.number().int().min(1).max(100).default(10),
+      from: z.coerce.date().optional(),
+      to: z.coerce.date().optional(),
     }),
   }),
   asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -33,13 +73,23 @@ router.get(
       return res.status(403).json({ error: "Only freelancers can access earnings" });
     }
 
-    const { page = 1, limit = 10 } = req.query as unknown as { page: number; limit: number };
+    const query = req.query as unknown as {
+      page: number;
+      limit: number;
+      from?: Date;
+      to?: Date;
+    };
+    const { page = 1, limit = 10 } = query;
     const skip = (Number(page) - 1) * Number(limit);
     const wallet = user.walletAddress;
 
     if (!wallet) {
       return res.status(400).json({ error: "Freelancer has no wallet address." });
     }
+
+    const fallback = defaultRange();
+    const rangeFrom = query.from ?? fallback.from;
+    const rangeTo = query.to ?? fallback.to;
 
     // ── Summary stats ──
     const [totalEarnedAgg, earnedThisMonthAgg, pendingJobs, escrowJobs] = await Promise.all([
@@ -93,6 +143,44 @@ router.get(
       ORDER BY month ASC
     `;
 
+    // ── Weekly earnings within the selected range (for the time-series chart) ──
+    // Returned sparse (only weeks with earnings); the frontend fills zero-value gaps.
+    const weeklyRaw = await prisma.$queryRaw<Array<{ week: string; earnings: number }>>`
+      SELECT
+        TO_CHAR(DATE_TRUNC('week', "createdAt"), 'YYYY-MM-DD') as week,
+        COALESCE(SUM(amount), 0)::float as earnings
+      FROM "Transaction"
+      WHERE "toAddress" = ${wallet}
+        AND "type" IN ('RELEASE', 'DISPUTE_PAYOUT')
+        AND "createdAt" >= ${rangeFrom}
+        AND "createdAt" <= ${rangeTo}
+      GROUP BY DATE_TRUNC('week', "createdAt")
+      ORDER BY week ASC
+    `;
+
+    // ── Category breakdown within the selected range ──
+    // Derived from each job's category tag (not hardcoded).
+    const categoryRaw = await prisma.$queryRaw<Array<{ category: string; earnings: number }>>`
+      SELECT
+        COALESCE(j."category", 'Uncategorized') as category,
+        COALESCE(SUM(t.amount), 0)::float as earnings
+      FROM "Transaction" t
+      LEFT JOIN "Job" j ON j."id" = t."jobId"
+      WHERE t."toAddress" = ${wallet}
+        AND t."type" IN ('RELEASE', 'DISPUTE_PAYOUT')
+        AND t."createdAt" >= ${rangeFrom}
+        AND t."createdAt" <= ${rangeTo}
+      GROUP BY COALESCE(j."category", 'Uncategorized')
+      ORDER BY earnings DESC
+    `;
+
+    const categoryTotal = categoryRaw.reduce((sum, c) => sum + c.earnings, 0);
+    const categoryBreakdown = categoryRaw.map((c) => ({
+      category: c.category,
+      earnings: c.earnings,
+      percentage: categoryTotal > 0 ? (c.earnings / categoryTotal) * 100 : 0,
+    }));
+
     // ── Transaction history (paginated) ──
     const whereTx = {
       toAddress: wallet,
@@ -140,6 +228,9 @@ router.get(
         activeEscrow: escrowJobs._sum?.budget ?? 0,
       },
       monthlyEarnings: monthlyRaw,
+      weeklyEarnings: weeklyRaw,
+      categoryBreakdown,
+      range: { from: rangeFrom.toISOString(), to: rangeTo.toISOString() },
       transactions,
       pagination: {
         page: Number(page),
@@ -148,6 +239,276 @@ router.get(
         totalPages: Math.ceil(totalTx / Number(limit)),
       },
     });
+  }),
+);
+
+/**
+ * Resolve the authenticated user, asserting they are a freelancer with a wallet.
+ * Returns the wallet on success, or writes an error response and returns null.
+ */
+async function requireFreelancerWallet(
+  req: AuthRequest,
+  res: Response,
+): Promise<{ userId: string; wallet: string } | null> {
+  const user = await prisma.user.findUnique({ where: { id: req.userId } });
+  if (!user) {
+    res.status(404).json({ error: "User not found" });
+    return null;
+  }
+  if (user.role !== "FREELANCER") {
+    res.status(403).json({ error: "Only freelancers can access earnings" });
+    return null;
+  }
+  if (!user.walletAddress) {
+    res.status(400).json({ error: "Freelancer has no wallet address." });
+    return null;
+  }
+  return { userId: user.id, wallet: user.walletAddress };
+}
+
+interface EarningsRecord {
+  txHash: string;
+  jobId: string | null;
+  jobTitle: string | null;
+  clientName: string | null;
+  category: string | null;
+  amount: number;
+  createdAt: Date;
+}
+
+/** Load DB earnings (RELEASE / DISPUTE_PAYOUT) for a wallet within a date range. */
+async function loadDbEarnings(
+  wallet: string,
+  from: Date,
+  to: Date,
+): Promise<EarningsRecord[]> {
+  const txs = await prisma.transaction.findMany({
+    where: {
+      toAddress: wallet,
+      type: { in: [...EARNING_TX_TYPES] as any },
+      createdAt: { gte: from, lte: to },
+    },
+    orderBy: { createdAt: "desc" },
+    include: {
+      job: {
+        select: {
+          id: true,
+          title: true,
+          category: true,
+          client: { select: { username: true } },
+        },
+      },
+    },
+  });
+
+  return txs.map((tx) => ({
+    txHash: tx.txHash,
+    jobId: tx.jobId,
+    jobTitle: tx.job?.title ?? null,
+    clientName: tx.job?.client?.username ?? null,
+    category: tx.job?.category ?? null,
+    amount: tx.amount ?? 0,
+    createdAt: tx.createdAt,
+  }));
+}
+
+/**
+ * GET /api/freelancers/earnings/reconcile?from=<ISO>&to=<ISO>
+ * Cross-check DB earnings records against on-chain escrow releases from Horizon.
+ *
+ * Returns three buckets:
+ *  - matched: present in both Horizon and the DB (joined by jobId memo / txHash)
+ *  - onChainOnly: settled on-chain but missing from the DB (indicates a sync failure)
+ *  - dbOnly: recorded in the DB but not found on-chain in the window
+ */
+router.get(
+  "/earnings/reconcile",
+  authenticate,
+  validate({ query: dateRangeQuerySchema }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const auth = await requireFreelancerWallet(req, res);
+    if (!auth) return;
+
+    const q = req.query as unknown as { from?: Date; to?: Date };
+    const fallback = defaultRange();
+    const from = q.from ?? fallback.from;
+    const to = q.to ?? fallback.to;
+
+    const dbRecords = await loadDbEarnings(auth.wallet, from, to);
+
+    let onChainPayments: Awaited<ReturnType<typeof fetchOnChainPayments>>;
+    try {
+      onChainPayments = await fetchOnChainPayments(auth.wallet, from, to);
+    } catch (err) {
+      logger.error({ err, wallet: auth.wallet }, "[Reconciliation] Horizon fetch failed");
+      return res.status(502).json({ error: "Unable to reach the Stellar network for reconciliation." });
+    }
+
+    // Index DB records by txHash and by jobId for matching.
+    const dbByTxHash = new Map(dbRecords.map((r) => [r.txHash, r]));
+    const dbByJobId = new Map(
+      dbRecords.filter((r) => r.jobId).map((r) => [r.jobId as string, r]),
+    );
+
+    const matchedTxHashes = new Set<string>();
+    const matched: Array<{
+      txHash: string;
+      jobId: string | null;
+      jobTitle: string | null;
+      amount: number;
+      onChainAmount: number;
+      createdAt: string;
+    }> = [];
+    const onChainOnly: Array<{
+      txHash: string;
+      memoJobId: string | null;
+      amount: number;
+      assetCode: string;
+      createdAt: string;
+      horizonUrl: string;
+    }> = [];
+
+    for (const payment of onChainPayments) {
+      const dbRecord =
+        dbByTxHash.get(payment.txHash) ??
+        (payment.memoJobId ? dbByJobId.get(payment.memoJobId) : undefined);
+
+      if (dbRecord) {
+        matchedTxHashes.add(dbRecord.txHash);
+        matched.push({
+          txHash: payment.txHash,
+          jobId: dbRecord.jobId,
+          jobTitle: dbRecord.jobTitle,
+          amount: dbRecord.amount,
+          onChainAmount: payment.amount,
+          createdAt: payment.createdAt,
+        });
+      } else {
+        onChainOnly.push({
+          txHash: payment.txHash,
+          memoJobId: payment.memoJobId,
+          amount: payment.amount,
+          assetCode: payment.assetCode,
+          createdAt: payment.createdAt,
+          horizonUrl: `${config.stellar.horizonUrl.replace(/\/+$/, "")}/transactions/${payment.txHash}`,
+        });
+      }
+    }
+
+    const dbOnly = dbRecords
+      .filter((r) => !matchedTxHashes.has(r.txHash))
+      .map((r) => ({
+        txHash: r.txHash,
+        jobId: r.jobId,
+        jobTitle: r.jobTitle,
+        amount: r.amount,
+        createdAt: r.createdAt.toISOString(),
+      }));
+
+    // on_chain_only entries indicate the DB failed to record a settled payment.
+    if (onChainOnly.length > 0) {
+      logger.warn(
+        { userId: auth.userId, wallet: auth.wallet, count: onChainOnly.length },
+        "[Reconciliation] On-chain payments missing from DB — possible sync failure",
+      );
+    }
+
+    res.json({
+      range: { from: from.toISOString(), to: to.toISOString() },
+      summary: {
+        onChainCount: onChainPayments.length,
+        dbCount: dbRecords.length,
+        matchedCount: matched.length,
+        onChainOnlyCount: onChainOnly.length,
+        dbOnlyCount: dbOnly.length,
+        allMatched: onChainOnly.length === 0 && dbOnly.length === 0,
+      },
+      matched,
+      onChainOnly,
+      dbOnly,
+    });
+  }),
+);
+
+/**
+ * GET /api/freelancers/earnings/export?from=<ISO>&to=<ISO>&format=csv
+ * Download earnings for a tax period as CSV. Reconciliation status is computed
+ * against Horizon when reachable; otherwise rows fall back to "unverified".
+ */
+router.get(
+  "/earnings/export",
+  authenticate,
+  validate({
+    query: dateRangeQuerySchema.and(
+      z.object({ format: z.enum(["csv"]).default("csv") }),
+    ),
+  }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const auth = await requireFreelancerWallet(req, res);
+    if (!auth) return;
+
+    const q = req.query as unknown as { from?: Date; to?: Date };
+    const fallback = defaultRange();
+    const from = q.from ?? fallback.from;
+    const to = q.to ?? fallback.to;
+
+    const dbRecords = await loadDbEarnings(auth.wallet, from, to);
+
+    // Best-effort reconciliation so each row carries a status; export still
+    // succeeds (rows marked "unverified") if Horizon is unreachable.
+    const onChainTxHashes = new Set<string>();
+    const onChainJobIds = new Set<string>();
+    try {
+      const payments = await fetchOnChainPayments(auth.wallet, from, to);
+      for (const p of payments) {
+        onChainTxHashes.add(p.txHash);
+        if (p.memoJobId) onChainJobIds.add(p.memoJobId);
+      }
+    } catch (err) {
+      logger.warn({ err, wallet: auth.wallet }, "[Export] Horizon unreachable — exporting without on-chain status");
+    }
+
+    const xlmUsdRate = Number(process.env.XLM_USD_RATE ?? "0");
+
+    const header = [
+      "date",
+      "job_title",
+      "client_name",
+      "amount_xlm",
+      "amount_usd",
+      "tx_hash",
+      "reconciliation_status",
+    ];
+
+    const lines = [header.join(",")];
+    for (const r of dbRecords) {
+      const reconciled =
+        onChainTxHashes.has(r.txHash) || (r.jobId ? onChainJobIds.has(r.jobId) : false);
+      const status = onChainTxHashes.size === 0 ? "unverified" : reconciled ? "matched" : "db_only";
+      const usd = xlmUsdRate > 0 ? (r.amount * xlmUsdRate).toFixed(2) : "";
+      lines.push(
+        [
+          escapeCsv(r.createdAt.toISOString().slice(0, 10)),
+          escapeCsv(r.jobTitle ?? "N/A"),
+          escapeCsv(r.clientName ?? "N/A"),
+          escapeCsv(r.amount),
+          escapeCsv(usd),
+          escapeCsv(r.txHash),
+          escapeCsv(status),
+        ].join(","),
+      );
+    }
+
+    const csv = lines.join("\n");
+    const fromStr = from.toISOString().slice(0, 10);
+    const toStr = to.toISOString().slice(0, 10);
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="earnings-${fromStr}-to-${toStr}.csv"`,
+    );
+    res.send(csv);
   }),
 );
 

--- a/backend/src/services/earnings-reconciliation.service.ts
+++ b/backend/src/services/earnings-reconciliation.service.ts
@@ -1,0 +1,114 @@
+import { Horizon } from "@stellar/stellar-sdk";
+import { config } from "../config";
+import { logger } from "../lib/logger";
+
+/**
+ * A payment that settled on-chain to the freelancer's wallet, as reported by Horizon.
+ * Escrow releases carry the related `jobId` in the transaction memo (memo_type "text").
+ */
+export interface OnChainPayment {
+  txHash: string;
+  /** jobId parsed from the transaction memo, when present. */
+  memoJobId: string | null;
+  /** Amount of the payment (Horizon reports issued/native amounts as decimal strings). */
+  amount: number;
+  /** Asset code — "XLM" for native, otherwise the issued asset code. */
+  assetCode: string;
+  createdAt: string;
+  from: string;
+}
+
+const HORIZON_PAGE_LIMIT = 200;
+
+let cachedServer: Horizon.Server | null = null;
+
+function getServer(): Horizon.Server {
+  if (!cachedServer) {
+    cachedServer = new Horizon.Server(config.stellar.horizonUrl);
+  }
+  return cachedServer;
+}
+
+/**
+ * Minimal shape of the Horizon payment records we consume. Typed locally rather
+ * than via deep `Horizon.ServerApi.*` aliases so the service is resilient to
+ * SDK minor-version type churn.
+ */
+interface HorizonPaymentRecord {
+  type: string;
+  to?: string;
+  from?: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  created_at: string;
+  transaction_hash: string;
+  transaction: () => Promise<{ memo_type?: string; memo?: string }>;
+}
+
+const PAYMENT_TYPES = new Set([
+  "payment",
+  "path_payment_strict_send",
+  "path_payment_strict_receive",
+]);
+
+/**
+ * Fetch every inbound payment credited to `walletAddress` between `from` and
+ * `to`, walking Horizon's pagination cursor until the window closes.
+ *
+ * Records are requested oldest-first so the date filter can short-circuit once
+ * we pass the `to` boundary.
+ */
+export async function fetchOnChainPayments(
+  walletAddress: string,
+  from: Date,
+  to: Date,
+): Promise<OnChainPayment[]> {
+  const server = getServer();
+  const results: OnChainPayment[] = [];
+
+  let page = await server
+    .payments()
+    .forAccount(walletAddress)
+    .order("asc")
+    .limit(HORIZON_PAGE_LIMIT)
+    .call();
+
+  while (page.records.length > 0) {
+    for (const raw of page.records as unknown as HorizonPaymentRecord[]) {
+      const createdAt = new Date(raw.created_at);
+      if (createdAt < from) continue;
+      if (createdAt > to) return results;
+
+      if (!PAYMENT_TYPES.has(raw.type)) continue;
+      // Only inbound payments to the freelancer count as earnings.
+      if (raw.to !== walletAddress) continue;
+
+      let memoJobId: string | null = null;
+      try {
+        const tx = await raw.transaction();
+        if (tx.memo_type === "text" && tx.memo) {
+          memoJobId = tx.memo;
+        }
+      } catch (err) {
+        logger.warn(
+          { err, txHash: raw.transaction_hash },
+          "[Reconciliation] Failed to load tx memo",
+        );
+      }
+
+      results.push({
+        txHash: raw.transaction_hash,
+        memoJobId,
+        amount: Number(raw.amount ?? 0),
+        assetCode: raw.asset_type === "native" ? "XLM" : raw.asset_code ?? "UNKNOWN",
+        createdAt: raw.created_at,
+        from: raw.from ?? "",
+      });
+    }
+
+    page = await page.next();
+  }
+
+  return results;
+}

--- a/frontend/src/app/dashboard/earnings-page.tsx
+++ b/frontend/src/app/dashboard/earnings-page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import {
-  LineChart,
+  ComposedChart,
+  Bar,
   Line,
   XAxis,
   YAxis,
   CartesianGrid,
   Tooltip,
+  Legend,
   ResponsiveContainer,
 } from "recharts";
 import {
@@ -19,10 +21,13 @@ import {
   Loader2,
   AlertTriangle,
   TrendingUp,
+  CheckCircle2,
+  ExternalLink,
 } from "lucide-react";
 import axios from "axios";
 import StatusBadge from "@/components/StatusBadge";
 import { useAuth } from "@/context/AuthContext";
+import { buildSeries, type WeeklyEarning } from "./earnings/earnings-utils";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000/api";
 
@@ -33,9 +38,10 @@ interface EarningsSummary {
   activeEscrow: number;
 }
 
-interface MonthlyEarning {
-  month: string;
+interface CategoryBreakdown {
+  category: string;
   earnings: number;
+  percentage: number;
 }
 
 interface TransactionEarnings {
@@ -58,7 +64,9 @@ interface TransactionEarnings {
 
 interface EarningsResponse {
   summary: EarningsSummary;
-  monthlyEarnings: MonthlyEarning[];
+  weeklyEarnings: WeeklyEarning[];
+  categoryBreakdown: CategoryBreakdown[];
+  range: { from: string; to: string };
   transactions: TransactionEarnings[];
   pagination: {
     page: number;
@@ -68,6 +76,57 @@ interface EarningsResponse {
   };
 }
 
+interface ReconcileResponse {
+  range: { from: string; to: string };
+  summary: {
+    onChainCount: number;
+    dbCount: number;
+    matchedCount: number;
+    onChainOnlyCount: number;
+    dbOnlyCount: number;
+    allMatched: boolean;
+  };
+  onChainOnly: Array<{
+    txHash: string;
+    memoJobId: string | null;
+    amount: number;
+    assetCode: string;
+    createdAt: string;
+    horizonUrl: string;
+  }>;
+}
+
+type RangePreset = "this_month" | "last_3_months" | "this_year";
+
+const RANGE_PRESETS: { value: RangePreset; label: string }[] = [
+  { value: "this_month", label: "This month" },
+  { value: "last_3_months", label: "Last 3 months" },
+  { value: "this_year", label: "This year" },
+];
+
+/** Resolve a preset to a concrete [from, to] ISO window. */
+function resolveRange(preset: RangePreset): { from: string; to: string } {
+  const now = new Date();
+  const to = now.toISOString();
+  let from: Date;
+  switch (preset) {
+    case "this_month":
+      from = new Date(now.getFullYear(), now.getMonth(), 1);
+      break;
+    case "last_3_months":
+      from = new Date(now.getFullYear(), now.getMonth() - 3, 1);
+      break;
+    case "this_year":
+      from = new Date(now.getFullYear(), 0, 1);
+      break;
+  }
+  return { from: from.toISOString(), to };
+}
+
+const authHeader = () => ({
+  Authorization: `Bearer ${typeof window !== "undefined" ? localStorage.getItem("token") : ""}`,
+});
+
 const EarningsPage = () => {
   const { user } = useAuth();
   const [summary, setSummary] = useState<EarningsSummary>({
@@ -76,13 +135,19 @@ const EarningsPage = () => {
     pendingRelease: 0,
     activeEscrow: 0,
   });
-  const [monthlyEarnings, setMonthlyEarnings] = useState<MonthlyEarning[]>([]);
+  const [weeklyEarnings, setWeeklyEarnings] = useState<WeeklyEarning[]>([]);
+  const [categories, setCategories] = useState<CategoryBreakdown[]>([]);
   const [transactions, setTransactions] = useState<TransactionEarnings[]>([]);
+  const [reconcile, setReconcile] = useState<ReconcileResponse | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
+  const [preset, setPreset] = useState<RangePreset>("this_month");
   const [loading, setLoading] = useState(true);
+  const [reconciling, setReconciling] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const range = useMemo(() => resolveRange(preset), [preset]);
 
   const fetchEarnings = useCallback(async () => {
     if (!user) return;
@@ -94,19 +159,18 @@ const EarningsPage = () => {
       const params = new URLSearchParams({
         page: currentPage.toString(),
         limit: "10",
+        from: range.from,
+        to: range.to,
       });
 
       const response = await axios.get<EarningsResponse>(
         `${API}/freelancers/earnings?${params.toString()}`,
-        {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("token")}`,
-          },
-        }
+        { headers: authHeader() }
       );
 
       setSummary(response.data.summary);
-      setMonthlyEarnings(response.data.monthlyEarnings);
+      setWeeklyEarnings(response.data.weeklyEarnings);
+      setCategories(response.data.categoryBreakdown);
       setTransactions(response.data.transactions);
       setTotalPages(response.data.pagination.totalPages);
     } catch (err) {
@@ -118,78 +182,87 @@ const EarningsPage = () => {
     } finally {
       setLoading(false);
     }
-  }, [user, currentPage]);
+  }, [user, currentPage, range.from, range.to]);
+
+  const fetchReconciliation = useCallback(async () => {
+    if (!user) return;
+    setReconciling(true);
+    try {
+      const params = new URLSearchParams({ from: range.from, to: range.to });
+      const response = await axios.get<ReconcileResponse>(
+        `${API}/freelancers/earnings/reconcile?${params.toString()}`,
+        { headers: authHeader() }
+      );
+      setReconcile(response.data);
+    } catch {
+      // Reconciliation is best-effort; the chart/table still render without it.
+      setReconcile(null);
+    } finally {
+      setReconciling(false);
+    }
+  }, [user, range.from, range.to]);
 
   useEffect(() => {
     fetchEarnings();
   }, [fetchEarnings]);
 
-  const formatCurrency = (amount: number): string => {
-    return new Intl.NumberFormat("en-US", {
+  useEffect(() => {
+    fetchReconciliation();
+  }, [fetchReconciliation]);
+
+  // Reset to page 1 whenever the range changes.
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [preset]);
+
+  const formatCurrency = (amount: number): string =>
+    new Intl.NumberFormat("en-US", {
       style: "currency",
       currency: "USD",
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     }).format(amount);
-  };
 
-  const formatDate = (dateStr: string): string => {
-    return new Date(dateStr).toLocaleDateString("en-US", {
+  const formatDate = (dateStr: string): string =>
+    new Date(dateStr).toLocaleDateString("en-US", {
       year: "numeric",
       month: "short",
       day: "numeric",
     });
-  };
 
-  const formatMonth = (monthStr: string): string => {
-    const [year, month] = monthStr.split("-");
-    const date = new Date(Number(year), Number(month) - 1);
-    return date.toLocaleDateString("en-US", { month: "short", year: "2-digit" });
-  };
+  const formatWeek = (weekStr: string): string =>
+    new Date(`${weekStr}T00:00:00Z`).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    });
 
-  const chartData = monthlyEarnings.map((m) => ({
-    month: formatMonth(m.month),
-    earnings: m.earnings,
-  }));
+  const series = useMemo(
+    () =>
+      buildSeries(weeklyEarnings).map((s) => ({
+        ...s,
+        label: formatWeek(s.week),
+      })),
+    [weeklyEarnings]
+  );
 
   const handleExportCSV = async () => {
     setExporting(true);
     try {
-      const allTx: TransactionEarnings[] = [];
-      let page = 1;
-      let hasMore = true;
+      const params = new URLSearchParams({
+        from: range.from,
+        to: range.to,
+        format: "csv",
+      });
+      const response = await axios.get(
+        `${API}/freelancers/earnings/export?${params.toString()}`,
+        { headers: authHeader(), responseType: "blob" }
+      );
 
-      while (hasMore) {
-        const params = new URLSearchParams({ page: page.toString(), limit: "100" });
-        const response = await axios.get<EarningsResponse>(
-          `${API}/freelancers/earnings?${params.toString()}`,
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem("token")}`,
-            },
-          }
-        );
-        allTx.push(...response.data.transactions);
-        hasMore = page < response.data.pagination.totalPages;
-        page++;
-      }
-
-      const headers = ["Job Title", "Client", "Amount", "Date", "Status", "Transaction Hash"];
-      const rows = allTx.map((tx) => [
-        `"${tx.job?.title ?? "N/A"}"`,
-        `"${tx.job?.client?.username ?? "N/A"}"`,
-        tx.amount.toString(),
-        formatDate(tx.createdAt),
-        tx.type.replace("_", " "),
-        tx.txHash,
-      ]);
-
-      const csv = [headers.join(","), ...rows.map((r) => r.join(","))].join("\n");
-      const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+      const blob = new Blob([response.data], { type: "text/csv;charset=utf-8;" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `earnings-${new Date().toISOString().split("T")[0]}.csv`;
+      a.download = `earnings-${range.from.slice(0, 10)}-to-${range.to.slice(0, 10)}.csv`;
       a.click();
       URL.revokeObjectURL(url);
     } catch {
@@ -199,7 +272,8 @@ const EarningsPage = () => {
     }
   };
 
-  const isNewAccount = !loading && summary.totalEarned === 0 && transactions.length === 0;
+  const isNewAccount =
+    !loading && summary.totalEarned === 0 && transactions.length === 0;
 
   return (
     <div className="space-y-6 p-4 sm:p-6 bg-theme-bg min-h-screen">
@@ -210,23 +284,40 @@ const EarningsPage = () => {
             Earnings
           </h1>
           <p className="text-theme-text mt-1 text-sm sm:text-base">
-            Track your freelance earnings and payment history
+            Track your freelance earnings, reconcile on-chain payments, and export for taxes
           </p>
         </div>
-        {!loading && !isNewAccount && (
-          <button
-            onClick={handleExportCSV}
-            disabled={exporting}
-            className="btn-secondary flex items-center gap-2 px-4 py-2 text-sm self-start"
+        <div className="flex items-center gap-2 self-start">
+          <label htmlFor="range-preset" className="sr-only">
+            Date range
+          </label>
+          <select
+            id="range-preset"
+            value={preset}
+            onChange={(e) => setPreset(e.target.value as RangePreset)}
+            className="btn-secondary px-3 py-2 text-sm"
           >
-            {exporting ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
-            ) : (
-              <Download className="w-4 h-4" />
-            )}
-            {exporting ? "Exporting..." : "Export CSV"}
-          </button>
-        )}
+            {RANGE_PRESETS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+          {!loading && !isNewAccount && (
+            <button
+              onClick={handleExportCSV}
+              disabled={exporting}
+              className="btn-secondary flex items-center gap-2 px-4 py-2 text-sm"
+            >
+              {exporting ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Download className="w-4 h-4" />
+              )}
+              {exporting ? "Exporting..." : "Export CSV"}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Error */}
@@ -241,7 +332,10 @@ const EarningsPage = () => {
       {loading ? (
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="bg-theme-card rounded-lg border border-theme-border p-6 animate-pulse">
+            <div
+              key={i}
+              className="bg-theme-card rounded-lg border border-theme-border p-6 animate-pulse"
+            >
               <div className="h-4 w-24 bg-theme-border rounded mb-3" />
               <div className="h-8 w-20 bg-theme-border rounded" />
             </div>
@@ -290,8 +384,8 @@ const EarningsPage = () => {
         </div>
       )}
 
-      {/* Line Chart */}
-      {!loading && !isNewAccount && chartData.length > 0 && (
+      {/* Time-series chart: weekly bars + 30-day moving average line */}
+      {!loading && !isNewAccount && series.length > 0 && (
         <div className="bg-theme-card rounded-lg border border-theme-border p-4 sm:p-6 shadow-sm">
           <h2 className="text-theme-heading text-lg font-semibold mb-4">
             Earnings Over Time
@@ -299,9 +393,9 @@ const EarningsPage = () => {
           <div className="overflow-x-auto -mx-4 sm:mx-0">
             <div className="min-w-[500px] px-4 sm:px-0">
               <ResponsiveContainer width="100%" height={300}>
-                <LineChart data={chartData}>
+                <ComposedChart data={series}>
                   <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="month" />
+                  <XAxis dataKey="label" />
                   <YAxis />
                   <Tooltip
                     formatter={(value) => formatCurrency(Number(value))}
@@ -312,19 +406,60 @@ const EarningsPage = () => {
                       color: "#f1f5f9",
                     }}
                   />
+                  <Legend />
+                  <Bar
+                    dataKey="earnings"
+                    name="Weekly earnings"
+                    fill="#10b981"
+                    radius={[4, 4, 0, 0]}
+                  />
                   <Line
                     type="monotone"
-                    dataKey="earnings"
-                    stroke="#10b981"
-                    name="Earnings"
+                    dataKey="movingAvg"
+                    name="30-day moving avg"
+                    stroke="#6366f1"
                     strokeWidth={2}
-                    dot={{ r: 4 }}
+                    dot={false}
                   />
-                </LineChart>
+                </ComposedChart>
               </ResponsiveContainer>
             </div>
           </div>
         </div>
+      )}
+
+      {/* Category breakdown (derived from job category tags) */}
+      {!loading && !isNewAccount && categories.length > 0 && (
+        <div className="bg-theme-card rounded-lg border border-theme-border p-4 sm:p-6 shadow-sm">
+          <h2 className="text-theme-heading text-lg font-semibold mb-4">
+            By Category
+          </h2>
+          <div className="space-y-3">
+            {categories.map((c) => (
+              <div key={c.category}>
+                <div className="flex items-center justify-between text-sm mb-1">
+                  <span className="text-theme-heading font-medium">
+                    {c.category}
+                  </span>
+                  <span className="text-theme-text">
+                    {formatCurrency(c.earnings)} ({c.percentage.toFixed(0)}%)
+                  </span>
+                </div>
+                <div className="h-2 w-full bg-theme-bg-secondary rounded">
+                  <div
+                    className="h-2 rounded bg-stellar-blue"
+                    style={{ width: `${Math.min(100, c.percentage)}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Reconciliation panel */}
+      {!loading && !isNewAccount && (
+        <ReconciliationPanel reconcile={reconcile} loading={reconciling} />
       )}
 
       {/* Transaction Table */}
@@ -412,7 +547,9 @@ const EarningsPage = () => {
                     Previous
                   </button>
                   <button
-                    onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                    onClick={() =>
+                      setCurrentPage((p) => Math.min(totalPages, p + 1))
+                    }
                     disabled={currentPage === totalPages}
                     className="btn-secondary px-4 py-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                   >
@@ -421,6 +558,128 @@ const EarningsPage = () => {
                 </div>
               </div>
             </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface ReconciliationPanelProps {
+  reconcile: ReconcileResponse | null;
+  loading: boolean;
+}
+
+const ReconciliationPanel = ({ reconcile, loading }: ReconciliationPanelProps) => {
+  const [showUnmatched, setShowUnmatched] = useState(false);
+
+  if (loading) {
+    return (
+      <div className="bg-theme-card rounded-lg border border-theme-border p-4 sm:p-6 shadow-sm flex items-center gap-2 text-theme-text text-sm">
+        <Loader2 className="w-4 h-4 animate-spin" /> Reconciling with the Stellar
+        ledger…
+      </div>
+    );
+  }
+
+  if (!reconcile) {
+    return (
+      <div className="bg-theme-card rounded-lg border border-theme-border p-4 sm:p-6 shadow-sm text-sm text-theme-text">
+        Reconciliation is currently unavailable. Earnings shown reflect the
+        platform database only.
+      </div>
+    );
+  }
+
+  const { summary, onChainOnly } = reconcile;
+
+  return (
+    <div className="bg-theme-card rounded-lg border border-theme-border p-4 sm:p-6 shadow-sm space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="text-theme-heading text-lg font-semibold">
+          Reconciliation
+        </h2>
+        {summary.allMatched ? (
+          <span className="flex items-center gap-1.5 text-sm text-theme-success">
+            <CheckCircle2 className="w-4 h-4" /> All matched
+          </span>
+        ) : (
+          <span className="flex items-center gap-1.5 text-sm text-theme-warning">
+            <AlertTriangle className="w-4 h-4" />{" "}
+            {summary.onChainOnlyCount + summary.dbOnlyCount} unmatched
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 text-center">
+        <div>
+          <p className="text-2xl font-bold text-theme-heading">
+            {summary.onChainCount}
+          </p>
+          <p className="text-xs text-theme-text uppercase tracking-wider">
+            On-chain txs
+          </p>
+        </div>
+        <div>
+          <p className="text-2xl font-bold text-theme-heading">
+            {summary.dbCount}
+          </p>
+          <p className="text-xs text-theme-text uppercase tracking-wider">
+            DB records
+          </p>
+        </div>
+        <div>
+          <p className="text-2xl font-bold text-theme-heading">
+            {summary.onChainOnlyCount + summary.dbOnlyCount}
+          </p>
+          <p className="text-xs text-theme-text uppercase tracking-wider">Gaps</p>
+        </div>
+      </div>
+
+      {/* Warning banner for on-chain payments missing from the DB */}
+      {summary.onChainOnlyCount > 0 && (
+        <div className="bg-theme-warning/10 border border-theme-warning/30 rounded-lg p-4 space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="w-5 h-5 text-theme-warning flex-shrink-0 mt-0.5" />
+              <p className="text-sm text-theme-warning">
+                {summary.onChainOnlyCount} on-chain payment
+                {summary.onChainOnlyCount > 1 ? "s were" : " was"} found on the
+                Stellar ledger but {summary.onChainOnlyCount > 1 ? "are" : "is"}{" "}
+                missing from your earnings records.
+              </p>
+            </div>
+            <button
+              onClick={() => setShowUnmatched((s) => !s)}
+              className="btn-secondary px-3 py-1.5 text-xs whitespace-nowrap"
+            >
+              {showUnmatched ? "Hide" : "View unmatched"}
+            </button>
+          </div>
+
+          {showUnmatched && (
+            <ul className="space-y-2">
+              {onChainOnly.map((p) => (
+                <li
+                  key={p.txHash}
+                  className="flex items-center justify-between gap-3 text-sm bg-theme-bg-secondary rounded p-2"
+                >
+                  <span className="text-theme-text">
+                    {new Date(p.createdAt).toLocaleDateString()} ·{" "}
+                    {p.amount.toLocaleString()} {p.assetCode}
+                    {p.memoJobId ? ` · job ${p.memoJobId}` : ""}
+                  </span>
+                  <a
+                    href={p.horizonUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-stellar-blue hover:underline"
+                  >
+                    View tx <ExternalLink className="w-3 h-3" />
+                  </a>
+                </li>
+              ))}
+            </ul>
           )}
         </div>
       )}

--- a/frontend/src/app/dashboard/earnings/__tests__/earnings-utils.test.ts
+++ b/frontend/src/app/dashboard/earnings/__tests__/earnings-utils.test.ts
@@ -1,0 +1,59 @@
+import { fillWeeklyGaps, movingAverage, buildSeries } from "../earnings-utils";
+
+describe("fillWeeklyGaps", () => {
+  it("returns empty for empty input", () => {
+    expect(fillWeeklyGaps([])).toEqual([]);
+  });
+
+  it("inserts zero-value weeks for gaps", () => {
+    const result = fillWeeklyGaps([
+      { week: "2026-05-04", earnings: 100 },
+      { week: "2026-05-25", earnings: 300 }, // 3 weeks later
+    ]);
+    expect(result).toEqual([
+      { week: "2026-05-04", earnings: 100 },
+      { week: "2026-05-11", earnings: 0 },
+      { week: "2026-05-18", earnings: 0 },
+      { week: "2026-05-25", earnings: 300 },
+    ]);
+  });
+
+  it("sorts unsorted input", () => {
+    const result = fillWeeklyGaps([
+      { week: "2026-05-11", earnings: 200 },
+      { week: "2026-05-04", earnings: 100 },
+    ]);
+    expect(result.map((w) => w.week)).toEqual(["2026-05-04", "2026-05-11"]);
+  });
+});
+
+describe("movingAverage", () => {
+  it("uses a partial window for the first three weeks", () => {
+    const weekly = [
+      { week: "w1", earnings: 100 },
+      { week: "w2", earnings: 200 },
+      { week: "w3", earnings: 300 },
+      { week: "w4", earnings: 400 },
+      { week: "w5", earnings: 500 },
+    ];
+    const avg = movingAverage(weekly);
+    // Partial windows: [100], [100,200], [100,200,300], then full 4-week windows.
+    expect(avg[0]).toBe(100);
+    expect(avg[1]).toBe(150);
+    expect(avg[2]).toBe(200);
+    expect(avg[3]).toBe(250); // (100+200+300+400)/4
+    expect(avg[4]).toBe(350); // (200+300+400+500)/4
+  });
+});
+
+describe("buildSeries", () => {
+  it("fills gaps and attaches the moving average", () => {
+    const series = buildSeries([
+      { week: "2026-05-04", earnings: 100 },
+      { week: "2026-05-18", earnings: 300 },
+    ]);
+    expect(series).toHaveLength(3);
+    expect(series[1]).toEqual({ week: "2026-05-11", earnings: 0, movingAvg: 50 });
+    expect(series[2].movingAvg).toBeCloseTo((100 + 0 + 300) / 3, 2);
+  });
+});

--- a/frontend/src/app/dashboard/earnings/earnings-utils.ts
+++ b/frontend/src/app/dashboard/earnings/earnings-utils.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure helpers for the freelancer earnings dashboard time-series.
+ * Kept framework-free so they can be unit-tested in isolation.
+ */
+
+export interface WeeklyEarning {
+  /** ISO date of the week-start (Monday), e.g. "2026-05-04". */
+  week: string;
+  earnings: number;
+}
+
+/** Add `days` to an ISO date string, returning a new ISO date (YYYY-MM-DD). */
+function addDays(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Fill missing weeks between the first and last data point with zero-value
+ * entries so the chart shows continuous weeks with no gaps.
+ *
+ * Input may be sparse and unsorted; output is sorted ascending by week.
+ */
+export function fillWeeklyGaps(data: WeeklyEarning[]): WeeklyEarning[] {
+  if (data.length === 0) return [];
+
+  const sorted = [...data].sort((a, b) => a.week.localeCompare(b.week));
+  const byWeek = new Map(sorted.map((d) => [d.week, d.earnings]));
+
+  const filled: WeeklyEarning[] = [];
+  let cursor = sorted[0].week;
+  const end = sorted[sorted.length - 1].week;
+
+  // Guard against malformed ranges to avoid an unbounded loop.
+  let safety = 0;
+  while (cursor <= end && safety < 1040 /* ~20 years of weeks */) {
+    filled.push({ week: cursor, earnings: byWeek.get(cursor) ?? 0 });
+    cursor = addDays(cursor, 7);
+    safety += 1;
+  }
+
+  return filled;
+}
+
+/**
+ * 30-day (4-week) trailing moving average over weekly earnings.
+ * For the first three weeks the window is partial (averaged over the weeks
+ * available so far), matching the acceptance criteria.
+ */
+export function movingAverage(weekly: WeeklyEarning[], window = 4): number[] {
+  return weekly.map((_, i) => {
+    const slice = weekly.slice(Math.max(0, i - (window - 1)), i + 1);
+    const sum = slice.reduce((s, w) => s + w.earnings, 0);
+    return sum / slice.length;
+  });
+}
+
+/** Combine filled weeks with their trailing moving average for charting. */
+export function buildSeries(data: WeeklyEarning[]): Array<{
+  week: string;
+  earnings: number;
+  movingAvg: number;
+}> {
+  const filled = fillWeeklyGaps(data);
+  const avg = movingAverage(filled);
+  return filled.map((w, i) => ({
+    week: w.week,
+    earnings: w.earnings,
+    movingAvg: Number(avg[i].toFixed(2)),
+  }));
+}


### PR DESCRIPTION
## Summary

Closes #672.

The freelancer earnings dashboard (#603, #477) previously showed a flat list of payments and a basic total sourced from PostgreSQL only — no time-based analysis, no way to verify records against the Stellar ledger, and no export for tax filing. This PR closes that trust gap by adding time-series decomposition, on-chain reconciliation against Horizon, and a tax-period CSV export.

## Backend

**`GET /api/freelancers/earnings` (extended)**
- Accepts optional `from`/`to` ISO dates so the chart, category breakdown, and reconciliation all share one window.
- Returns `weeklyEarnings` (sparse weekly buckets via `DATE_TRUNC('week', ...)`), a `categoryBreakdown` derived from each job's `category` tag (not hardcoded) with per-category percentages, and the resolved `range`.

**`GET /api/freelancers/earnings/reconcile?from=<ISO>&to=<ISO>`**
- Fetches inbound payments to the freelancer's verified wallet from Horizon for the window.
- Matches each Horizon payment to a DB earnings record by transaction hash or by the `jobId` carried in the transaction memo.
- Returns `matched`, `onChainOnly`, and `dbOnly` buckets plus a summary. `onChainOnly` entries indicate a DB sync failure, are logged as warnings, and carry a Horizon transaction URL. Returns `502` when Horizon is unreachable.

**`GET /api/freelancers/earnings/export?from=<ISO>&to=<ISO>&format=csv`**
- Streams a CSV with `date, job_title, client_name, amount_xlm, amount_usd, tx_hash, reconciliation_status` (USD via `XLM_USD_RATE` when configured). Reconciliation status is best-effort against Horizon; if unreachable, rows are marked `unverified` and the export still succeeds. Proper RFC-4180 quoting/escaping.

Horizon access is encapsulated in `backend/src/services/earnings-reconciliation.service.ts`.

## Frontend (`frontend/src/app/dashboard/earnings-page.tsx`)

- **Time-series chart** — Recharts `ComposedChart` with weekly bars and a 30-day (4-week) trailing moving-average line. Zero-gap filling and the partial-window moving average live in `earnings/earnings-utils.ts` (unit-tested); the average uses a partial window for the first three weeks.
- **Category breakdown** — horizontal bars derived from job category tags.
- **Reconciliation panel** — matched-vs-unmatched summary with a warning banner and "View unmatched" links to Horizon when on-chain payments are missing from the DB.
- **Date-range picker** — applies to chart, category breakdown, and reconciliation simultaneously.
- **CSV export** — downloads via the new endpoint as a Blob URL, no page reload.

## Acceptance criteria

- [x] Weekly aggregation fills zero-value weeks (no gaps in chart)
- [x] 30-day moving average correct for the first 3 weeks (partial window)
- [x] Reconciliation identifies Horizon-only and DB-only transactions
- [x] CSV export includes all required fields and downloads via Blob URL without a reload
- [x] Date-range picker applies to chart, category breakdown, and reconciliation simultaneously
- [x] Category breakdown derived from job category tags (not hardcoded)
- [x] Warning banner appears when reconciliation finds any unmatched on-chain transaction

## Tests

- `backend/src/routes/__tests__/freelancer.earnings.test.ts` — reconciliation bucket classification, memo-based matching, Horizon-failure handling (`502`), range validation, role gating, and CSV export shape/escaping.
- `frontend/src/app/dashboard/earnings/__tests__/earnings-utils.test.ts` — zero-gap filling and partial-window moving average.

Follows the existing route/service/test conventions and the contributing guide.