### PR TITLE
feat: SHA-256 integrity proof for dispute evidence uploads

### DIFF
--- a/backend/prisma/migrations/20260622000000_add_evidence_integrity_fields/migration.sql
+++ b/backend/prisma/migrations/20260622000000_add_evidence_integrity_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable — add SHA-256 and Stellar anchor tx hash for evidence integrity
+ALTER TABLE "Attachment"
+  ADD COLUMN "sha256"       TEXT,
+  ADD COLUMN "anchorTxHash" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -351,6 +351,8 @@ model Attachment {
   mimeType     String
   size         Int
   url          String
+  sha256       String?
+  anchorTxHash String?
   createdAt    DateTime  @default(now())
 
   uploader  User       @relation(fields: [uploaderId], references: [id], onDelete: Cascade)

--- a/backend/src/routes/dispute.routes.ts
+++ b/backend/src/routes/dispute.routes.ts
@@ -9,6 +9,7 @@ import { validate } from "../middleware/validation";
 import { DisputeService } from "../services/dispute.service";
 import { upload, UPLOAD_DIR } from "../config/upload";
 import { validateFileMimeType, formatFileSize } from "../utils/fileValidation";
+import { config } from "../config";
 import {
   confirmDisputeTransactionSchema,
   createDisputeSchema,
@@ -21,6 +22,17 @@ import {
 } from "../schemas/dispute";
 
 const prisma = new PrismaClient();
+
+async function verifyAnchorTxOnHorizon(txHash: string): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `${config.stellar.horizonUrl}/transactions/${txHash}`,
+    );
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
 
 const router = Router();
 
@@ -356,6 +368,15 @@ router.post(
         continue;
       }
 
+      const candidateAnchorTx = anchorTxHashes[i] || null;
+      if (candidateAnchorTx) {
+        const txExists = await verifyAnchorTxOnHorizon(candidateAnchorTx);
+        if (!txExists) {
+          fs.unlinkSync(file.path);
+          continue;
+        }
+      }
+
       const attachment = await prisma.attachment.create({
         data: {
           uploaderId: req.userId!,
@@ -366,7 +387,7 @@ router.post(
           size: file.size,
           url: `/api/uploads/${file.filename}`,
           sha256: computedSha256,
-          anchorTxHash: anchorTxHashes[i] || null,
+          anchorTxHash: candidateAnchorTx,
         },
       });
 

--- a/backend/src/routes/dispute.routes.ts
+++ b/backend/src/routes/dispute.routes.ts
@@ -1,9 +1,14 @@
 import { Router, Request, Response } from "express";
-import { DisputeStatus, UserRole } from "@prisma/client";
+import { DisputeStatus, UserRole, PrismaClient } from "@prisma/client";
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { asyncHandler } from "../middleware/error";
 import { validate } from "../middleware/validation";
 import { DisputeService } from "../services/dispute.service";
+import { upload, UPLOAD_DIR } from "../config/upload";
+import { validateFileMimeType, formatFileSize } from "../utils/fileValidation";
 import {
   confirmDisputeTransactionSchema,
   createDisputeSchema,
@@ -14,6 +19,8 @@ import {
   resolveDisputeSchema,
   webhookPayloadSchema,
 } from "../schemas/dispute";
+
+const prisma = new PrismaClient();
 
 const router = Router();
 
@@ -273,6 +280,197 @@ router.post(
     const result = await DisputeService.processWebhook(payload);
 
     res.json(result);
+  }),
+);
+
+/**
+ * POST /api/disputes/:id/evidence
+ * Upload evidence files for a dispute with optional integrity metadata
+ */
+router.post(
+  "/:id/evidence",
+  authenticate,
+  validate({ params: disputeIdParamSchema }),
+  upload.array("files", 5),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const disputeId = req.params.id as string;
+    const files = req.files as Express.Multer.File[];
+
+    if (!files || files.length === 0) {
+      return res.status(400).json({ error: "No files uploaded" });
+    }
+
+    const dispute = await DisputeService.getDisputeById(disputeId);
+    if (!dispute) {
+      for (const f of files) fs.unlinkSync(f.path);
+      return res.status(404).json({ error: "Dispute not found" });
+    }
+
+    const isParticipant =
+      dispute.clientId === req.userId ||
+      dispute.freelancerId === req.userId ||
+      dispute.initiatorId === req.userId;
+
+    if (!isParticipant) {
+      for (const f of files) fs.unlinkSync(f.path);
+      return res.status(403).json({
+        error: "Only dispute participants can upload evidence",
+      });
+    }
+
+    let hashes: string[] = [];
+    let anchorTxHashes: string[] = [];
+    try {
+      hashes = req.body.hashes ? JSON.parse(req.body.hashes) : [];
+      anchorTxHashes = req.body.anchorTxHashes
+        ? JSON.parse(req.body.anchorTxHashes)
+        : [];
+    } catch {
+      hashes = [];
+      anchorTxHashes = [];
+    }
+
+    const attachments = [];
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      const validation = await validateFileMimeType(file.path);
+
+      if (!validation.valid) {
+        fs.unlinkSync(file.path);
+        continue;
+      }
+
+      const serverHash = crypto.createHash("sha256");
+      const stream = fs.createReadStream(file.path);
+      await new Promise<void>((resolve, reject) => {
+        stream.on("data", (chunk) => serverHash.update(chunk));
+        stream.on("end", resolve);
+        stream.on("error", reject);
+      });
+      const computedSha256 = serverHash.digest("hex");
+
+      const clientSha256 = hashes[i] || null;
+      if (clientSha256 && clientSha256 !== computedSha256) {
+        fs.unlinkSync(file.path);
+        continue;
+      }
+
+      const attachment = await prisma.attachment.create({
+        data: {
+          uploaderId: req.userId!,
+          disputeId,
+          filename: file.filename,
+          originalName: file.originalname,
+          mimeType: validation.detectedType || file.mimetype,
+          size: file.size,
+          url: `/api/uploads/${file.filename}`,
+          sha256: computedSha256,
+          anchorTxHash: anchorTxHashes[i] || null,
+        },
+      });
+
+      attachments.push({
+        ...attachment,
+        sizeFormatted: formatFileSize(attachment.size),
+      });
+    }
+
+    res.status(201).json({ attachments });
+  }),
+);
+
+/**
+ * GET /api/disputes/:id/evidence
+ * Get all evidence attachments for a dispute with integrity info
+ */
+router.get(
+  "/:id/evidence",
+  authenticate,
+  validate({ params: disputeIdParamSchema }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const disputeId = req.params.id as string;
+
+    const attachments = await prisma.attachment.findMany({
+      where: { disputeId },
+      include: {
+        uploader: {
+          select: {
+            id: true,
+            username: true,
+            walletAddress: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    res.json({
+      evidence: attachments.map((att) => ({
+        id: att.id,
+        fileName: att.originalName,
+        fileType: att.mimeType,
+        size: att.size,
+        sizeFormatted: formatFileSize(att.size),
+        sha256: att.sha256,
+        anchorTxHash: att.anchorTxHash,
+        uploadedAt: att.createdAt.toISOString(),
+        uploader: att.uploader,
+        url: att.url,
+      })),
+    });
+  }),
+);
+
+/**
+ * GET /api/disputes/:id/evidence/:evidenceId/verify
+ * Re-compute SHA-256 of the stored evidence file and check integrity
+ */
+router.get(
+  "/:id/evidence/:evidenceId/verify",
+  authenticate,
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const attachment = await prisma.attachment.findFirst({
+      where: {
+        id: req.params.evidenceId as string,
+        disputeId: req.params.id as string,
+      },
+    });
+
+    if (!attachment) {
+      return res.status(404).json({ error: "Evidence not found" });
+    }
+
+    if (!attachment.sha256) {
+      return res.status(400).json({
+        error: "No integrity hash recorded for this evidence",
+      });
+    }
+
+    const filePath = path.join(UPLOAD_DIR, attachment.filename);
+    if (!fs.existsSync(filePath)) {
+      return res.status(404).json({ error: "File not found on server" });
+    }
+
+    const hash = crypto.createHash("sha256");
+    const stream = fs.createReadStream(filePath);
+
+    await new Promise<void>((resolve, reject) => {
+      stream.on("data", (chunk) => hash.update(chunk));
+      stream.on("end", resolve);
+      stream.on("error", reject);
+    });
+
+    const computedHash = hash.digest("hex");
+    const intact = computedHash === attachment.sha256;
+
+    res.json({
+      intact,
+      storedHash: attachment.sha256,
+      computedHash,
+      anchorTxHash: attachment.anchorTxHash,
+      fileName: attachment.originalName,
+    });
   }),
 );
 

--- a/backend/src/routes/upload.routes.ts
+++ b/backend/src/routes/upload.routes.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import path from "path";
 import { authenticate, AuthRequest } from "../middleware/auth";
 import { validate } from "../middleware/validation";
+import { config } from "../config";
 import {
   upload,
   UPLOAD_DIR,
@@ -152,6 +153,27 @@ router.post(
           fs.unlinkSync(req.file.path);
           return res.status(403).json({
             error: "Only job participants can upload files",
+          });
+        }
+      }
+
+      if (anchorTxHash) {
+        try {
+          const horizonRes = await fetch(
+            `${config.stellar.horizonUrl}/transactions/${anchorTxHash}`,
+          );
+          if (!horizonRes.ok) {
+            fs.unlinkSync(req.file.path);
+            return res.status(422).json({
+              error:
+                "Anchor transaction not found on the Stellar network. Provide a valid transaction hash.",
+            });
+          }
+        } catch {
+          fs.unlinkSync(req.file.path);
+          return res.status(502).json({
+            error:
+              "Unable to verify anchor transaction on the Stellar network. Please try again.",
           });
         }
       }

--- a/backend/src/routes/upload.routes.ts
+++ b/backend/src/routes/upload.routes.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import { z } from "zod";
+import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import { authenticate, AuthRequest } from "../middleware/auth";
@@ -23,6 +24,8 @@ const uploadSchema = {
   body: z.object({
     jobId: z.string().optional(),
     disputeId: z.string().optional(),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/, "Invalid SHA-256 hash").optional(),
+    anchorTxHash: z.string().min(1).optional(),
   }),
 };
 
@@ -70,9 +73,8 @@ router.post(
         return res.status(400).json({ error: "No file uploaded" });
       }
 
-      const { jobId, disputeId } = req.body;
+      const { jobId, disputeId, sha256, anchorTxHash } = req.body;
 
-      // Validate that at least one of jobId or disputeId is provided
       if (!jobId && !disputeId) {
         // Clean up uploaded file
         fs.unlinkSync(req.file.path);
@@ -154,7 +156,6 @@ router.post(
         }
       }
 
-      // Create attachment record
       const attachment = await prisma.attachment.create({
         data: {
           uploaderId: req.userId!,
@@ -165,6 +166,8 @@ router.post(
           mimeType: validation.detectedType || req.file.mimetype,
           size: req.file.size,
           url: `/api/uploads/${req.file.filename}`,
+          sha256: sha256 || null,
+          anchorTxHash: anchorTxHash || null,
         },
         include: {
           uploader: {
@@ -280,6 +283,60 @@ router.get(
     } catch (error) {
       console.error("Error downloading file:", error);
       res.status(500).json({ error: "Failed to download file" });
+    }
+  },
+);
+
+/**
+ * GET /api/uploads/:id/verify
+ * Re-compute SHA-256 of the stored file and compare against the recorded hash
+ */
+router.get(
+  "/:id/verify",
+  authenticate,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const attachment = await prisma.attachment.findUnique({
+        where: { id: req.params.id as string },
+      });
+
+      if (!attachment) {
+        return res.status(404).json({ error: "Attachment not found" });
+      }
+
+      if (!attachment.sha256) {
+        return res.status(400).json({
+          error: "No integrity hash recorded for this attachment",
+        });
+      }
+
+      const filePath = path.join(UPLOAD_DIR, attachment.filename);
+      if (!fs.existsSync(filePath)) {
+        return res.status(404).json({ error: "File not found on server" });
+      }
+
+      const hash = crypto.createHash("sha256");
+      const stream = fs.createReadStream(filePath);
+
+      await new Promise<void>((resolve, reject) => {
+        stream.on("data", (chunk) => hash.update(chunk));
+        stream.on("end", resolve);
+        stream.on("error", reject);
+      });
+
+      const computedHash = hash.digest("hex");
+      const intact = computedHash === attachment.sha256;
+
+      res.json({
+        intact,
+        storedHash: attachment.sha256,
+        computedHash,
+        anchorTxHash: attachment.anchorTxHash,
+        fileName: attachment.originalName,
+      });
+    } catch (error) {
+      console.error("Error verifying file integrity:", error);
+      res.status(500).json({ error: "Failed to verify file integrity" });
     }
   },
 );

--- a/frontend/src/app/disputes/[id]/page.tsx
+++ b/frontend/src/app/disputes/[id]/page.tsx
@@ -9,6 +9,8 @@ import { useWallet } from "@/context/WalletContext";
 import { useAuth } from "@/context/AuthContext";
 import { Dispute, Vote } from "@/types";
 import DisputeVoteProgress from "@/components/DisputeVoteProgress";
+import EvidenceViewer from "@/components/EvidenceViewer";
+import EvidenceUpload from "@/components/EvidenceUpload";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
 
@@ -226,6 +228,19 @@ export default function DisputeDetailPage() {
               </p>
             </div>
             
+            <EvidenceViewer disputeId={dispute.id} />
+
+            {isParticipant &&
+              dispute.status !== "RESOLVED_CLIENT" &&
+              dispute.status !== "RESOLVED_FREELANCER" && (
+                <div className="card">
+                  <EvidenceUpload
+                    disputeId={dispute.id}
+                    onUploadComplete={fetchDispute}
+                  />
+                </div>
+              )}
+
             <h2 className="text-xl font-bold text-theme-heading mb-4 border-b border-theme-border pb-2">
               Community Votes
             </h2>

--- a/frontend/src/components/ArbitratorVoteView.tsx
+++ b/frontend/src/components/ArbitratorVoteView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ExternalLink, Loader2, Scale } from "lucide-react";
+import { ExternalLink, Loader2, Scale, Shield } from "lucide-react";
 import type { Dispute } from "@/types";
 
 interface ArbitratorVoteViewProps {
@@ -108,14 +108,28 @@ export default function ArbitratorVoteView({
                 key={item.id}
                 className="flex items-center justify-between bg-theme-card border border-theme-border rounded-lg px-3 py-2"
               >
-                <div>
+                <div className="min-w-0">
                   <p className="text-sm text-theme-heading truncate max-w-[200px]">
                     {item.fileName}
                   </p>
                   <p className="text-[10px] text-theme-text-muted">{item.fileType}</p>
+                  {item.sha256 && (
+                    <div className="flex items-center gap-1 mt-0.5">
+                      <Shield size={9} className="text-theme-success flex-shrink-0" />
+                      <span className="font-mono text-[9px] text-theme-success">
+                        {item.sha256.slice(0, 12)}…
+                      </span>
+                    </div>
+                  )}
                 </div>
                 <a
-                  href={`https://ipfs.io/ipfs/${item.ipfsHash}`}
+                  href={
+                    item.url
+                      ? `${(process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api").replace("/api", "")}${item.url}`
+                      : item.ipfsHash
+                        ? `https://ipfs.io/ipfs/${item.ipfsHash}`
+                        : "#"
+                  }
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex items-center gap-1 text-xs text-stellar-blue hover:underline flex-shrink-0 ml-3"

--- a/frontend/src/components/EvidenceUpload.tsx
+++ b/frontend/src/components/EvidenceUpload.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import {
+  Paperclip,
+  X,
+  Upload,
+  Shield,
+  Loader2,
+  CheckCircle,
+} from "lucide-react";
+import axios from "axios";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
+
+const MAX_FILES = 5;
+const MAX_FILE_SIZE_MB = 10;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+const STREAMING_HASH_THRESHOLD = 50 * 1024 * 1024;
+
+type HashedFile = {
+  file: File;
+  sha256: string;
+  anchorTxHash?: string;
+};
+
+type EvidenceUploadProps = {
+  disputeId: string;
+  onUploadComplete?: () => void;
+  disabled?: boolean;
+};
+
+async function hashFileSmall(file: File): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  const hashBuffer = await window.crypto.subtle.digest("SHA-256", buffer);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function hashFileLarge(
+  file: File,
+  onProgress?: (pct: number) => void,
+): Promise<string> {
+  const CHUNK_SIZE = 2 * 1024 * 1024;
+  const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
+  let offset = 0;
+  let chunkIndex = 0;
+
+  const parts: ArrayBuffer[] = [];
+
+  while (offset < file.size) {
+    const slice = file.slice(offset, offset + CHUNK_SIZE);
+    const buffer = await slice.arrayBuffer();
+    parts.push(buffer);
+    offset += CHUNK_SIZE;
+    chunkIndex++;
+    onProgress?.(Math.round((chunkIndex / totalChunks) * 100));
+  }
+
+  const combined = new Uint8Array(
+    parts.reduce((acc, buf) => acc + buf.byteLength, 0),
+  );
+  let pos = 0;
+  for (const buf of parts) {
+    combined.set(new Uint8Array(buf), pos);
+    pos += buf.byteLength;
+  }
+
+  const hashBuffer = await window.crypto.subtle.digest("SHA-256", combined);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function hashFile(
+  file: File,
+  onProgress?: (pct: number) => void,
+): Promise<string> {
+  if (file.size > STREAMING_HASH_THRESHOLD) {
+    return hashFileLarge(file, onProgress);
+  }
+  return hashFileSmall(file);
+}
+
+export default function EvidenceUpload({
+  disputeId,
+  onUploadComplete,
+  disabled = false,
+}: EvidenceUploadProps) {
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [hashedFiles, setHashedFiles] = useState<HashedFile[]>([]);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [hashing, setHashing] = useState(false);
+  const [hashProgress, setHashProgress] = useState(0);
+  const [uploading, setUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [done, setDone] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFileError(null);
+    setDone(false);
+    const incoming = Array.from(e.target.files || []);
+    const combined = [...selectedFiles, ...incoming];
+
+    if (combined.length > MAX_FILES) {
+      setFileError(`You may attach up to ${MAX_FILES} files.`);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    const oversized = incoming.find((f) => f.size > MAX_FILE_SIZE_BYTES);
+    if (oversized) {
+      setFileError(
+        `"${oversized.name}" exceeds the ${MAX_FILE_SIZE_MB} MB limit.`,
+      );
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    setSelectedFiles(combined);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const removeFile = (index: number) => {
+    setSelectedFiles((prev) => prev.filter((_, i) => i !== index));
+    setHashedFiles((prev) => prev.filter((_, i) => i !== index));
+    setFileError(null);
+    setDone(false);
+  };
+
+  const handleUpload = useCallback(async () => {
+    if (selectedFiles.length === 0) return;
+
+    setHashing(true);
+    setHashProgress(0);
+    setFileError(null);
+
+    try {
+      const hashed: HashedFile[] = [];
+      for (let i = 0; i < selectedFiles.length; i++) {
+        const file = selectedFiles[i];
+        const sha256 = await hashFile(file, (pct) => {
+          const base = (i / selectedFiles.length) * 100;
+          const filePortion = (1 / selectedFiles.length) * 100;
+          setHashProgress(Math.round(base + (pct / 100) * filePortion));
+        });
+        hashed.push({ file, sha256 });
+      }
+      setHashedFiles(hashed);
+      setHashProgress(100);
+      setHashing(false);
+
+      setUploading(true);
+      setUploadProgress(0);
+
+      const token = localStorage.getItem("token");
+      const formData = new FormData();
+      const hashesArr: string[] = [];
+
+      for (const h of hashed) {
+        formData.append("files", h.file);
+        hashesArr.push(h.sha256);
+      }
+      formData.append("hashes", JSON.stringify(hashesArr));
+
+      await axios.post(`${API_URL}/disputes/${disputeId}/evidence`, formData, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "multipart/form-data",
+        },
+        onUploadProgress: (progressEvent) => {
+          if (progressEvent.total) {
+            setUploadProgress(
+              Math.round((progressEvent.loaded * 100) / progressEvent.total),
+            );
+          }
+        },
+      });
+
+      setDone(true);
+      setUploading(false);
+      onUploadComplete?.();
+    } catch {
+      setFileError("Evidence upload failed. Please try again.");
+      setHashing(false);
+      setUploading(false);
+    }
+  }, [selectedFiles, disputeId, onUploadComplete]);
+
+  const isProcessing = hashing || uploading;
+
+  return (
+    <div className="space-y-3">
+      <label className="block text-sm font-medium text-theme-heading">
+        Evidence Upload{" "}
+        <span className="font-normal text-theme-text">(with integrity proof)</span>
+      </label>
+
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={disabled || isProcessing || selectedFiles.length >= MAX_FILES}
+        className="flex items-center gap-2 text-sm px-3 py-2 border border-dashed border-theme-border rounded-lg text-theme-text hover:border-stellar-blue hover:text-stellar-blue transition-colors disabled:opacity-50 disabled:cursor-not-allowed w-full justify-center"
+      >
+        <Paperclip size={14} />
+        {selectedFiles.length >= MAX_FILES
+          ? `Max ${MAX_FILES} files reached`
+          : `Attach files (up to ${MAX_FILES}, ${MAX_FILE_SIZE_MB} MB each)`}
+      </button>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={handleFileChange}
+        disabled={disabled || isProcessing}
+      />
+
+      {fileError && (
+        <p className="text-xs text-theme-error">{fileError}</p>
+      )}
+
+      {selectedFiles.length > 0 && (
+        <ul className="space-y-1">
+          {selectedFiles.map((file, idx) => (
+            <li
+              key={idx}
+              className="flex items-center justify-between text-xs bg-theme-card border border-theme-border rounded-md px-2 py-1.5"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="truncate text-theme-text max-w-[200px]">
+                  {file.name}
+                </span>
+                {hashedFiles[idx] && (
+                  <span className="flex items-center gap-1 text-theme-success flex-shrink-0">
+                    <Shield size={10} />
+                    <span className="font-mono text-[10px]">
+                      {hashedFiles[idx].sha256.slice(0, 8)}…
+                    </span>
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => removeFile(idx)}
+                disabled={isProcessing}
+                className="ml-2 text-theme-text-muted hover:text-theme-error transition-colors flex-shrink-0"
+                aria-label={`Remove ${file.name}`}
+              >
+                <X size={12} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {hashing && (
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 text-xs text-stellar-blue">
+            <Shield size={12} className="animate-pulse" />
+            Computing SHA-256 integrity hashes… {hashProgress}%
+          </div>
+          <div className="w-full bg-theme-border rounded-full h-1.5 overflow-hidden">
+            <div
+              className="bg-stellar-blue h-1.5 rounded-full transition-all duration-200"
+              style={{ width: `${hashProgress}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {uploading && (
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 text-xs text-stellar-blue">
+            <Upload size={12} className="animate-bounce" />
+            Uploading evidence… {uploadProgress}%
+          </div>
+          <div className="w-full bg-theme-border rounded-full h-1.5 overflow-hidden">
+            <div
+              className="bg-stellar-blue h-1.5 rounded-full transition-all duration-200"
+              style={{ width: `${uploadProgress}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {done && (
+        <div className="flex items-center gap-2 text-xs text-theme-success">
+          <CheckCircle size={12} />
+          Evidence uploaded with integrity proof
+        </div>
+      )}
+
+      {selectedFiles.length > 0 && !done && (
+        <button
+          type="button"
+          onClick={handleUpload}
+          disabled={disabled || isProcessing}
+          className="btn-primary w-full text-sm flex items-center justify-center gap-2"
+        >
+          {isProcessing ? (
+            <>
+              <Loader2 size={14} className="animate-spin" />
+              {hashing ? "Hashing…" : "Uploading…"}
+            </>
+          ) : (
+            <>
+              <Shield size={14} />
+              Hash & Upload Evidence
+            </>
+          )}
+        </button>
+      )}
+
+      <p className="text-[10px] text-theme-text-muted">
+        Files are SHA-256 hashed client-side before upload. Hashes are stored
+        server-side to detect any tampering after submission.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/EvidenceViewer.tsx
+++ b/frontend/src/components/EvidenceViewer.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  FileText,
+  ExternalLink,
+  Shield,
+  ShieldAlert,
+  ShieldCheck,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
+import axios from "axios";
+import type { DisputeEvidence, EvidenceVerification } from "@/types";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
+
+type EvidenceViewerProps = {
+  disputeId: string;
+  evidence?: DisputeEvidence[];
+};
+
+type VerificationState = {
+  loading: boolean;
+  result?: EvidenceVerification;
+  error?: string;
+};
+
+export default function EvidenceViewer({
+  disputeId,
+  evidence: initialEvidence,
+}: EvidenceViewerProps) {
+  const [evidence, setEvidence] = useState<DisputeEvidence[]>(
+    initialEvidence || [],
+  );
+  const [loading, setLoading] = useState(!initialEvidence);
+  const [verifications, setVerifications] = useState<
+    Record<string, VerificationState>
+  >({});
+
+  const fetchEvidence = useCallback(async () => {
+    try {
+      setLoading(true);
+      const token = localStorage.getItem("token");
+      const res = await axios.get(
+        `${API_URL}/disputes/${disputeId}/evidence`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      setEvidence(res.data.evidence);
+    } catch {
+      // keep whatever we had
+    } finally {
+      setLoading(false);
+    }
+  }, [disputeId]);
+
+  useEffect(() => {
+    if (!initialEvidence) {
+      fetchEvidence();
+    }
+  }, [initialEvidence, fetchEvidence]);
+
+  const verifyItem = useCallback(
+    async (evidenceId: string) => {
+      setVerifications((prev) => ({
+        ...prev,
+        [evidenceId]: { loading: true },
+      }));
+
+      try {
+        const token = localStorage.getItem("token");
+        const res = await axios.get(
+          `${API_URL}/disputes/${disputeId}/evidence/${evidenceId}/verify`,
+          { headers: { Authorization: `Bearer ${token}` } },
+        );
+        setVerifications((prev) => ({
+          ...prev,
+          [evidenceId]: { loading: false, result: res.data },
+        }));
+      } catch {
+        setVerifications((prev) => ({
+          ...prev,
+          [evidenceId]: {
+            loading: false,
+            error: "Verification failed",
+          },
+        }));
+      }
+    },
+    [disputeId],
+  );
+
+  if (loading) {
+    return (
+      <div className="card">
+        <div className="flex items-center justify-center gap-2 py-6 text-theme-text">
+          <Loader2 size={16} className="animate-spin" />
+          Loading evidence…
+        </div>
+      </div>
+    );
+  }
+
+  if (evidence.length === 0) {
+    return (
+      <div className="card">
+        <div className="flex items-center gap-2 mb-3">
+          <FileText size={18} className="text-stellar-blue" />
+          <h3 className="font-semibold text-theme-heading">Evidence</h3>
+        </div>
+        <p className="text-sm text-theme-text-muted text-center py-4">
+          No evidence has been submitted yet.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card">
+      <div className="flex items-center gap-2 mb-4">
+        <FileText size={18} className="text-stellar-blue" />
+        <h3 className="font-semibold text-theme-heading">
+          Submitted Evidence
+        </h3>
+        <span className="ml-auto text-xs text-theme-text-muted">
+          {evidence.length} file{evidence.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <ul className="space-y-3">
+        {evidence.map((item) => {
+          const v = verifications[item.id];
+          return (
+            <li
+              key={item.id}
+              className="bg-theme-card border border-theme-border rounded-lg p-3 space-y-2"
+            >
+              <div className="flex items-center justify-between">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-theme-heading truncate max-w-[220px]">
+                    {item.fileName}
+                  </p>
+                  <p className="text-[10px] text-theme-text-muted">
+                    {item.fileType}
+                    {item.sizeFormatted && ` · ${item.sizeFormatted}`}
+                  </p>
+                </div>
+                {item.url && (
+                  <a
+                    href={`${API_URL.replace("/api", "")}${item.url}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-xs text-stellar-blue hover:underline flex-shrink-0 ml-3"
+                  >
+                    View <ExternalLink size={11} />
+                  </a>
+                )}
+              </div>
+
+              {item.sha256 && (
+                <div className="bg-theme-bg border border-theme-border rounded-md p-2 space-y-1.5">
+                  <div className="flex items-center gap-2">
+                    <Shield size={12} className="text-stellar-blue flex-shrink-0" />
+                    <span className="text-[10px] text-theme-text-muted">
+                      SHA-256
+                    </span>
+                    <span className="font-mono text-[10px] text-theme-heading truncate">
+                      {item.sha256}
+                    </span>
+                  </div>
+
+                  {item.anchorTxHash && (
+                    <div className="flex items-center gap-2">
+                      <ExternalLink
+                        size={12}
+                        className="text-stellar-blue flex-shrink-0"
+                      />
+                      <span className="text-[10px] text-theme-text-muted">
+                        Stellar Tx
+                      </span>
+                      <a
+                        href={`https://stellar.expert/explorer/testnet/tx/${item.anchorTxHash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-mono text-[10px] text-stellar-blue hover:underline truncate"
+                      >
+                        {item.anchorTxHash.slice(0, 12)}…
+                      </a>
+                    </div>
+                  )}
+
+                  {v?.result && (
+                    <div
+                      className={`flex items-center gap-2 text-[10px] ${
+                        v.result.intact
+                          ? "text-theme-success"
+                          : "text-theme-error"
+                      }`}
+                    >
+                      {v.result.intact ? (
+                        <>
+                          <ShieldCheck size={12} />
+                          Integrity verified — file matches stored hash
+                        </>
+                      ) : (
+                        <>
+                          <ShieldAlert size={12} />
+                          Hash mismatch — file may have been modified
+                        </>
+                      )}
+                    </div>
+                  )}
+
+                  {v?.error && (
+                    <p className="text-[10px] text-theme-error">
+                      {v.error}
+                    </p>
+                  )}
+
+                  <button
+                    type="button"
+                    onClick={() => verifyItem(item.id)}
+                    disabled={v?.loading}
+                    className="flex items-center gap-1 text-[10px] text-stellar-blue hover:underline disabled:opacity-50"
+                  >
+                    {v?.loading ? (
+                      <>
+                        <Loader2 size={10} className="animate-spin" />
+                        Verifying…
+                      </>
+                    ) : (
+                      <>
+                        <RefreshCw size={10} />
+                        {v?.result ? "Re-verify" : "Verify integrity"}
+                      </>
+                    )}
+                  </button>
+                </div>
+              )}
+
+              <p className="text-[10px] text-theme-text-muted">
+                Uploaded{" "}
+                {new Date(item.uploadedAt).toLocaleString()}
+                {item.uploader && ` by ${item.uploader.username}`}
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/RaiseDisputeModal.tsx
+++ b/frontend/src/components/RaiseDisputeModal.tsx
@@ -145,13 +145,26 @@ export default function RaiseDisputeModal({
       const newDisputeId: string | undefined =
         confirmRes.data?.dispute?.id ?? confirmRes.data?.id;
 
-      // 4. Upload evidence files if any
       if (selectedFiles.length > 0 && newDisputeId) {
         setUploading(true);
         setUploadProgress(0);
 
+        const hashes: string[] = [];
+        for (const file of selectedFiles) {
+          const buffer = await file.arrayBuffer();
+          const hashBuffer = await window.crypto.subtle.digest(
+            "SHA-256",
+            buffer,
+          );
+          const hex = Array.from(new Uint8Array(hashBuffer))
+            .map((b) => b.toString(16).padStart(2, "0"))
+            .join("");
+          hashes.push(hex);
+        }
+
         const formData = new FormData();
         selectedFiles.forEach((file) => formData.append("files", file));
+        formData.append("hashes", JSON.stringify(hashes));
 
         try {
           await axios.post(
@@ -173,7 +186,6 @@ export default function RaiseDisputeModal({
             },
           );
         } catch {
-          // Evidence upload failure is non-blocking — dispute already created
           setError(
             "Dispute created, but evidence upload failed. You can retry from the dispute page.",
           );

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -199,11 +199,29 @@ export interface Vote {
 
 export interface DisputeEvidence {
   id: string;
-  ipfsHash: string;
+  ipfsHash?: string;
   fileName: string;
   fileType: string;
+  size?: number;
+  sizeFormatted?: string;
+  sha256?: string;
+  anchorTxHash?: string;
   uploadedAt: string;
-  uploaderAddress: string;
+  uploaderAddress?: string;
+  url?: string;
+  uploader?: {
+    id: string;
+    username: string;
+    walletAddress?: string;
+  };
+}
+
+export interface EvidenceVerification {
+  intact: boolean;
+  storedHash: string;
+  computedHash: string;
+  anchorTxHash?: string;
+  fileName: string;
 }
 
 export interface Dispute {


### PR DESCRIPTION
## Summary

Closes #669

- **Client-side SHA-256 hashing**: Computes SHA-256 hash of each evidence file in-browser before upload using Web Crypto API. Files >50MB are chunked to avoid blocking the UI thread.
- **Server-side verification**: Backend re-computes SHA-256 on upload to validate client hash, stores the hash alongside the attachment. Provides `GET /disputes/:id/evidence/:evidenceId/verify` endpoint to re-verify integrity on demand.
- **Evidence viewer with integrity status**: New `EvidenceViewer` component shows SHA-256 hash, Stellar anchor tx link, and a "Verify integrity" button that re-fetches the file server-side and compares hashes.
- **Arbitrator panel updates**: `ArbitratorVoteView` now shows integrity badge (truncated SHA-256) next to each evidence item.
- **Prisma schema + migration**: Adds `sha256` and `anchorTxHash` nullable columns to the `Attachment` model.

### Files changed

| Area | File | Change |
|------|------|--------|
| Schema | `backend/prisma/schema.prisma` | Added `sha256`, `anchorTxHash` to Attachment |
| Migration | `backend/prisma/migrations/20260622000000_add_evidence_integrity_fields/` | SQL migration |
| Backend | `backend/src/routes/dispute.routes.ts` | Added `POST /:id/evidence`, `GET /:id/evidence`, `GET /:id/evidence/:evidenceId/verify` |
| Backend | `backend/src/routes/upload.routes.ts` | Accept `sha256`/`anchorTxHash` in upload, add `GET /:id/verify` |
| Frontend | `frontend/src/components/EvidenceUpload.tsx` | New component — hash + upload flow |
| Frontend | `frontend/src/components/EvidenceViewer.tsx` | New component — view evidence with integrity verification |
| Frontend | `frontend/src/app/disputes/[id]/page.tsx` | Integrated EvidenceViewer + EvidenceUpload |
| Frontend | `frontend/src/components/ArbitratorVoteView.tsx` | Shows SHA-256 badge per evidence item |
| Frontend | `frontend/src/components/RaiseDisputeModal.tsx` | Hashes files before initial evidence upload |
| Frontend | `frontend/src/types/index.ts` | Extended `DisputeEvidence`, added `EvidenceVerification` |

## Test plan

- [ ] Upload evidence files during dispute creation — verify SHA-256 is computed and sent
- [ ] Upload evidence from the dispute detail page via EvidenceUpload component
- [ ] Click "Verify integrity" in EvidenceViewer — confirm hash match returns ✓
- [ ] Modify a stored file on disk — verify re-verification shows mismatch warning
- [ ] Upload file >50MB — confirm streaming hash completes without freezing UI
- [ ] Arbitrator panel shows integrity badge alongside each evidence item
- [ ] `GET /disputes/:id/evidence/:evidenceId/verify` returns correct `intact` status