### PR TITLE
Backend ContractService circuit breaker implementation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4196,7 +4196,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -11,6 +11,7 @@ export const config = {
   stellar: {
     networkPassphrase: process.env.STELLAR_NETWORK_PASSPHRASE || "Test SDF Network ; September 2015",
     rpcUrl: process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org",
+    secondaryRpcUrl: process.env.STELLAR_SECONDARY_RPC_URL || "https://soroban-testnet.stellar.org/secondary",
     horizonUrl: process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org",
     escrowContractId: process.env.ESCROW_CONTRACT_ID || "",
     disputeContractId: process.env.DISPUTE_CONTRACT_ID || "",

--- a/backend/src/lib/circuit-breaker.ts
+++ b/backend/src/lib/circuit-breaker.ts
@@ -59,7 +59,7 @@ export class CircuitBreaker {
   onSuccess(): void {
     if (this.state !== "CLOSED") {
       logger.info(
-        { name: this.name, previousState: this.state },
+        { name: this.name, previousState: this.state, metric: "rpc_circuit_closed" },
         `[${this.name}] Circuit closed — service recovered`,
       );
     }
@@ -79,7 +79,7 @@ export class CircuitBreaker {
       this.openedAt = Date.now();
       this.reconnectAttempts += 1;
       logger.warn(
-        { name: this.name, consecutiveFailures: this.consecutiveFailures },
+        { name: this.name, consecutiveFailures: this.consecutiveFailures, metric: "rpc_circuit_open" },
         `[${this.name}] Circuit reopened after failed probe`,
       );
       return;
@@ -96,6 +96,7 @@ export class CircuitBreaker {
         {
           name: this.name,
           consecutiveFailures: this.consecutiveFailures,
+          metric: "rpc_circuit_open",
           [`${this.name.toLowerCase().replace(/\s+/g, "_")}_reconnects_total`]:
             this.reconnectAttempts,
         },

--- a/backend/src/middleware/error.ts
+++ b/backend/src/middleware/error.ts
@@ -81,6 +81,10 @@ export const errorHandler = (
   );
 
   // Send consistent error response
+  if (statusCode === 503) {
+    res.setHeader("Retry-After", "30");
+  }
+
   res.status(statusCode).json({
     error: message,
     requestId: req.requestId,

--- a/backend/src/services/__tests__/contract-service.circuit-breaker.test.ts
+++ b/backend/src/services/__tests__/contract-service.circuit-breaker.test.ts
@@ -1,0 +1,237 @@
+import { rpc } from "@stellar/stellar-sdk";
+import { logger } from "../../lib/logger";
+
+// Mock logger to avoid cluttering test output
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("../../config", () => ({
+  config: {
+    stellar: {
+      networkPassphrase: "Test SDF Network ; September 2015",
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      secondaryRpcUrl: "https://soroban-testnet.stellar.org/secondary",
+      escrowContractId: "CDLZFC3SYJYDZT7K67VZ75YJBMKBAV27Z6Y6Z6Z6Z6Z6Z6Z6Z6Z6Z6Z6Z",
+    },
+  },
+}));
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const mockTxBuilder = {
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnThis(),
+    toXDR: jest.fn().mockReturnValue("mock-xdr"),
+  };
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue({}),
+    })),
+    Address: jest.fn().mockImplementation(() => ({
+      toScVal: jest.fn().mockReturnValue({}),
+    })),
+    TransactionBuilder: jest.fn().mockImplementation(() => mockTxBuilder),
+    BASE_FEE: "100",
+    nativeToScVal: jest.fn().mockReturnValue({}),
+    rpc: {
+      Server: jest.fn(),
+      Api: {
+        GetTransactionStatus: {
+          SUCCESS: "SUCCESS",
+          FAILED: "FAILED",
+        },
+      },
+    },
+  };
+});
+
+import { ContractService } from "../contract.service";
+
+describe("ContractService Circuit Breaker", () => {
+  let mockPrimaryGetAccount: jest.Mock;
+  let mockSecondaryGetAccount: jest.Mock;
+  let mockPrimaryGetLatestLedger: jest.Mock;
+  let mockSecondaryGetLatestLedger: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const cb = ContractService.getCircuitBreaker();
+    // Reset the circuit breaker state to closed
+    cb.onSuccess();
+
+    mockPrimaryGetAccount = jest.fn();
+    mockSecondaryGetAccount = jest.fn();
+    mockPrimaryGetLatestLedger = jest.fn().mockResolvedValue({});
+    mockSecondaryGetLatestLedger = jest.fn().mockResolvedValue({});
+
+    (rpc.Server as jest.Mock).mockImplementation((url) => {
+      if (url && url.includes("secondary")) {
+        return {
+          getAccount: mockSecondaryGetAccount,
+          getLatestLedger: mockSecondaryGetLatestLedger,
+        };
+      } else {
+        return {
+          getAccount: mockPrimaryGetAccount,
+          getLatestLedger: mockPrimaryGetLatestLedger,
+        };
+      }
+    });
+  });
+
+  it("should use primary RPC when circuit is CLOSED", async () => {
+    mockPrimaryGetAccount.mockResolvedValueOnce({
+      accountId: () => "GPRIMARY",
+      sequenceNumber: () => "1",
+      incrementSequenceNumber: () => {},
+    });
+
+    const status = ContractService.getCircuitBreakerStatus();
+    expect(status.state).toBe("CLOSED");
+
+    const result = await ContractService.buildCreateJobTx(
+      "GPRIMARY",
+      "GFREELANCER",
+      "CTOKEN",
+      [],
+      123456
+    );
+
+    expect(result).toBeDefined();
+    expect(mockPrimaryGetLatestLedger).toHaveBeenCalledTimes(1);
+    expect(mockPrimaryGetAccount).toHaveBeenCalledTimes(1);
+    expect(mockSecondaryGetAccount).not.toHaveBeenCalled();
+    expect(ContractService.getCircuitBreakerStatus().state).toBe("CLOSED");
+  });
+
+  it("should open circuit after 5 failures and route to secondary RPC", async () => {
+    mockPrimaryGetLatestLedger.mockRejectedValue(new Error("Primary RPC Error"));
+    mockSecondaryGetAccount.mockResolvedValue({
+      accountId: () => "GSECONDARY",
+      sequenceNumber: () => "1",
+      incrementSequenceNumber: () => {},
+    });
+
+    // Perform 4 failing calls to primary
+    for (let i = 0; i < 4; i++) {
+      await expect(
+        ContractService.buildCreateJobTx("GPRIMARY", "GFREELANCER", "CTOKEN", [], 123456)
+      ).rejects.toThrow("Primary RPC Error");
+    }
+
+    expect(ContractService.getCircuitBreakerStatus().state).toBe("CLOSED");
+    expect(ContractService.getCircuitBreakerStatus().consecutiveFailures).toBe(4);
+
+    // The 5th call should open the circuit, and immediately fall back to secondary.
+    // So the call should succeed using secondary!
+    const result = await ContractService.buildCreateJobTx(
+      "GPRIMARY",
+      "GFREELANCER",
+      "CTOKEN",
+      [],
+      123456
+    );
+
+    expect(result).toBeDefined();
+    expect(ContractService.getCircuitBreakerStatus().state).toBe("OPEN");
+    expect(mockPrimaryGetLatestLedger).toHaveBeenCalledTimes(5);
+    expect(mockSecondaryGetLatestLedger).toHaveBeenCalledTimes(1);
+    expect(mockSecondaryGetAccount).toHaveBeenCalledTimes(1);
+
+    // A 6th call while open should bypass primary entirely and call secondary.
+    mockPrimaryGetLatestLedger.mockClear();
+    mockSecondaryGetLatestLedger.mockClear();
+    mockSecondaryGetAccount.mockClear();
+    
+    const result6 = await ContractService.buildCreateJobTx(
+      "GPRIMARY",
+      "GFREELANCER",
+      "CTOKEN",
+      [],
+      123456
+    );
+    expect(result6).toBeDefined();
+    expect(mockPrimaryGetLatestLedger).not.toHaveBeenCalled();
+    expect(mockSecondaryGetLatestLedger).toHaveBeenCalledTimes(1);
+    expect(mockSecondaryGetAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw a 503 error when both primary and secondary RPCs fail", async () => {
+    mockPrimaryGetLatestLedger.mockRejectedValue(new Error("Primary RPC Error"));
+    mockSecondaryGetLatestLedger.mockRejectedValue(new Error("Secondary RPC Error"));
+
+    // Force circuit to open
+    for (let i = 0; i < 4; i++) {
+      await expect(
+        ContractService.buildCreateJobTx("GPRIMARY", "GFREELANCER", "CTOKEN", [], 123456)
+      ).rejects.toThrow("Primary RPC Error");
+    }
+
+    // 5th failure should trigger primary fail + secondary fail -> throws 503
+    let error: any;
+    try {
+      await ContractService.buildCreateJobTx("GPRIMARY", "GFREELANCER", "CTOKEN", [], 123456);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeDefined();
+    expect(error.statusCode).toBe(503);
+    expect(error.message).toBe("Stellar RPC services unavailable");
+    expect(ContractService.getCircuitBreakerStatus().state).toBe("OPEN");
+  });
+
+  it("should transition to HALF_OPEN and probe primary RPC after 60s cooldown", async () => {
+    jest.useFakeTimers();
+
+    mockPrimaryGetLatestLedger.mockRejectedValue(new Error("Primary RPC Error"));
+    mockSecondaryGetAccount.mockResolvedValue({
+      accountId: () => "GSECONDARY",
+      sequenceNumber: () => "1",
+      incrementSequenceNumber: () => {},
+    });
+
+    // Manually force the circuit breaker to OPEN state by failing 5 times
+    const cb = ContractService.getCircuitBreaker();
+    for (let i = 0; i < 5; i++) {
+      cb.onFailure();
+    }
+    expect(ContractService.getCircuitBreakerStatus().state).toBe("OPEN");
+
+    // Advance timer by 61 seconds
+    jest.advanceTimersByTime(61000);
+
+    // Next call should probe primary
+    mockPrimaryGetLatestLedger.mockClear();
+    mockPrimaryGetLatestLedger.mockResolvedValueOnce({});
+    mockPrimaryGetAccount.mockResolvedValueOnce({
+      accountId: () => "GPRIMARY",
+      sequenceNumber: () => "2",
+      incrementSequenceNumber: () => {},
+    });
+    mockSecondaryGetLatestLedger.mockClear();
+
+    const result = await ContractService.buildCreateJobTx(
+      "GPRIMARY",
+      "GFREELANCER",
+      "CTOKEN",
+      [],
+      123456
+    );
+
+    expect(result).toBeDefined();
+    expect(mockPrimaryGetLatestLedger).toHaveBeenCalledTimes(1);
+    expect(mockPrimaryGetAccount).toHaveBeenCalledTimes(1);
+    expect(mockSecondaryGetLatestLedger).not.toHaveBeenCalled();
+    expect(ContractService.getCircuitBreakerStatus().state).toBe("CLOSED");
+
+    jest.useRealTimers();
+  });
+});

--- a/backend/src/services/contract.service.ts
+++ b/backend/src/services/contract.service.ts
@@ -13,18 +13,69 @@ import { MilestoneStatus } from "@prisma/client";
 import { config } from "../config";
 import { getRequestId } from "../lib/request-context";
 import { logger } from "../lib/logger";
+import { CircuitBreaker } from "../lib/circuit-breaker";
 
 const networkPassphrase = config.stellar.networkPassphrase;
 const contractId = config.stellar.escrowContractId;
 const READONLY_SOURCE = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 const STROOPS_PER_XLM = 10_000_000n;
 
+const contractCB = new CircuitBreaker({
+  failureThreshold: 5,
+  openDurationMs: 60_000,
+  name: "ContractRpc",
+});
+
 function getRpcServer(): rpc.Server {
   const requestId = getRequestId();
+  const headers = requestId ? { "X-Request-ID": requestId } : undefined;
 
-  return new rpc.Server(config.stellar.rpcUrl, {
-    headers: requestId ? { "X-Request-ID": requestId } : undefined,
-  });
+  const primary = new rpc.Server(config.stellar.rpcUrl, { headers });
+  const secondary = new rpc.Server(config.stellar.secondaryRpcUrl, { headers });
+
+  return new Proxy(primary, {
+    get(target, prop, receiver) {
+      const origValue = Reflect.get(target, prop, receiver);
+      if (typeof origValue === "function") {
+        return async (...args: any[]) => {
+          const isPrimaryAllowed = contractCB.allowRequest();
+          if (isPrimaryAllowed) {
+            try {
+              const res = await origValue.apply(target, args);
+              contractCB.onSuccess();
+              return res;
+            } catch (err) {
+              contractCB.onFailure();
+              if (contractCB.getStatus().state === "OPEN") {
+                logger.warn({ err }, "Primary RPC failed, circuit opened. Falling back to secondary RPC.");
+                try {
+                  const secondaryMethod = Reflect.get(secondary, prop);
+                  return await secondaryMethod.apply(secondary, args);
+                } catch (secErr) {
+                  logger.error({ err: secErr }, "Secondary RPC fallback failed.");
+                  const apiErr = new Error("Stellar RPC services unavailable") as any;
+                  apiErr.statusCode = 503;
+                  throw apiErr;
+                }
+              }
+              throw err;
+            }
+          } else {
+            try {
+              const secondaryMethod = Reflect.get(secondary, prop);
+              return await secondaryMethod.apply(secondary, args);
+            } catch (secErr) {
+              logger.error({ err: secErr }, "Secondary RPC failed while circuit is open.");
+              const apiErr = new Error("Stellar RPC services unavailable") as any;
+              apiErr.statusCode = 503;
+              throw apiErr;
+            }
+          }
+        };
+      }
+      return origValue;
+    },
+  }) as rpc.Server;
 }
 
 export type RevisionProposalView = {
@@ -65,6 +116,14 @@ export class ContractSimulationError extends Error {
 }
 
 export class ContractService {
+  static getCircuitBreakerStatus() {
+    return contractCB.getStatus();
+  }
+
+  static getCircuitBreaker() {
+    return contractCB;
+  }
+
   /**
    * Builds an un-signed transaction XDR for creating a job on-chain.
    */


### PR DESCRIPTION
- Configured primary and secondary Stellar RPC URLs in config.
- Implemented a circuit breaker using the custom CircuitBreaker class.
- Routed calls to the secondary RPC when the circuit is open.
- Returned 503 Service Unavailable with Retry-After: 30 when both RPCs fail.
- Emitted rpc_circuit_open and rpc_circuit_closed metrics.

Closes #719