### PR TITLE
feat:frontend backend enhancements

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,14 @@ JWT_SECRET="your-super-secret-jwt-key-change-this"
 PORT=5000
 FRONTEND_URL="http://localhost:3000"
 
+# Job posting and private dispute evidence storage
+PLATFORM_MIN_BUDGET_XLM=1
+EVIDENCE_S3_BUCKET=""
+EVIDENCE_S3_REGION="us-east-1"
+# Optional S3-compatible endpoint (for MinIO/R2); leave blank for AWS S3.
+EVIDENCE_S3_ENDPOINT=""
+EVIDENCE_S3_FORCE_PATH_STYLE=false
+
 # Optional: override default upload directory (default: backend/uploads)
 UPLOAD_DIR="./uploads"
 # Optional: avatar storage (default: UPLOAD_DIR/avatars). Set to a path for local storage.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "@stellarmarket/backend",
       "version": "1.0.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1075.0",
+        "@aws-sdk/s3-request-presigner": "^3.1075.0",
         "@bull-board/api": "^6.10.2",
         "@bull-board/express": "^6.10.2",
         "@prisma/client": "^5.22.0",
@@ -124,6 +126,452 @@
       },
       "peerDependencies": {
         "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.8.tgz",
+      "integrity": "sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1075.0.tgz",
+      "integrity": "sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.33",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.54",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.31",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+      "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+      "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+      "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-login": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+      "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+      "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-ini": "^3.972.56",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+      "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+      "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/token-providers": "3.1074.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+      "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.33.tgz",
+      "integrity": "sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.54.tgz",
+      "integrity": "sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1075.0.tgz",
+      "integrity": "sha512-++ftTvAGZSTuzFVHEPk8lLi7mybBD8PzJ9USWBvwnE4kSrXOyqYVJ5Ixd06xUEWS/xsrhpkI07mzCLGIxrRymA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1074.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+      "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2088,6 +2536,126 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+      "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -3299,6 +3867,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -4714,6 +5288,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,15 +13,17 @@
     "prisma:verify-review-aggregates": "node scripts/verify-user-review-aggregates.js"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1075.0",
+    "@aws-sdk/s3-request-presigner": "^3.1075.0",
     "@bull-board/api": "^6.10.2",
     "@bull-board/express": "^6.10.2",
     "@prisma/client": "^5.22.0",
-    "bullmq": "^5.56.0",
     "@stellar/stellar-sdk": "^12.3.0",
     "@types/ioredis": "^4.28.10",
     "@types/multer": "^2.0.0",
     "@types/web-push": "^3.6.4",
     "bcryptjs": "^2.4.3",
+    "bullmq": "^5.56.0",
     "clamscan": "^2.3.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -2,12 +2,27 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
+const configuredPlatformMinimum = Number(process.env.PLATFORM_MIN_BUDGET_XLM || "1");
+const platformMinBudgetXlm =
+  Number.isFinite(configuredPlatformMinimum) && configuredPlatformMinimum > 0
+    ? configuredPlatformMinimum
+    : 1;
+
 export const config = {
   port: process.env.PORT || 5000,
   jwtSecret: process.env.JWT_SECRET || "default-secret-change-me",
   databaseUrl: process.env.DATABASE_URL,
   frontendUrl: process.env.FRONTEND_URL || "http://localhost:3000",
   encryptionKey: process.env.ENCRYPTION_KEY || "",
+  // The minimum is kept server-side so clients cannot create zero-value jobs
+  // by bypassing the posting form.
+  platformMinBudgetXlm,
+  evidenceStorage: {
+    bucket: process.env.EVIDENCE_S3_BUCKET || "",
+    region: process.env.EVIDENCE_S3_REGION || process.env.AWS_REGION || "us-east-1",
+    endpoint: process.env.EVIDENCE_S3_ENDPOINT || undefined,
+    forcePathStyle: process.env.EVIDENCE_S3_FORCE_PATH_STYLE === "true",
+  },
   stellar: {
     networkPassphrase: process.env.STELLAR_NETWORK_PASSPHRASE || "Test SDF Network ; September 2015",
     rpcUrl: process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org",

--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -27,6 +27,18 @@ export const validate = (schema: {
       next();
     } catch (error) {
       if (error instanceof ZodError) {
+        const budgetMinimumError = error.issues.find(
+          (issue) =>
+            issue.path.length === 1 &&
+            issue.path[0] === "budget" &&
+            issue.message.startsWith("Budget must be at least "),
+        );
+        if (budgetMinimumError) {
+          return res.status(422).json({
+            code: "BudgetBelowMinimum",
+            message: budgetMinimumError.message,
+          });
+        }
         return next(createError("Validation failed", 400, error.issues));
       }
       next(error);

--- a/backend/src/routes/dispute.routes.ts
+++ b/backend/src/routes/dispute.routes.ts
@@ -11,6 +11,12 @@ import { upload, UPLOAD_DIR } from "../config/upload";
 import { validateFileMimeType, formatFileSize } from "../utils/fileValidation";
 import { config } from "../config";
 import {
+  createEvidenceDownloadUrl,
+  isEvidenceStorageConfigured,
+  readEvidenceObject,
+  uploadEvidenceObject,
+} from "../services/evidence-storage.service";
+import {
   confirmDisputeTransactionSchema,
   createDisputeSchema,
   castVoteSchema,
@@ -344,6 +350,11 @@ router.post(
 
     const attachments = [];
 
+    if (!isEvidenceStorageConfigured()) {
+      for (const f of files) fs.unlinkSync(f.path);
+      return res.status(503).json({ error: "Evidence S3 storage is not configured" });
+    }
+
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
       const validation = await validateFileMimeType(file.path);
@@ -377,15 +388,28 @@ router.post(
         }
       }
 
+      const storageKey = `disputes/${disputeId}/${file.filename}`;
+      try {
+        await uploadEvidenceObject({
+          key: storageKey,
+          filePath: file.path,
+          contentType: validation.detectedType || file.mimetype,
+        });
+      } finally {
+        // Files are only staged on disk while validating and uploading them.
+        fs.unlinkSync(file.path);
+      }
+
       const attachment = await prisma.attachment.create({
         data: {
           uploaderId: req.userId!,
           disputeId,
-          filename: file.filename,
+          filename: storageKey,
           originalName: file.originalname,
           mimeType: validation.detectedType || file.mimetype,
           size: file.size,
-          url: `/api/uploads/${file.filename}`,
+          // This is an object identifier, never a publicly usable file URL.
+          url: `s3://${config.evidenceStorage.bucket}/${storageKey}`,
           sha256: computedSha256,
           anchorTxHash: candidateAnchorTx,
         },
@@ -444,6 +468,57 @@ router.get(
 );
 
 /**
+ * GET /api/disputes/:id/evidence/:evidenceId/download
+ * Redirect an authorised reviewer to a private, one-minute S3 download URL.
+ */
+router.get(
+  "/:id/evidence/:evidenceId/download",
+  authenticate,
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const attachment = await prisma.attachment.findFirst({
+      where: {
+        id: req.params.evidenceId as string,
+        disputeId: req.params.id as string,
+      },
+      include: {
+        dispute: {
+          include: { votes: { where: { voterId: req.userId }, select: { id: true } } },
+        },
+      },
+    });
+
+    if (!attachment || !attachment.dispute) {
+      return res.status(404).json({ error: "Evidence not found" });
+    }
+
+    const dispute = attachment.dispute;
+    const canReview =
+      dispute.clientId === req.userId ||
+      dispute.freelancerId === req.userId ||
+      dispute.initiatorId === req.userId ||
+      dispute.votes.length > 0 ||
+      req.userRole === UserRole.ADMIN;
+    if (!canReview) {
+      return res.status(403).json({ error: "Access denied" });
+    }
+
+    try {
+      const url = await createEvidenceDownloadUrl({
+        key: attachment.filename,
+        filename: attachment.originalName,
+        contentType: attachment.mimeType,
+      });
+      return res.redirect(302, url);
+    } catch (error) {
+      if (error instanceof Error && error.message === "Evidence S3 storage is not configured") {
+        return res.status(503).json({ error: error.message });
+      }
+      throw error;
+    }
+  }),
+);
+
+/**
  * GET /api/disputes/:id/evidence/:evidenceId/verify
  * Re-compute SHA-256 of the stored evidence file and check integrity
  */
@@ -468,19 +543,26 @@ router.get(
       });
     }
 
-    const filePath = path.join(UPLOAD_DIR, attachment.filename);
-    if (!fs.existsSync(filePath)) {
-      return res.status(404).json({ error: "File not found on server" });
-    }
-
     const hash = crypto.createHash("sha256");
-    const stream = fs.createReadStream(filePath);
-
-    await new Promise<void>((resolve, reject) => {
-      stream.on("data", (chunk) => hash.update(chunk));
-      stream.on("end", resolve);
-      stream.on("error", reject);
-    });
+    if (attachment.filename.startsWith("disputes/")) {
+      try {
+        hash.update(await readEvidenceObject(attachment.filename));
+      } catch {
+        return res.status(404).json({ error: "File not found in evidence storage" });
+      }
+    } else {
+      // Legacy evidence uploaded before private S3 storage remains verifiable.
+      const filePath = path.join(UPLOAD_DIR, attachment.filename);
+      if (!fs.existsSync(filePath)) {
+        return res.status(404).json({ error: "File not found on server" });
+      }
+      const stream = fs.createReadStream(filePath);
+      await new Promise<void>((resolve, reject) => {
+        stream.on("data", (chunk) => hash.update(chunk));
+        stream.on("end", resolve);
+        stream.on("error", reject);
+      });
+    }
 
     const computedHash = hash.digest("hex");
     const intact = computedHash === attachment.sha256;

--- a/backend/src/schemas/__tests__/job.test.ts
+++ b/backend/src/schemas/__tests__/job.test.ts
@@ -1,6 +1,15 @@
 import { createJobSchema } from "../job";
 
 describe("createJobSchema", () => {
+  const validJob = {
+    title: "Build Stellar escrow flow",
+    description: "Implement backend validation for escrow initialization and job creation.",
+    budget: 500,
+    skills: ["TypeScript"],
+    category: "Development",
+    deadline: "2026-03-01T00:00:00Z",
+  };
+
   it("requires deadline", () => {
     const result = createJobSchema.safeParse({
       title: "Build Stellar escrow flow",
@@ -16,5 +25,20 @@ describe("createJobSchema", () => {
     }
 
     expect(result.error.issues.some(issue => issue.path.includes("deadline"))).toBe(true);
+  });
+
+  it("rejects a zero budget with the platform minimum message", () => {
+    const result = createJobSchema.safeParse({ ...validJob, budget: 0 });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected zero budget to be rejected.");
+    expect(result.error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ["budget"],
+          message: "Budget must be at least 1 XLM",
+        }),
+      ]),
+    );
   });
 });

--- a/backend/src/schemas/job.ts
+++ b/backend/src/schemas/job.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 import { paginationSchema, jobStatusSchema } from "./common";
+import { config } from "../config";
+
+const platformMinimumBudget = Number.isFinite(config.platformMinBudgetXlm)
+  ? config.platformMinBudgetXlm
+  : 1;
+const minimumBudgetMessage = `Budget must be at least ${platformMinimumBudget} XLM`;
 
 export const createJobSchema = z.object({
   title: z
@@ -10,7 +16,7 @@ export const createJobSchema = z.object({
     .string()
     .min(20, "Description must be at least 20 characters long")
     .max(5000, "Description must be less than 5000 characters"),
-  budget: z.number().positive("Budget must be a positive number"),
+  budget: z.number().min(platformMinimumBudget, minimumBudgetMessage),
   skills: z
     .array(z.string())
     .min(1, "At least one skill is required")

--- a/backend/src/services/__tests__/evidence-storage.service.test.ts
+++ b/backend/src/services/__tests__/evidence-storage.service.test.ts
@@ -1,0 +1,45 @@
+const getSignedUrl = jest.fn();
+
+jest.mock("@aws-sdk/s3-request-presigner", () => ({ getSignedUrl }));
+jest.mock("../../config", () => ({
+  config: {
+    evidenceStorage: {
+      bucket: "private-evidence",
+      region: "us-east-1",
+      endpoint: undefined,
+      forcePathStyle: false,
+    },
+  },
+}));
+
+import {
+  createEvidenceDownloadUrl,
+  EVIDENCE_DOWNLOAD_EXPIRY_SECONDS,
+} from "../evidence-storage.service";
+
+describe("evidence download signing", () => {
+  it("creates a new 60-second signed URL for every download request", async () => {
+    getSignedUrl
+      .mockResolvedValueOnce("https://signed.example/first")
+      .mockResolvedValueOnce("https://signed.example/second");
+
+    const first = await createEvidenceDownloadUrl({
+      key: "disputes/dispute-1/file.pdf",
+      filename: "file.pdf",
+      contentType: "application/pdf",
+    });
+    const second = await createEvidenceDownloadUrl({
+      key: "disputes/dispute-1/file.pdf",
+      filename: "file.pdf",
+      contentType: "application/pdf",
+    });
+
+    expect(first).not.toBe(second);
+    expect(getSignedUrl).toHaveBeenCalledTimes(2);
+    expect(getSignedUrl).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { expiresIn: EVIDENCE_DOWNLOAD_EXPIRY_SECONDS },
+    );
+  });
+});

--- a/backend/src/services/evidence-storage.service.ts
+++ b/backend/src/services/evidence-storage.service.ts
@@ -1,0 +1,81 @@
+import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import fs from "fs";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { config } from "../config";
+
+export const EVIDENCE_DOWNLOAD_EXPIRY_SECONDS = 60;
+
+let s3Client: S3Client | undefined;
+
+function getS3Client() {
+  if (!s3Client) {
+    s3Client = new S3Client({
+      region: config.evidenceStorage.region,
+      endpoint: config.evidenceStorage.endpoint,
+      forcePathStyle: config.evidenceStorage.forcePathStyle,
+    });
+  }
+  return s3Client;
+}
+
+export function isEvidenceStorageConfigured(): boolean {
+  return Boolean(config.evidenceStorage.bucket);
+}
+
+function getBucket(): string {
+  const { bucket } = config.evidenceStorage;
+  if (!bucket) throw new Error("Evidence S3 storage is not configured");
+  return bucket;
+}
+
+export async function uploadEvidenceObject({
+  key,
+  filePath,
+  contentType,
+}: {
+  key: string;
+  filePath: string;
+  contentType: string;
+}): Promise<void> {
+  await getS3Client().send(
+    new PutObjectCommand({
+      Bucket: getBucket(),
+      Key: key,
+      Body: fs.createReadStream(filePath),
+      ContentType: contentType,
+    }),
+  );
+}
+
+export async function readEvidenceObject(key: string): Promise<Buffer> {
+  const result = await getS3Client().send(
+    new GetObjectCommand({ Bucket: getBucket(), Key: key }),
+  );
+  if (!result.Body) throw new Error("Evidence object not found");
+  return Buffer.from(await result.Body.transformToByteArray());
+}
+
+/**
+ * Creates a one-minute, attachment-specific URL. Evidence objects are private;
+ * callers must pass this URL on rather than exposing the bucket URL directly.
+ */
+export async function createEvidenceDownloadUrl({
+  key,
+  filename,
+  contentType,
+}: {
+  key: string;
+  filename: string;
+  contentType: string;
+}): Promise<string> {
+  return getSignedUrl(
+    getS3Client(),
+    new GetObjectCommand({
+      Bucket: getBucket(),
+      Key: key,
+      ResponseContentDisposition: `attachment; filename="${filename.replace(/["\\]/g, "_")}"`,
+      ResponseContentType: contentType,
+    }),
+    { expiresIn: EVIDENCE_DOWNLOAD_EXPIRY_SECONDS },
+  );
+}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_API_URL=http://localhost:5000/api
+NEXT_PUBLIC_PLATFORM_MIN_BUDGET_XLM=1
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
 
 # The canonical public URL of the site, used for OG tags and sitemap

--- a/frontend/src/app/jobs/page.tsx
+++ b/frontend/src/app/jobs/page.tsx
@@ -16,7 +16,7 @@ import {
   type ListImperativeAPI,
   type RowComponentProps,
 } from "react-window";
-import { Search, SlidersHorizontal, Briefcase, Loader2, Wifi, ArrowUp } from "lucide-react";
+import { Search, SlidersHorizontal, Briefcase, Loader2, Wifi, ArrowUp, X } from "lucide-react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import axios from "axios";
 import JobCard from "@/components/JobCard";
@@ -120,6 +120,7 @@ function JobsContent() {
     updateSearch,
     toggleArrayFilter,
     clearAll,
+    clearFilters,
     activeCount,
     postedAfterDate,
   } = useJobFilters();
@@ -350,6 +351,31 @@ function JobsContent() {
     [feedState, newJobIds, savedJobIds, debouncedSearch, toggleSavedJob, handleTagClick, dynamicRowHeight.observeRowElements],
   );
 
+  const activeFilters = useMemo(() => {
+    const items: Array<{ label: string; clear: () => void }> = [];
+    if (filters.category !== "All") {
+      items.push({ label: `Category: ${filters.category}`, clear: () => updateFilter("category", "All") });
+    }
+    filters.skills.forEach((skill) => items.push({
+      label: `Skill: ${skill}`,
+      clear: () => toggleArrayFilter("skills", skill),
+    }));
+    filters.status.forEach((status) => items.push({
+      label: `Status: ${status.replace("_", " ")}`,
+      clear: () => toggleArrayFilter("status", status),
+    }));
+    if (filters.minBudget) {
+      items.push({ label: `Min budget: ${filters.minBudget} XLM`, clear: () => updateFilter("minBudget", "") });
+    }
+    if (filters.maxBudget) {
+      items.push({ label: `Max budget: ${filters.maxBudget} XLM`, clear: () => updateFilter("maxBudget", "") });
+    }
+    if (filters.postedDate !== "all") {
+      items.push({ label: `Posted: ${filters.postedDate}`, clear: () => updateFilter("postedDate", "all") });
+    }
+    return items;
+  }, [filters, toggleArrayFilter, updateFilter]);
+
   return (
     <>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -493,22 +519,35 @@ function JobsContent() {
             ) : (
               <div role="status" aria-live="polite">
                 <EmptyState
-                  icon={Briefcase}
-                  title="No jobs found matching your filters."
-                  description="Try adjusting or clearing your filters to broaden the search."
-                  action={
-                    user?.role === "CLIENT"
-                      ? { label: "Post a Job", href: "/post-job" }
-                      : activeCount > 0
-                        ? { label: "Clear Filters", onClick: clearAll }
-                        : undefined
-                  }
-                  secondaryAction={
-                    user?.role === "CLIENT" && activeCount > 0
-                      ? { label: "Clear Filters", onClick: clearAll }
-                      : undefined
-                  }
-                />
+                  icon={Search}
+                  iconOverlay="?"
+                  title={debouncedSearch ? `No jobs found for ${debouncedSearch}` : "No jobs found"}
+                  description="Try clearing filters or browse all available jobs."
+                  action={{ label: "Browse all jobs", onClick: clearAll }}
+                  secondaryAction={{
+                    label: "Clear filters",
+                    onClick: activeCount > 0 ? clearFilters : clearAll,
+                  }}
+                >
+                  {activeFilters.length > 0 && (
+                    <div className="mb-6 max-w-lg" aria-label="Active filters">
+                      <p className="mb-2 text-sm font-medium text-theme-heading">Active filters</p>
+                      <div className="flex flex-wrap justify-center gap-2">
+                        {activeFilters.map((filter) => (
+                          <button
+                            key={filter.label}
+                            type="button"
+                            onClick={filter.clear}
+                            className="inline-flex items-center gap-1 rounded-full border border-theme-border bg-theme-card px-2.5 py-1 text-xs text-theme-text hover:border-stellar-blue hover:text-stellar-blue"
+                            aria-label={`Clear ${filter.label} filter`}
+                          >
+                            {filter.label} <X size={12} aria-hidden="true" />
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </EmptyState>
               </div>
             )}
           </div>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Navbar from "@/components/Navbar";
 import EmailVerificationBanner from "@/components/EmailVerificationBanner";
 import OfflineBanner from "@/components/OfflineBanner";
 import PushNotificationPrompt from "@/components/PushNotificationPrompt";
+import MobileNavigation from "@/components/MobileNavigation";
 import Footer from "@/components/Footer";
 import Providers from "./providers";
 
@@ -94,8 +95,9 @@ export default function RootLayout({
           <Navbar />
           <EmailVerificationBanner />
           <OfflineBanner />
-          <main id="main-content" className="min-h-screen">{children}</main>
+          <main id="main-content" className="min-h-screen pb-16 md:pb-0">{children}</main>
           <Footer />
+          <MobileNavigation />
           <PushNotificationPrompt />
         </Providers>
       </body>

--- a/frontend/src/app/post-job/page.tsx
+++ b/frontend/src/app/post-job/page.tsx
@@ -13,12 +13,20 @@ import { useWallet } from "@/context/WalletContext";
 import { JOB_CATEGORIES, JOB_SKILLS, PAYMENT_TOKENS } from "@/constants/jobs";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
+const configuredPlatformMinimum = Number(
+  process.env.NEXT_PUBLIC_PLATFORM_MIN_BUDGET_XLM || "1",
+);
+const PLATFORM_MIN_BUDGET_XLM =
+  Number.isFinite(configuredPlatformMinimum) && configuredPlatformMinimum > 0
+    ? configuredPlatformMinimum
+    : 1;
+const minimumBudgetMessage = `Budget must be at least ${PLATFORM_MIN_BUDGET_XLM} XLM.`;
 
 const milestoneSchema = z.object({
   title: z.string().min(3, "Milestone title is too short"),
   description: z.string().min(5, "Milestone description is too short"),
-  amount: z.string().refine((value) => Number.parseFloat(value) > 0, {
-    message: "Milestone amount must be greater than 0",
+  amount: z.string().refine((value) => Number.parseFloat(value) >= PLATFORM_MIN_BUDGET_XLM, {
+    message: minimumBudgetMessage,
   }),
   deadline: z.string().refine((value) => {
     if (!value) return false;
@@ -463,6 +471,8 @@ export default function PostJobPage() {
                       type="number"
                       placeholder="Amount (XLM)"
                       className="input-field"
+                      min={PLATFORM_MIN_BUDGET_XLM}
+                      step="0.0000001"
                       {...register(`milestones.${index}.amount`)}
                     />
                   </div>

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -19,6 +19,9 @@ interface EmptyStateProps {
     href?: string;
     onClick?: () => void;
   };
+  /** Small marker layered over the illustration, e.g. a question mark. */
+  iconOverlay?: string;
+  children?: React.ReactNode;
 }
 
 export default function EmptyState({
@@ -27,15 +30,24 @@ export default function EmptyState({
   description,
   action,
   secondaryAction,
+  iconOverlay,
+  children,
 }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center text-center py-20 px-4">
-      <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-theme-card border border-theme-border mb-6">
+      <div className="relative inline-flex items-center justify-center w-20 h-20 rounded-full bg-theme-card border border-theme-border mb-6">
         <Icon className="text-stellar-blue" size={36} />
+        {iconOverlay && (
+          <span className="absolute -right-1 -bottom-1 flex h-7 w-7 items-center justify-center rounded-full border-2 border-theme-bg bg-stellar-purple text-sm font-bold text-white" aria-hidden="true">
+            {iconOverlay}
+          </span>
+        )}
       </div>
 
       <h3 className="text-xl font-semibold text-theme-heading mb-2">{title}</h3>
       <p className="text-theme-text max-w-sm mx-auto mb-6">{description}</p>
+
+      {children}
 
       <div className="flex flex-col sm:flex-row items-center gap-3">
         {action && (

--- a/frontend/src/components/EvidenceViewer.tsx
+++ b/frontend/src/components/EvidenceViewer.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import {
   FileText,
   ExternalLink,
+  Download,
   Shield,
   ShieldAlert,
   ShieldCheck,
@@ -38,6 +39,7 @@ export default function EvidenceViewer({
     Record<string, VerificationState>
   >({});
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const listRef = useRef<HTMLUListElement>(null);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
@@ -110,6 +112,28 @@ export default function EvidenceViewer({
     [disputeId],
   );
 
+  const downloadItem = useCallback(async (item: DisputeEvidence) => {
+    setDownloadingId(item.id);
+    try {
+      const token = localStorage.getItem("token");
+      const response = await axios.get(
+        `${API_URL}/disputes/${disputeId}/evidence/${item.id}/download`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          responseType: "blob",
+        },
+      );
+      const url = URL.createObjectURL(response.data);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = item.fileName;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setDownloadingId(null);
+    }
+  }, [disputeId]);
+
   if (loading) {
     return (
       <div className="card">
@@ -178,22 +202,25 @@ export default function EvidenceViewer({
                   <p className="text-sm font-medium text-theme-heading truncate max-w-[220px]">
                     {item.fileName}
                   </p>
-                  <p className="text-[10px] text-theme-text-muted">
-                    {item.fileType}
-                    {item.sizeFormatted && ` · ${item.sizeFormatted}`}
-                  </p>
+                  <div className="mt-1 flex items-center gap-1.5 text-[10px] text-theme-text-muted">
+                    <span className="rounded-full bg-stellar-blue/10 px-1.5 py-0.5 font-medium text-stellar-blue">
+                      {item.fileType}
+                    </span>
+                    {item.sizeFormatted && <span>{item.sizeFormatted}</span>}
+                  </div>
                 </button>
-                {item.url && (
-                  <a
-                    href={`${API_URL.replace("/api", "")}${item.url}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1 text-xs text-stellar-blue hover:underline flex-shrink-0 ml-3"
-                    aria-label={`View or download ${item.fileName}`}
+                <div className="flex items-center gap-3 flex-shrink-0 ml-3">
+                  <button
+                    type="button"
+                    onClick={() => downloadItem(item)}
+                    disabled={downloadingId === item.id}
+                    className="flex items-center gap-1 text-xs text-stellar-blue hover:underline disabled:opacity-50"
+                    aria-label={`Download ${item.fileName}`}
                   >
-                    View <ExternalLink size={11} />
-                  </a>
-                )}
+                    {downloadingId === item.id ? <Loader2 size={11} className="animate-spin" /> : <Download size={11} />}
+                    Download
+                  </button>
+                </div>
               </div>
  
               {item.sha256 && (

--- a/frontend/src/components/MobileNavigation.tsx
+++ b/frontend/src/components/MobileNavigation.tsx
@@ -1,87 +1,49 @@
-'use client';
+"use client";
 
-import React, { useState } from 'react';
-import { Menu, X, Home, Briefcase, Users, MessageSquare, Settings, User } from 'lucide-react';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import Link from "next/link";
+import { Briefcase, LayoutDashboard, ShieldCheck, User } from "lucide-react";
+import { usePathname } from "next/navigation";
 
 const navigationItems = [
-  { href: '/dashboard', icon: Home, label: 'Dashboard' },
-  { href: '/jobs', icon: Briefcase, label: 'Jobs' },
-  { href: '/freelancers', icon: Users, label: 'Freelancers' },
-  { href: '/messages', icon: MessageSquare, label: 'Messages' },
-  { href: '/profile', icon: User, label: 'Profile' },
-  { href: '/settings', icon: Settings, label: 'Settings' },
+  { href: "/dashboard", icon: LayoutDashboard, label: "Dashboard" },
+  { href: "/jobs", icon: Briefcase, label: "Jobs" },
+  { href: "/disputes", icon: ShieldCheck, label: "Disputes" },
+  { href: "/profile", icon: User, label: "Profile" },
 ];
 
 export default function MobileNavigation() {
-  const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
 
-  const toggleMenu = () => setIsOpen(!isOpen);
-  const closeMenu = () => setIsOpen(false);
-
   return (
-    <>
-      {/* Mobile menu button */}
-      <button
-        onClick={toggleMenu}
-        className="md:hidden fixed top-4 left-4 z-50 p-2 bg-theme-card rounded-lg shadow-lg border border-theme-border"
-        aria-label="Toggle navigation menu"
-      >
-        {isOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
-      </button>
+    <nav
+      aria-label="Mobile navigation"
+      className="fixed inset-x-0 bottom-0 z-40 flex h-16 items-stretch border-t border-theme-border bg-theme-card/95 px-2 backdrop-blur md:hidden"
+    >
+      {navigationItems.map((item) => {
+        const Icon = item.icon;
+        const isActive = pathname === item.href || pathname?.startsWith(`${item.href}/`);
 
-      {/* Backdrop */}
-      {isOpen && (
-        <div
-          className="fixed inset-0 bg-black bg-opacity-50 z-40 md:hidden"
-          onClick={closeMenu}
-        />
-      )}
-
-      {/* Mobile navigation drawer */}
-      <div
-        className={`fixed top-0 left-0 h-full w-64 bg-theme-bg shadow-xl z-50 transform transition-transform duration-300 ease-in-out md:hidden ${
-          isOpen ? 'translate-x-0' : '-translate-x-full'
-        }`}
-      >
-        <div className="p-6">
-          <div className="flex items-center justify-between mb-8">
-            <h2 className="text-xl font-bold text-theme-heading">StellarMarket</h2>
-            <button
-              onClick={closeMenu}
-              className="p-1 rounded-lg hover:bg-theme-bg-secondary"
-              aria-label="Close menu"
-            >
-              <X className="w-5 h-5" />
-            </button>
-          </div>
-
-          <nav className="space-y-2">
-            {navigationItems.map((item) => {
-              const Icon = item.icon;
-              const isActive = pathname === item.href;
-              
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  onClick={closeMenu}
-                  className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
-                    isActive
-                      ? 'bg-stellar-blue/10 text-stellar-blue border-r-2 border-stellar-blue'
-                      : 'text-theme-text hover:bg-theme-bg-secondary'
-                  }`}
-                >
-                  <Icon className="w-5 h-5" />
-                  <span className="font-medium">{item.label}</span>
-                </Link>
-              );
-            })}
-          </nav>
-        </div>
-      </div>
-    </>
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-label={item.label}
+            aria-current={isActive ? "page" : undefined}
+            data-active={isActive ? "true" : "false"}
+            className={`relative flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 rounded-md transition-colors ${
+              isActive
+                ? "active text-stellar-blue font-bold"
+                : "text-theme-text hover:text-theme-heading"
+            }`}
+          >
+            <Icon size={isActive ? 22 : 20} strokeWidth={isActive ? 2.75 : 2} />
+            <span className={isActive ? "text-[10px] leading-none" : "hidden min-[420px]:block text-[10px] leading-none"}>
+              {item.label}
+            </span>
+            {isActive && <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-t bg-stellar-blue" aria-hidden="true" />}
+          </Link>
+        );
+      })}
+    </nav>
   );
 }

--- a/frontend/src/components/__tests__/EvidenceViewer.test.tsx
+++ b/frontend/src/components/__tests__/EvidenceViewer.test.tsx
@@ -1,0 +1,48 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import axios from "axios";
+import EvidenceViewer from "@/components/EvidenceViewer";
+
+jest.mock("axios", () => ({ get: jest.fn() }));
+const mockGet = axios.get as jest.Mock;
+
+describe("EvidenceViewer", () => {
+  beforeEach(() => {
+    localStorage.setItem("token", "test-token");
+    Object.defineProperty(URL, "createObjectURL", { value: jest.fn(() => "blob:download"), writable: true });
+    Object.defineProperty(URL, "revokeObjectURL", { value: jest.fn(), writable: true });
+    jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+    mockGet.mockResolvedValue({ data: new Blob(["evidence"]) });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it("requests the protected signed-download endpoint", async () => {
+    render(
+      <EvidenceViewer
+        disputeId="dispute-1"
+        evidence={[{
+          id: "evidence-1",
+          fileName: "contract.pdf",
+          fileType: "application/pdf",
+          sizeFormatted: "42 KB",
+          uploadedAt: "2026-01-01T00:00:00.000Z",
+        }]}
+      />,
+    );
+
+    expect(screen.getByText("application/pdf")).toBeInTheDocument();
+    expect(screen.getByText("42 KB")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Download contract.pdf" }));
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        "http://localhost:5000/api/disputes/dispute-1/evidence/evidence-1/download",
+        expect.objectContaining({ responseType: "blob" }),
+      );
+    });
+  });
+});

--- a/frontend/src/components/__tests__/MobileNavigation.test.tsx
+++ b/frontend/src/components/__tests__/MobileNavigation.test.tsx
@@ -1,0 +1,32 @@
+import "@testing-library/jest-dom";
+import type React from "react";
+import { render, screen } from "@testing-library/react";
+import MobileNavigation from "@/components/MobileNavigation";
+
+let pathname = "/jobs";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+describe("MobileNavigation", () => {
+  it("moves the active indicator after client-side navigation", () => {
+    const { rerender } = render(<MobileNavigation />);
+
+    expect(screen.getByRole("link", { name: "Jobs" })).toHaveAttribute("data-active", "true");
+    expect(screen.getByRole("link", { name: "Disputes" })).toHaveAttribute("data-active", "false");
+
+    pathname = "/disputes";
+    rerender(<MobileNavigation />);
+
+    expect(screen.getByRole("link", { name: "Jobs" })).toHaveAttribute("data-active", "false");
+    expect(screen.getByRole("link", { name: "Disputes" })).toHaveAttribute("data-active", "true");
+  });
+});

--- a/frontend/src/hooks/useJobFilters.ts
+++ b/frontend/src/hooks/useJobFilters.ts
@@ -135,6 +135,17 @@ export function useJobFilters() {
     syncToUrl(DEFAULTS);
   }, [syncToUrl]);
 
+  // Keep a search query while removing the narrowing filters. This is useful
+  // from the zero-results state: users can broaden a search without retyping it.
+  const clearFilters = useCallback(() => {
+    setFilters((prev) => {
+      const next = { ...DEFAULTS, search: prev.search };
+      setDebouncedSearch(prev.search);
+      syncToUrl(next);
+      return next;
+    });
+  }, [syncToUrl]);
+
   const activeCount = useMemo(() => {
     let count = 0;
     if (filters.category !== "All") count++;
@@ -173,6 +184,7 @@ export function useJobFilters() {
     updateSearch,
     toggleArrayFilter,
     clearAll,
+    clearFilters,
     activeCount,
     postedAfterDate,
   };


### PR DESCRIPTION
feat: improve job discovery, evidence review, mobile navigation, and budget validation

Closes #725
Closes #727 
Closes #728 
Closes #734 

- Adds a query-aware zero-results state with clear/browse actions and removable filter chips.
- Adds private S3-backed evidence downloads using fresh 60-second presigned URLs, plus file type and size badges.
- Adds an active-route indicator to the mobile bottom navigation.
- Enforces configurable platform minimum job budgets on both client and server, returning `422 BudgetBelowMinimum` for invalid posts.
- Adds focused coverage for minimum-budget validation, evidence URL expiry behavior, mobile active navigation, and evidence download requests.