### PR TITLE
 Issue #722 Milestone submission form has no draft autosave — users lose work if the tab is closed or the session expires

### DIFF
--- a/frontend/src/app/jobs/[id]/JobDetailClient.tsx
+++ b/frontend/src/app/jobs/[id]/JobDetailClient.tsx
@@ -25,7 +25,9 @@ import StatusBadge from "@/components/StatusBadge";
 import ApplyModal from "@/components/ApplyModal";
 import RaiseDisputeModal from "@/components/RaiseDisputeModal";
 import ReviewModal from "@/components/ReviewModal";
-import MilestoneTimeline from "@/components/MilestoneTimeline";
+import MilestoneTimeline, {
+  getMilestoneDraftKey,
+} from "@/components/MilestoneTimeline";
 import MilestoneProgressTracker from "@/components/MilestoneProgressTracker";
 import TransactionConfirmationModal from "@/components/TransactionConfirmationModal";
 import DepositRateInfo from "@/components/DepositRateInfo";
@@ -330,6 +332,21 @@ export default function JobDetailClient() {
         action.milestoneId
       ) {
         setRecentlyApprovedMilestoneId(action.milestoneId);
+      }
+
+      if (
+        action.confirmType === "SUBMIT_MILESTONE" &&
+        action.milestoneId &&
+        job
+      ) {
+        const milestoneIndex = job.milestones.findIndex(
+          (milestone) => milestone.id === action.milestoneId,
+        );
+        if (milestoneIndex !== -1) {
+          window.localStorage.removeItem(
+            getMilestoneDraftKey(job.id, milestoneIndex),
+          );
+        }
       }
 
       if (action.confirmType === "PROPOSE_REVISION") {

--- a/frontend/src/components/MilestoneTimeline.tsx
+++ b/frontend/src/components/MilestoneTimeline.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { ChangeEvent } from "react";
+import { useEffect, useState } from "react";
 import {
   CheckCircle,
   Loader2,
@@ -15,11 +17,32 @@ import StatusBadge from "@/components/StatusBadge";
 import type { Milestone } from "@/types";
 import { useOfflineStatus } from "@/hooks/useOfflineStatus";
 
+const DRAFT_SAVE_DELAY_MS = 2000;
+
+export type MilestoneSubmissionDraft = {
+  description: string;
+  links: string;
+  attachmentNames: string[];
+};
+
+const emptySubmissionDraft: MilestoneSubmissionDraft = {
+  description: "",
+  links: "",
+  attachmentNames: [],
+};
+
+export function getMilestoneDraftKey(jobId: string, milestoneIndex: number) {
+  return `milestone_draft_${jobId}_${milestoneIndex}`;
+}
+
 type MilestoneTimelineProps = {
   milestones: Milestone[];
   isClient: boolean;
   isFreelancerOnJob: boolean;
-  onSubmitMilestone: (milestoneId: string) => void;
+  onSubmitMilestone: (
+    milestoneId: string,
+    draft?: MilestoneSubmissionDraft,
+  ) => void;
   onApproveMilestone: (milestoneId: string) => void;
   onRequestRevision: (milestoneId: string) => void;
   actioningMilestoneId: string | null;
@@ -80,6 +103,224 @@ function formatDeadline(deadline: string | Date | null | undefined): string {
   }
 }
 
+function hasDraftContent(draft: MilestoneSubmissionDraft) {
+  return (
+    draft.description.trim().length > 0 ||
+    draft.links.trim().length > 0 ||
+    draft.attachmentNames.length > 0
+  );
+}
+
+type MilestoneSubmissionFormProps = {
+  milestone: Milestone;
+  milestoneIndex: number;
+  isActioning: boolean;
+  isOffline: boolean;
+  onSubmitMilestone: (
+    milestoneId: string,
+    draft?: MilestoneSubmissionDraft,
+  ) => void;
+};
+
+function MilestoneSubmissionForm({
+  milestone,
+  milestoneIndex,
+  isActioning,
+  isOffline,
+  onSubmitMilestone,
+}: MilestoneSubmissionFormProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [draft, setDraft] = useState<MilestoneSubmissionDraft>(
+    emptySubmissionDraft,
+  );
+  const [draftRestored, setDraftRestored] = useState(false);
+  const draftKey = getMilestoneDraftKey(milestone.jobId, milestoneIndex);
+
+  useEffect(() => {
+    try {
+      const savedDraft = window.localStorage.getItem(draftKey);
+      if (!savedDraft) return;
+
+      const parsed = JSON.parse(savedDraft) as Partial<MilestoneSubmissionDraft>;
+      const restoredDraft = {
+        description: parsed.description ?? "",
+        links: parsed.links ?? "",
+        attachmentNames: Array.isArray(parsed.attachmentNames)
+          ? parsed.attachmentNames.filter((name) => typeof name === "string")
+          : [],
+      };
+
+      setDraft(restoredDraft);
+      setDraftRestored(true);
+      setIsOpen(true);
+    } catch {
+      window.localStorage.removeItem(draftKey);
+    }
+  }, [draftKey]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      try {
+        if (hasDraftContent(draft)) {
+          window.localStorage.setItem(draftKey, JSON.stringify(draft));
+        } else {
+          window.localStorage.removeItem(draftKey);
+        }
+      } catch {
+        // Ignore storage errors so milestone submission remains usable.
+      }
+    }, DRAFT_SAVE_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [draft, draftKey]);
+
+  const discardDraft = () => {
+    window.localStorage.removeItem(draftKey);
+    setDraft(emptySubmissionDraft);
+    setDraftRestored(false);
+  };
+
+  const handleFilesChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setDraft((current) => ({
+      ...current,
+      attachmentNames: Array.from(event.target.files ?? []).map(
+        (file) => file.name,
+      ),
+    }));
+  };
+
+  if (!isOpen) {
+    return (
+      <div className="relative group">
+        <button
+          type="button"
+          disabled={isActioning || isOffline}
+          onClick={() => setIsOpen(true)}
+          className="btn-primary py-1.5 text-xs flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isActioning ? (
+            <Loader2 className="animate-spin" size={14} />
+          ) : isOffline ? (
+            <WifiOff size={14} />
+          ) : (
+            <CheckCircle size={14} />
+          )}
+          Submit Milestone
+        </button>
+        {isOffline && (
+          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-xs rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+            Blockchain transactions require an internet connection
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full rounded-lg border border-theme-border bg-theme-card p-3">
+      {draftRestored && (
+        <div
+          role="status"
+          className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-theme-info/30 bg-theme-info/10 px-3 py-2 text-xs text-theme-heading"
+        >
+          <span>Draft restored</span>
+          <button
+            type="button"
+            onClick={discardDraft}
+            className="font-semibold text-stellar-blue hover:underline"
+          >
+            Discard draft
+          </button>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-theme-heading">
+            Description
+          </span>
+          <textarea
+            value={draft.description}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                description: event.target.value,
+              }))
+            }
+            rows={3}
+            className="w-full rounded-md border border-theme-border bg-theme-bg px-3 py-2 text-sm text-theme-heading focus:border-stellar-blue focus:outline-none"
+            placeholder="Summarize what is ready for review."
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-theme-heading">
+            Links
+          </span>
+          <textarea
+            value={draft.links}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                links: event.target.value,
+              }))
+            }
+            rows={2}
+            className="w-full rounded-md border border-theme-border bg-theme-bg px-3 py-2 text-sm text-theme-heading focus:border-stellar-blue focus:outline-none"
+            placeholder="Add review links, one per line."
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-theme-heading">
+            Attachments
+          </span>
+          <input
+            type="file"
+            multiple
+            onChange={handleFilesChange}
+            className="block w-full text-xs text-theme-text file:mr-3 file:rounded-md file:border-0 file:bg-stellar-blue file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white"
+          />
+        </label>
+
+        {draft.attachmentNames.length > 0 && (
+          <ul className="space-y-1 text-xs text-theme-text">
+            {draft.attachmentNames.map((name) => (
+              <li key={name}>{name}</li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            disabled={isActioning || isOffline}
+            onClick={() => onSubmitMilestone(milestone.id, draft)}
+            className="btn-primary py-1.5 text-xs flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isActioning ? (
+              <Loader2 className="animate-spin" size={14} />
+            ) : isOffline ? (
+              <WifiOff size={14} />
+            ) : (
+              <CheckCircle size={14} />
+            )}
+            Submit Milestone
+          </button>
+          <button
+            type="button"
+            disabled={isActioning}
+            onClick={() => setIsOpen(false)}
+            className="btn-secondary py-1.5 text-xs disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function MilestoneTimeline({
   milestones,
   isClient,
@@ -100,6 +341,20 @@ export default function MilestoneTimeline({
   const progressPct = totalCount
     ? Math.round((completedCount / totalCount) * 100)
     : 0;
+
+  useEffect(() => {
+    try {
+      milestones.forEach((milestone, index) => {
+        if (milestone.status !== "IN_PROGRESS") {
+          window.localStorage.removeItem(
+            getMilestoneDraftKey(milestone.jobId, index),
+          );
+        }
+      });
+    } catch {
+      // Ignore storage errors so timeline status updates keep rendering.
+    }
+  }, [milestones]);
 
   return (
     <div className="space-y-5">
@@ -231,28 +486,13 @@ export default function MilestoneTimeline({
                   <div className="mt-4 flex flex-wrap gap-2">
                     {isFreelancerOnJob &&
                       milestone.status === "IN_PROGRESS" && (
-                        <div className="relative group">
-                          <button
-                            type="button"
-                            disabled={isActioning || isOffline}
-                            onClick={() => onSubmitMilestone(milestone.id)}
-                            className="btn-primary py-1.5 text-xs flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                          >
-                            {isActioning ? (
-                              <Loader2 className="animate-spin" size={14} />
-                            ) : isOffline ? (
-                              <WifiOff size={14} />
-                            ) : (
-                              <CheckCircle size={14} />
-                            )}
-                            Submit Milestone
-                          </button>
-                          {isOffline && (
-                            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-xs rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
-                              Blockchain transactions require an internet connection
-                            </div>
-                          )}
-                        </div>
+                        <MilestoneSubmissionForm
+                          milestone={milestone}
+                          milestoneIndex={index}
+                          isActioning={isActioning}
+                          isOffline={isOffline}
+                          onSubmitMilestone={onSubmitMilestone}
+                        />
                       )}
 
                     {isClient && milestone.status === "SUBMITTED" && (

--- a/frontend/src/components/__tests__/MilestoneTimeline.test.tsx
+++ b/frontend/src/components/__tests__/MilestoneTimeline.test.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MilestoneTimeline, {
+  getMilestoneDraftKey,
+} from "../MilestoneTimeline";
+import type { Milestone } from "@/types";
+
+jest.mock("@/hooks/useOfflineStatus", () => ({
+  useOfflineStatus: () => ({ isOnline: true, hasPendingSync: false }),
+}));
+
+const baseMilestone: Milestone = {
+  id: "milestone-1",
+  jobId: "job-1",
+  title: "Design handoff",
+  description: "Final screens and notes",
+  amount: 250,
+  status: "IN_PROGRESS",
+  order: 0,
+  contractDeadline: "2026-08-01T00:00:00.000Z",
+};
+
+function renderTimeline(
+  milestone: Milestone = baseMilestone,
+  onSubmitMilestone = jest.fn(),
+) {
+  return render(
+    <MilestoneTimeline
+      milestones={[milestone]}
+      isClient={false}
+      isFreelancerOnJob
+      onSubmitMilestone={onSubmitMilestone}
+      onApproveMilestone={jest.fn()}
+      onRequestRevision={jest.fn()}
+      actioningMilestoneId={null}
+      recentlyApprovedMilestoneId={null}
+    />,
+  );
+}
+
+describe("MilestoneTimeline draft persistence", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    window.localStorage.clear();
+  });
+
+  test("saves milestone submission draft to localStorage within two seconds", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const draftKey = getMilestoneDraftKey("job-1", 0);
+
+    renderTimeline();
+
+    await user.click(screen.getByRole("button", { name: /submit milestone/i }));
+    await user.type(
+      screen.getByLabelText(/description/i),
+      "The prototype is ready for review.",
+    );
+    await user.type(screen.getByLabelText(/links/i), "https://example.com/demo");
+    await user.upload(
+      screen.getByLabelText(/attachments/i),
+      new File(["notes"], "handoff-notes.txt", { type: "text/plain" }),
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(JSON.parse(window.localStorage.getItem(draftKey) ?? "{}")).toEqual({
+      description: "The prototype is ready for review.",
+      links: "https://example.com/demo",
+      attachmentNames: ["handoff-notes.txt"],
+    });
+  });
+
+  test("restores a saved draft on remount with a visible banner", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const draftKey = getMilestoneDraftKey("job-1", 0);
+
+    const firstRender = renderTimeline();
+    await user.click(screen.getByRole("button", { name: /submit milestone/i }));
+    await user.type(screen.getByLabelText(/description/i), "Ready for QA.");
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    firstRender.unmount();
+    renderTimeline();
+
+    expect(screen.getByRole("status")).toHaveTextContent("Draft restored");
+    expect(screen.getByRole("button", { name: /discard draft/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/description/i)).toHaveValue("Ready for QA.");
+    expect(window.localStorage.getItem(draftKey)).not.toBeNull();
+  });
+
+  test("clears the draft after the milestone is submitted successfully", () => {
+    const draftKey = getMilestoneDraftKey("job-1", 0);
+    window.localStorage.setItem(
+      draftKey,
+      JSON.stringify({
+        description: "Done.",
+        links: "",
+        attachmentNames: [],
+      }),
+    );
+
+    const { rerender } = renderTimeline();
+
+    rerender(
+      <MilestoneTimeline
+        milestones={[{ ...baseMilestone, status: "SUBMITTED" }]}
+        isClient={false}
+        isFreelancerOnJob
+        onSubmitMilestone={jest.fn()}
+        onApproveMilestone={jest.fn()}
+        onRequestRevision={jest.fn()}
+        actioningMilestoneId={null}
+        recentlyApprovedMilestoneId={null}
+      />,
+    );
+
+    expect(window.localStorage.getItem(draftKey)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds autosave for milestone submission drafts so freelancers do not lose description, links, or attachment selections after accidental navigation, tab close, or remounts.

Drafts are saved to `localStorage` under `milestone_draft_{jobId}_{milestoneIndex}` after a 2-second debounce, restored on mount with a “Draft restored” banner, and cleared after successful submission.

## Type of Change

- [ ] Bug Fixes
- [x] New feature

## Testing Done

Added focused frontend tests for milestone draft persistence behavior.

- [x] New tests added for changed behaviour

## Checklist

- [x] Changes are focused — one concern per PR
- [x] No unresolved merge conflicts

## Related Issue

Closes #722