### PR TITLE
feat(frontend): localise timestamps across dispute, evidence, milestone and notification views

### DIFF
--- a/frontend/src/components/ApplicationStatusTracker.tsx
+++ b/frontend/src/components/ApplicationStatusTracker.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { CheckCircle, Clock, XCircle, AlertCircle } from 'lucide-react';
+import LocalTimestamp from '@/components/LocalTimestamp';
 
 interface ApplicationStatusTrackerProps {
   status: 'pending' | 'accepted' | 'rejected' | 'withdrawn';
@@ -57,7 +58,7 @@ export default function ApplicationStatusTracker({
         <div>
           <h3 className="font-semibold text-theme-heading">{config.label}</h3>
           <p className="text-sm text-theme-text">
-            Submitted {new Date(submittedAt).toLocaleDateString()}
+            Submitted <LocalTimestamp isoString={submittedAt} />
           </p>
         </div>
       </div>
@@ -67,9 +68,7 @@ export default function ApplicationStatusTracker({
           <div className="flex items-center gap-2 text-sm">
             <div className="w-2 h-2 bg-stellar-blue rounded-full"></div>
             <span className="text-theme-text">Application submitted</span>
-            <span className="text-theme-text ml-auto">
-              {new Date(submittedAt).toLocaleString()}
-            </span>
+            <LocalTimestamp isoString={submittedAt} className="text-theme-text ml-auto" />
           </div>
           
           {status !== 'pending' && (
@@ -79,9 +78,10 @@ export default function ApplicationStatusTracker({
                 status === 'rejected' ? 'bg-theme-error' : 'bg-theme-text'
               }`}></div>
               <span className="text-theme-text">Status updated to {config.label.toLowerCase()}</span>
-              <span className="text-theme-text ml-auto">
-                {lastUpdated ? new Date(lastUpdated).toLocaleString() : 'Recently'}
-              </span>
+              {lastUpdated
+                ? <LocalTimestamp isoString={lastUpdated} className="text-theme-text ml-auto" />
+                : <span className="text-theme-text ml-auto">Recently</span>
+              }
             </div>
           )}
         </div>

--- a/frontend/src/components/DisputeTimeline.tsx
+++ b/frontend/src/components/DisputeTimeline.tsx
@@ -2,6 +2,7 @@
 
 import { CheckCircle, Circle, FileText, Scale, Gavel, Clock } from "lucide-react";
 import type { Dispute } from "@/types";
+import LocalTimestamp from "@/components/LocalTimestamp";
 
 interface DisputeTimelineProps {
   dispute: Dispute;
@@ -84,9 +85,10 @@ export default function DisputeTimeline({ dispute }: DisputeTimelineProps) {
                 <p className="text-xs text-theme-text mt-0.5">{ev.detail}</p>
               )}
               {ev.done && (
-                <time className="text-[10px] text-theme-text-muted">
-                  {new Date(ev.timestamp).toLocaleString()}
-                </time>
+                <LocalTimestamp
+                  isoString={ev.timestamp}
+                  className="text-[10px] text-theme-text-muted"
+                />
               )}
             </div>
           </li>

--- a/frontend/src/components/EvidenceViewer.tsx
+++ b/frontend/src/components/EvidenceViewer.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import axios from "axios";
 import type { DisputeEvidence, EvidenceVerification } from "@/types";
+import LocalTimestamp from "@/components/LocalTimestamp";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
 
@@ -307,7 +308,7 @@ export default function EvidenceViewer({
  
               <p className="text-[10px] text-theme-text-muted">
                 Uploaded{" "}
-                {new Date(item.uploadedAt).toLocaleString()}
+                <LocalTimestamp isoString={item.uploadedAt} />
                 {item.uploader && ` by ${item.uploader.username}`}
               </p>
             </li>

--- a/frontend/src/components/LocalTimestamp.tsx
+++ b/frontend/src/components/LocalTimestamp.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+/**
+ * Formats an ISO timestamp into the user's local timezone using Intl.DateTimeFormat.
+ * Example output: "15 Jun 2026, 10:32 PM"
+ */
+export function formatLocalTimestamp(isoString: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(new Date(isoString));
+}
+
+/**
+ * Formats an ISO timestamp as a UTC reference string for tooltip display.
+ * Example output: "UTC: 2026-06-15 14:32"
+ */
+export function formatUtcTimestamp(isoString: string): string {
+  const d = new Date(isoString);
+  const year = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  const hours = String(d.getUTCHours()).padStart(2, "0");
+  const minutes = String(d.getUTCMinutes()).padStart(2, "0");
+  return `UTC: ${year}-${month}-${day} ${hours}:${minutes}`;
+}
+
+interface LocalTimestampProps {
+  isoString: string;
+  className?: string;
+}
+
+/**
+ * Renders a locale-aware timestamp with a hover tooltip showing the UTC equivalent.
+ * Replaces raw `new Date(ts).toISOString()` / `toLocaleString()` calls.
+ */
+export default function LocalTimestamp({ isoString, className }: LocalTimestampProps) {
+  return (
+    <time
+      dateTime={isoString}
+      title={formatUtcTimestamp(isoString)}
+      className={className}
+    >
+      {formatLocalTimestamp(isoString)}
+    </time>
+  );
+}

--- a/frontend/src/components/MilestoneProgressTracker.tsx
+++ b/frontend/src/components/MilestoneProgressTracker.tsx
@@ -3,6 +3,7 @@
 import { ArrowUpRight, AlertTriangle, CheckCircle2, Clock3, Circle } from "lucide-react";
 import Link from "next/link";
 import type { Milestone } from "@/types";
+import { formatLocalTimestamp, formatUtcTimestamp } from "@/components/LocalTimestamp";
 
 type TrackedMilestone = Milestone & {
   releaseTransactionHash?: string;
@@ -52,11 +53,7 @@ const statusMeta: Record<
 
 function formatDeadline(deadline?: string | null) {
   if (!deadline) return "No deadline";
-  return new Date(deadline).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+  return formatLocalTimestamp(deadline);
 }
 
 export default function MilestoneProgressTracker({
@@ -128,7 +125,10 @@ export default function MilestoneProgressTracker({
                       {milestone.contractDeadline && (
                         <>
                           {" "}
-                          · due {formatDeadline(milestone.contractDeadline)}
+                          ·{" "}
+                          <span title={formatUtcTimestamp(milestone.contractDeadline)}>
+                            due {formatDeadline(milestone.contractDeadline)}
+                          </span>
                         </>
                       )}
                     </div>

--- a/frontend/src/components/MilestoneTimeline.tsx
+++ b/frontend/src/components/MilestoneTimeline.tsx
@@ -16,6 +16,7 @@ import {
 import StatusBadge from "@/components/StatusBadge";
 import type { Milestone } from "@/types";
 import { useOfflineStatus } from "@/hooks/useOfflineStatus";
+import { formatLocalTimestamp, formatUtcTimestamp } from "@/components/LocalTimestamp";
 
 const DRAFT_SAVE_DELAY_MS = 2000;
 
@@ -99,8 +100,13 @@ function formatDeadline(deadline: string | Date | null | undefined): string {
   } else if (diffDays <= 7) {
     return `Due in ${diffDays} days`;
   } else {
-    return date.toLocaleDateString();
+    return formatLocalTimestamp(String(deadline));
   }
+}
+
+function getDeadlineUtcTitle(deadline: string | Date | null | undefined): string | undefined {
+  if (!deadline) return undefined;
+  return formatUtcTimestamp(String(deadline));
 }
 
 function hasDraftContent(draft: MilestoneSubmissionDraft) {
@@ -444,6 +450,7 @@ export default function MilestoneTimeline({
                         </span>
                         {(milestone.contractDeadline) && (
                           <span
+                            title={getDeadlineUtcTitle(milestone.contractDeadline)}
                             className={`text-xs flex items-center gap-1 ${
                               milestoneOverdue &&
                               milestone.status !== "APPROVED"

--- a/frontend/src/components/NotificationItem.tsx
+++ b/frontend/src/components/NotificationItem.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { Notification, NotificationType } from "@/types";
 import { formatRelativeTime } from "@/utils/date";
+import { formatLocalTimestamp, formatUtcTimestamp } from "@/components/LocalTimestamp";
 
 interface NotificationItemProps {
   notification: Notification;
@@ -102,9 +103,13 @@ export default function NotificationItem({
         <p className="text-xs text-theme-text line-clamp-2 mt-0.5">
           {notification.message}
         </p>
-        <p className="text-[10px] text-theme-text/60 mt-1">
+        <time
+          dateTime={notification.createdAt}
+          title={`${formatLocalTimestamp(notification.createdAt)} · ${formatUtcTimestamp(notification.createdAt)}`}
+          className="text-[10px] text-theme-text/60 mt-1 block"
+        >
           {formatRelativeTime(notification.createdAt)}
-        </p>
+        </time>
       </div>
     </Link>
   );

--- a/frontend/src/components/__tests__/LocalTimestamp.test.tsx
+++ b/frontend/src/components/__tests__/LocalTimestamp.test.tsx
@@ -1,0 +1,93 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import LocalTimestamp, {
+  formatLocalTimestamp,
+  formatUtcTimestamp,
+} from "@/components/LocalTimestamp";
+
+const ISO = "2026-06-15T14:32:00Z";
+
+describe("formatUtcTimestamp", () => {
+  it("formats UTC time as 'UTC: YYYY-MM-DD HH:MM'", () => {
+    expect(formatUtcTimestamp(ISO)).toBe("UTC: 2026-06-15 14:32");
+  });
+
+  it("zero-pads month, day, hours and minutes", () => {
+    expect(formatUtcTimestamp("2026-01-05T03:07:00Z")).toBe(
+      "UTC: 2026-01-05 03:07",
+    );
+  });
+});
+
+describe("formatLocalTimestamp in UTC+1 context", () => {
+  const RealDateTimeFormat = Intl.DateTimeFormat;
+
+  beforeEach(() => {
+    // Simulate a UTC+1 browser by forcing Europe/London (BST in June = UTC+1)
+    jest
+      .spyOn(global.Intl, "DateTimeFormat")
+      .mockImplementation(
+        (locale?: string | string[], options?: Intl.DateTimeFormatOptions) =>
+          new RealDateTimeFormat(locale, {
+            ...options,
+            timeZone: "Europe/London",
+          }),
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows 15 Jun 2026, 3:32 PM for UTC 14:32 in a UTC+1 context", () => {
+    const result = formatLocalTimestamp(ISO);
+    // BST (UTC+1) shifts 14:32 → 15:32 = 3:32 PM
+    expect(result).toMatch(/15 Jun 2026/);
+    expect(result).toMatch(/3:32/);
+    expect(result.toLowerCase()).toMatch(/pm/);
+  });
+});
+
+describe("LocalTimestamp component", () => {
+  const RealDateTimeFormat = Intl.DateTimeFormat;
+
+  beforeEach(() => {
+    jest
+      .spyOn(global.Intl, "DateTimeFormat")
+      .mockImplementation(
+        (locale?: string | string[], options?: Intl.DateTimeFormatOptions) =>
+          new RealDateTimeFormat(locale, {
+            ...options,
+            timeZone: "Europe/London",
+          }),
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders localised time text for UTC+1", () => {
+    render(<LocalTimestamp isoString={ISO} />);
+    const el = screen.getByRole("time");
+    expect(el.textContent).toMatch(/15 Jun 2026/);
+    expect(el.textContent).toMatch(/3:32/);
+    expect(el.textContent!.toLowerCase()).toMatch(/pm/);
+  });
+
+  it("tooltip shows UTC time", () => {
+    render(<LocalTimestamp isoString={ISO} />);
+    const el = screen.getByRole("time");
+    expect(el).toHaveAttribute("title", "UTC: 2026-06-15 14:32");
+  });
+
+  it("sets dateTime attribute to the original ISO string", () => {
+    render(<LocalTimestamp isoString={ISO} />);
+    expect(screen.getByRole("time")).toHaveAttribute("dateTime", ISO);
+  });
+
+  it("forwards className to the time element", () => {
+    render(<LocalTimestamp isoString={ISO} className="text-xs" />);
+    expect(screen.getByRole("time")).toHaveClass("text-xs");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a reusable `LocalTimestamp` component that uses `Intl.DateTimeFormat` with the user's detected local timezone to render timestamps in a human-friendly format (`15 Jun 2026, 10:32 PM`)
- Every rendered timestamp now has a hover tooltip showing the UTC equivalent (`UTC: 2026-06-15 14:32`) for cross-timezone reference
- No raw ISO strings or unformatted `toLocaleString()` / `toLocaleDateString()` calls remain in the targeted views

## Components updated

| Component | Change |
|-----------|--------|
| `DisputeTimeline` | Timeline event timestamps use `LocalTimestamp` |
| `EvidenceViewer` | Evidence upload timestamp uses `LocalTimestamp` |
| `MilestoneTimeline` | Deadline fallback uses `formatLocalTimestamp`; UTC tooltip added via `title` |
| `MilestoneProgressTracker` | Deadline display uses `formatLocalTimestamp`; UTC tooltip added |
| `ApplicationStatusTracker` | Submitted-at and last-updated timestamps use `LocalTimestamp` |
| `NotificationItem` | Relative-time display wrapped in `<time>` with full local + UTC tooltip |

## Tests

`LocalTimestamp.test.tsx` covers:
- `formatUtcTimestamp` always produces `UTC: YYYY-MM-DD HH:MM`
- `formatLocalTimestamp` in a mocked UTC+1 context renders `15 Jun 2026, 3:32 PM` for a UTC 14:32 input
- Component renders localised text and sets the correct `title` / `dateTime` attributes

## Test plan

- [ ] Open a dispute detail page — all timeline events show local time, tooltip shows UTC
- [ ] Upload evidence — uploaded-at shows local time with UTC tooltip
- [ ] Check milestone tracker — deadline shows local time with UTC tooltip on hover
- [ ] Check notifications page — relative time unchanged; hover tooltip shows full local + UTC time
- [ ] Run `npm test` in `frontend/` — `LocalTimestamp` suite passes

closes #745
closes #737