### PR TITLE
fix: soft-delete users and check deletedAt in JWT middleware

### DIFF
--- a/backend/prisma/migrations/20260627000000_add_user_deleted_at/migration.sql
+++ b/backend/prisma/migrations/20260627000000_add_user_deleted_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: add soft-delete column to User
+ALTER TABLE "User" ADD COLUMN "deletedAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -128,6 +128,7 @@ model User {
   isSuspended            Boolean   @default(false)
   suspendReason          String?
   suspendedAt            DateTime?
+  deletedAt              DateTime?
   isSuspiciousReporter   Boolean   @default(false)
   createdAt              DateTime  @default(now())
   updatedAt              DateTime  @updatedAt

--- a/backend/src/errors/codes.ts
+++ b/backend/src/errors/codes.ts
@@ -14,6 +14,7 @@ export const ErrorCodes = {
   UNEXPECTED_FIELD: "UNEXPECTED_FIELD",
   EXTERNAL_SERVICE_UNAVAILABLE: "EXTERNAL_SERVICE_UNAVAILABLE",
   RATE_LIMITED: "RATE_LIMITED",
+  ACCOUNT_DELETED: "ACCOUNT_DELETED",
 } as const;
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/backend/src/middleware/__tests__/auth.middleware.test.ts
+++ b/backend/src/middleware/__tests__/auth.middleware.test.ts
@@ -81,4 +81,27 @@ describe("authenticate middleware", () => {
     });
     expect(next).not.toHaveBeenCalled();
   });
+
+  it("returns 401 with ACCOUNT_DELETED for a soft-deleted user", async () => {
+    const req = {
+      headers: { authorization: "Bearer valid.token" },
+      path: "/dashboard",
+    } as AuthRequest;
+
+    (jwt.verify as jest.Mock).mockReturnValue({ userId: "deleted-user" });
+    prismaMock.user.findUnique.mockResolvedValue({
+      role: UserRole.CLIENT,
+      emailVerified: true,
+      deletedAt: new Date("2025-01-01"),
+    });
+
+    await authenticate(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({
+      error: "Account deleted.",
+      code: "ACCOUNT_DELETED",
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -47,11 +47,16 @@ export const authenticate = async (
 
     const user = await prisma.user.findUnique({
       where: { id: decoded.userId },
-      select: { role: true, emailVerified: true },
+      select: { role: true, emailVerified: true, deletedAt: true },
     });
 
     if (!user) {
       res.status(401).json({ error: "User not found." });
+      return;
+    }
+
+    if (user.deletedAt) {
+      res.status(401).json({ error: "Account deleted.", code: "ACCOUNT_DELETED" });
       return;
     }
 
@@ -108,11 +113,16 @@ export const requireAdmin = async (
     // Query database for user role
     const user = await prisma.user.findUnique({
       where: { id: decoded.userId },
-      select: { role: true },
+      select: { role: true, deletedAt: true },
     });
 
     if (!user) {
       res.status(401).json({ error: "User not found." });
+      return;
+    }
+
+    if (user.deletedAt) {
+      res.status(401).json({ error: "Account deleted.", code: "ACCOUNT_DELETED" });
       return;
     }
 
@@ -170,10 +180,10 @@ export const optionalAuthenticate = async (
 
     const user = await prisma.user.findUnique({
       where: { id: decoded.userId },
-      select: { role: true, emailVerified: true },
+      select: { role: true, emailVerified: true, deletedAt: true },
     });
 
-    if (!user) {
+    if (!user || user.deletedAt) {
       return next();
     }
 

--- a/backend/src/routes/__tests__/user.delete.test.ts
+++ b/backend/src/routes/__tests__/user.delete.test.ts
@@ -1,0 +1,146 @@
+import crypto from "crypto";
+
+const mockRefreshToken = {
+  updateMany: jest.fn(),
+};
+const mockUser = {
+  findUnique: jest.fn(),
+  update: jest.fn(),
+};
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => ({
+    refreshToken: mockRefreshToken,
+    user: mockUser,
+    $disconnect: jest.fn(),
+  })),
+  UserRole: {
+    CLIENT: "CLIENT",
+    FREELANCER: "FREELANCER",
+    ADMIN: "ADMIN",
+  },
+}));
+
+jest.mock("jsonwebtoken", () => ({
+  verify: jest.fn(),
+}));
+
+jest.mock("../../config", () => ({
+  config: {
+    jwtSecret: "test-secret",
+    frontendUrl: "http://localhost:3000",
+    stellar: {
+      networkPassphrase: "Test SDF Network ; September 2015",
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      secondaryRpcUrl: "https://soroban-testnet.stellar.org/secondary",
+      horizonUrl: "https://horizon-testnet.stellar.org",
+      escrowContractId: "CCJFT7373737",
+      disputeContractId: "CCJFT7373738",
+      reputationContractId: "CCJFT7373739",
+      nativeTokenId: "CDLZFC3SYJYDZT7K67VZ75YJBMKBAV27Z6Y6Z6Z6Z6Z6Z6Z6Z6Z6Z6Z",
+      keeperSecretKey: "",
+    },
+  },
+}));
+
+jest.mock("../../lib/logger", () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+  installRequestIdConsolePatch: jest.fn(),
+}));
+
+jest.mock("../../lib/cache", () => ({
+  invalidateCacheKey: jest.fn(),
+  generateUserCacheKey: jest.fn(),
+  cache: jest.fn(),
+}));
+
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import userRouter from "../user.routes";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/users", userRouter);
+  return app;
+}
+
+describe("DELETE /users/me", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 ACCOUNT_DELETED for a soft-deleted user", async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ userId: "deleted-user" });
+    mockUser.findUnique.mockResolvedValue({
+      role: "CLIENT",
+      emailVerified: true,
+      deletedAt: new Date("2025-01-01"),
+    });
+
+    const res = await request(app)
+      .get("/users/me")
+      .set("Authorization", "Bearer old.token");
+
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({
+      error: "Account deleted.",
+      code: "ACCOUNT_DELETED",
+    });
+  });
+
+  it("allows requests from non-deleted users", async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ userId: "active-user" });
+    mockUser.findUnique.mockResolvedValue({
+      id: "active-user",
+      username: "alice",
+      walletAddress: null,
+      email: "alice@test.com",
+      emailVerified: true,
+      password: "hashed",
+      bio: null,
+      avatarUrl: null,
+      role: "CLIENT",
+      skills: [],
+      availability: true,
+      completedOnboarding: true,
+      createdAt: new Date(),
+      deletedAt: null,
+    });
+
+    const res = await request(app)
+      .get("/users/me")
+      .set("Authorization", "Bearer valid.token");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("soft-deletes the user and revokes refresh tokens", async () => {
+    (jwt.verify as jest.Mock).mockReturnValue({ userId: "user-to-delete" });
+    mockUser.findUnique.mockResolvedValue({
+      role: "CLIENT",
+      emailVerified: true,
+      deletedAt: null,
+    });
+    mockUser.update.mockResolvedValue({ id: "user-to-delete", deletedAt: new Date() });
+    mockRefreshToken.updateMany.mockResolvedValue({ count: 3 });
+
+    const res = await request(app)
+      .delete("/users/me")
+      .set("Authorization", "Bearer valid.token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: "Account deleted." });
+    expect(mockUser.update).toHaveBeenCalledWith({
+      where: { id: "user-to-delete" },
+      data: { deletedAt: expect.any(Date) },
+    });
+    expect(mockRefreshToken.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-to-delete" },
+      data: { revoked: true },
+    });
+  });
+});

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -61,6 +61,24 @@ router.get("/me", authenticate, async (req: AuthRequest, res: Response) => {
   }
 });
 
+// DELETE /api/users/me — soft-delete current authenticated user's account
+router.delete("/me", authenticate, asyncHandler(async (req: AuthRequest, res: Response) => {
+  const userId = req.userId!;
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: { deletedAt: new Date() },
+  });
+
+  // Revoke all refresh tokens so any stored sessions are invalidated
+  await prisma.refreshToken.updateMany({
+    where: { userId },
+    data: { revoked: true },
+  });
+
+  res.json({ message: "Account deleted." });
+}));
+
 // PUT /api/users/me — update current authenticated user's profile
 router.put(
   "/me",


### PR DESCRIPTION
- Add deletedAt field to User model (soft-delete)
- New DELETE /users/me sets deletedAt and revokes all refresh tokens
- JWT middleware returns 401 ACCOUNT_DELETED for soft-deleted users
- Add ACCOUNT_DELETED error code
- Unit/integration tests for middleware and delete endpoint

closes #792 