### PR TITLE
fix: scope GET /disputes results to the requesting user's role (#803)

### DIFF
--- a/backend/src/__tests__/dispute-scoping.test.ts
+++ b/backend/src/__tests__/dispute-scoping.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for #803: GET /disputes must be scoped to the requesting user.
+ */
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+
+// ── Prisma mock ──────────────────────────────────────────────────────────────
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => ({
+    dispute: { findMany: jest.fn().mockResolvedValue([]), count: jest.fn().mockResolvedValue(0) },
+    attachment: { findMany: jest.fn(), findFirst: jest.fn(), create: jest.fn() },
+    $use: jest.fn(),
+  })),
+  DisputeStatus: { OPEN: "OPEN", RESOLVED: "RESOLVED" },
+  UserRole: { FREELANCER: "FREELANCER", CLIENT: "CLIENT", ADMIN: "ADMIN" },
+}));
+
+// ── DisputeService mock ──────────────────────────────────────────────────────
+const mockGetDisputes = jest.fn().mockResolvedValue({ disputes: [], pagination: { page: 1, limit: 20, total: 0, totalPages: 0 } });
+
+jest.mock("../services/dispute.service", () => ({
+  DisputeService: { getDisputes: mockGetDisputes },
+}));
+
+// ── Validation mock (pass-through) ──────────────────────────────────────────
+jest.mock("../middleware/validation", () => ({
+  validate: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+// ── asyncHandler mock (pass-through) ────────────────────────────────────────
+jest.mock("../middleware/error", () => ({
+  asyncHandler: (fn: Function) => (req: Request, res: Response, next: NextFunction) =>
+    Promise.resolve(fn(req, res, next)).catch(next),
+  errorHandler: (_err: unknown, _req: Request, res: Response, _next: NextFunction) =>
+    res.status(500).json({ error: "internal" }),
+}));
+
+// ── Configurable auth mock ───────────────────────────────────────────────────
+let mockUserId = "user-1";
+let mockUserRole = "FREELANCER";
+
+jest.mock("../middleware/auth", () => ({
+  authenticate: (req: any, _res: Response, next: NextFunction) => {
+    req.userId = mockUserId;
+    req.userRole = mockUserRole;
+    next();
+  },
+  AuthRequest: {},
+  requireAdmin: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+// ── Other mocks needed by the route file ────────────────────────────────────
+jest.mock("../config/upload", () => ({ upload: { array: () => (_: any, __: any, next: any) => next() }, UPLOAD_DIR: "/tmp" }));
+jest.mock("../services/evidence-storage.service", () => ({
+  createEvidenceDownloadUrl: jest.fn(),
+  isEvidenceStorageConfigured: jest.fn().mockReturnValue(false),
+  readEvidenceObject: jest.fn(),
+  uploadEvidenceObject: jest.fn(),
+}));
+jest.mock("../config", () => ({
+  config: { stellar: { horizonUrl: "https://horizon.stellar.org" }, evidenceStorage: { bucket: "test" } },
+  MAX_PAGE_SIZE: 100,
+}));
+jest.mock("../schemas/dispute", () => ({
+  createDisputeSchema: {},
+  castVoteSchema: {},
+  disputeIdParamSchema: {},
+  initRaiseDisputeSchema: {},
+  queryDisputesSchema: {},
+  resolveDisputeSchema: {},
+  webhookPayloadSchema: {},
+  confirmDisputeTransactionSchema: {},
+}));
+jest.mock("../utils/fileValidation", () => ({
+  validateFileMimeType: jest.fn(),
+  formatFileSize: jest.fn().mockReturnValue("0 B"),
+}));
+jest.mock("../lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import disputeRouter from "../routes/dispute.routes";
+
+const app = express();
+app.use(express.json());
+app.use("/api/disputes", disputeRouter);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetDisputes.mockResolvedValue({
+    disputes: [],
+    pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+  });
+});
+
+describe("GET /api/disputes — user scoping (#803)", () => {
+  it("freelancer only sees their own disputes (userFilter by freelancerId)", async () => {
+    mockUserId = "freelancer-1";
+    mockUserRole = "FREELANCER";
+
+    await request(app).get("/api/disputes");
+
+    expect(mockGetDisputes).toHaveBeenCalledWith(
+      expect.objectContaining({ userFilter: { freelancerId: "freelancer-1" } }),
+      expect.any(Object),
+    );
+  });
+
+  it("client only sees their own disputes (userFilter by clientId)", async () => {
+    mockUserId = "client-1";
+    mockUserRole = "CLIENT";
+
+    await request(app).get("/api/disputes");
+
+    expect(mockGetDisputes).toHaveBeenCalledWith(
+      expect.objectContaining({ userFilter: { clientId: "client-1" } }),
+      expect.any(Object),
+    );
+  });
+
+  it("admin sees all disputes (no userFilter applied)", async () => {
+    mockUserId = "admin-1";
+    mockUserRole = "ADMIN";
+
+    await request(app).get("/api/disputes");
+
+    expect(mockGetDisputes).toHaveBeenCalledWith(
+      expect.objectContaining({ userFilter: undefined }),
+      expect.any(Object),
+    );
+  });
+
+  it("user with no disputes receives an empty array", async () => {
+    mockUserId = "freelancer-empty";
+    mockUserRole = "FREELANCER";
+    mockGetDisputes.mockResolvedValue({
+      disputes: [],
+      pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+    });
+
+    const res = await request(app).get("/api/disputes");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("returns 403 for unrecognised roles", async () => {
+    mockUserId = "unknown-1";
+    mockUserRole = "UNKNOWN_ROLE";
+
+    const res = await request(app).get("/api/disputes");
+
+    expect(res.status).toBe(403);
+    expect(mockGetDisputes).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/dispute.routes.ts
+++ b/backend/src/routes/dispute.routes.ts
@@ -80,7 +80,8 @@ router.get(
 
 /**
  * GET /api/disputes
- * Get all disputes with optional filtering and pagination
+ * Get disputes scoped to the requesting user's role.
+ * Freelancers see their own disputes; clients see theirs; admins see all.
  */
 router.get(
   "/",
@@ -88,9 +89,24 @@ router.get(
   validate({ query: queryDisputesSchema }),
   asyncHandler(async (req: AuthRequest, res: Response) => {
     const query = req.query as unknown as { page: number; limit: number };
+    const userId = req.userId!;
+    const role = req.userRole;
+
+    let userFilter: Record<string, unknown> | undefined;
+
+    if (role === UserRole.FREELANCER) {
+      userFilter = { freelancerId: userId };
+    } else if (role === UserRole.CLIENT) {
+      userFilter = { clientId: userId };
+    } else if (role === UserRole.ADMIN) {
+      userFilter = undefined;
+    } else {
+      res.status(403).json({ error: "Access denied." });
+      return;
+    }
 
     const result = await DisputeService.getDisputes(
-      { status: DisputeStatus.OPEN },
+      { status: DisputeStatus.OPEN, userFilter },
       { page: query.page, limit: query.limit },
     );
 

--- a/backend/src/services/dispute.service.ts
+++ b/backend/src/services/dispute.service.ts
@@ -464,14 +464,14 @@ export class DisputeService {
    * Get disputes with filtering and pagination
    */
   static async getDisputes(
-    filters: { status?: DisputeStatus },
+    filters: { status?: DisputeStatus; userFilter?: Record<string, unknown> },
     pagination: { page: number; limit: number },
   ) {
-    const { status } = filters;
+    const { status, userFilter } = filters;
     const { page, limit } = pagination;
     const skip = (page - 1) * limit;
 
-    const where = status ? { status } : {};
+    const where = { ...(status ? { status } : {}), ...userFilter };
 
     const [disputes, total] = await Promise.all([
       prisma.dispute.findMany({


### PR DESCRIPTION
Freelancers see only their own disputes, clients see only theirs, admins retain full visibility. Unknown roles receive 403. Extends DisputeService.getDisputes to accept an optional userFilter that is merged into the Prisma where clause before querying.

Closes #803