### PR TITLE
fix: add DB startup retry with exponential backoff (#804)

### DIFF
--- a/backend/src/__tests__/db-startup-retry.test.ts
+++ b/backend/src/__tests__/db-startup-retry.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for #804: backend retries the Prisma $connect() call with
+ * exponential back-off before giving up and crashing.
+ */
+
+jest.mock("../lib/logger", () => ({
+  installRequestIdConsolePatch: jest.fn(),
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { logger } from "../lib/logger";
+import { connectWithRetry } from "../lib/db-connect";
+
+const mockConnect = jest.fn();
+const mockPrisma = { $connect: mockConnect } as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("connectWithRetry (#804)", () => {
+  it("connects immediately when DB is available on the first attempt", async () => {
+    mockConnect.mockResolvedValueOnce(undefined);
+
+    await connectWithRetry(mockPrisma);
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("retries after failure and succeeds on the third attempt", async () => {
+    const connError = new Error("ECONNREFUSED");
+    mockConnect
+      .mockRejectedValueOnce(connError)
+      .mockRejectedValueOnce(connError)
+      .mockResolvedValueOnce(undefined);
+
+    const promise = connectWithRetry(mockPrisma, 5, 100);
+    await jest.runAllTimersAsync();
+    await promise;
+
+    expect(mockConnect).toHaveBeenCalledTimes(3);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs a warn message for each failed attempt with retry info", async () => {
+    const connError = new Error("ECONNREFUSED");
+    mockConnect
+      .mockRejectedValueOnce(connError)
+      .mockResolvedValueOnce(undefined);
+
+    const promise = connectWithRetry(mockPrisma, 5, 100);
+    await jest.runAllTimersAsync();
+    await promise;
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect((logger.warn as jest.Mock).mock.calls[0][0]).toMatch(/DB not ready.*attempt 1\/5/);
+  });
+
+  it("throws after exhausting all retries", async () => {
+    const connError = new Error("ECONNREFUSED");
+    mockConnect.mockRejectedValue(connError);
+
+    const promise = connectWithRetry(mockPrisma, 3, 100);
+    // Run timers concurrently so the retries advance without deadlocking
+    void jest.runAllTimersAsync();
+
+    await expect(promise).rejects.toThrow("ECONNREFUSED");
+    expect(mockConnect).toHaveBeenCalledTimes(3);
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,7 @@ import {
   stopHorizonListener,
 } from "./services/horizon-listener.service";
 import { installRequestIdConsolePatch, logger } from "./lib/logger";
+import { connectWithRetry } from "./lib/db-connect";
 import { getHealthStatus } from "./lib/health";
 import { RecommendationQueueService } from "./services/recommendation-queue.service";
 import { initializeVirusScanner } from "./utils/virusScanner";
@@ -185,7 +186,8 @@ app.use((req, res) => {
 // Error handler
 app.use(errorHandler);
 
-function startServer(): void {
+async function startServer(): Promise<void> {
+  await connectWithRetry(prisma);
   httpServer.listen(config.port, async () => {
     logger.info({ port: config.port }, "StellarMarket API running");
     startExpiryJob();
@@ -226,7 +228,10 @@ process.on("SIGTERM", () => void gracefulShutdown("SIGTERM"));
 process.on("SIGINT", () => void gracefulShutdown("SIGINT"));
 
 if (require.main === module) {
-  startServer();
+  startServer().catch((err) => {
+    logger.error({ err }, "Failed to start server");
+    process.exit(1);
+  });
 }
 
 export { app, httpServer, startServer };

--- a/backend/src/lib/db-connect.ts
+++ b/backend/src/lib/db-connect.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from "@prisma/client";
+import { logger } from "./logger";
+
+export async function connectWithRetry(
+  prisma: PrismaClient,
+  retries = 5,
+  delay = 2000,
+): Promise<void> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      await prisma.$connect();
+      return;
+    } catch (err) {
+      if (i === retries - 1) throw err;
+      logger.warn(
+        `DB not ready, retrying in ${delay * 2 ** i}ms (attempt ${i + 1}/${retries})`,
+      );
+      await new Promise((r) => setTimeout(r, delay * 2 ** i));
+    }
+  }
+}


### PR DESCRIPTION
Extract connectWithRetry() into lib/db-connect.ts and call it before app.listen(). Retries Prisma \$connect() up to 5 times with exponential backoff (2s base), logging a warning on each failed attempt and exiting cleanly after all retries are exhausted.

Closes #804