### PR TITLE
Add delivery ack, optimistic UI, retry and offline queueing to chat messages

### DIFF
--- a/backend/prisma/migrations/20260720000000_add_message_client_id/migration.sql
+++ b/backend/prisma/migrations/20260720000000_add_message_client_id/migration.sql
@@ -1,0 +1,8 @@
+-- Add clientId to Message: a client-generated id echoed back on the ack so the
+-- frontend can reconcile its optimistic message with the server-confirmed one,
+-- and so a retried send that actually landed server-side is not inserted twice
+-- (issue #878).
+ALTER TABLE "Message" ADD COLUMN "clientId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Message_clientId_key" ON "Message"("clientId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -328,6 +328,7 @@ model Invitation {
 
 model Message {
   id         String   @id @default(cuid())
+  clientId   String?  @unique
   senderId   String
   receiverId String
   jobId      String?

--- a/backend/src/socket/__tests__/messageHandlers.test.ts
+++ b/backend/src/socket/__tests__/messageHandlers.test.ts
@@ -20,6 +20,7 @@ jest.mock("@prisma/client", () => {
     message: {
       create: jest.fn(),
       updateMany: jest.fn(),
+      findUnique: jest.fn().mockResolvedValue(null),
     },
     pendingNotification: {
       findMany: jest.fn().mockResolvedValue([]),
@@ -34,6 +35,7 @@ const prismaMock = new PrismaClient() as jest.Mocked<PrismaClient>;
 const messageMock = prismaMock.message as unknown as {
   create: jest.Mock;
   updateMany: jest.Mock;
+  findUnique: jest.Mock;
 };
 
 // ─── Helper: make a signed JWT ────────────────────────────────────────────────
@@ -175,6 +177,88 @@ describe("send_message event", () => {
     });
 
     expect(err.message).toMatch(/receiverId and content are required/i);
+    client.disconnect();
+  });
+
+  it("acks with ok:true and the persisted message on a successful send", async () => {
+    const mockMessage = {
+      id: "msg-ack-1",
+      clientId: "client-ack-1",
+      senderId: "user-1",
+      receiverId: "user-2",
+      content: "Acked!",
+      read: false,
+      createdAt: new Date(),
+      sender: { id: "user-1", username: "alice", avatarUrl: null },
+      receiver: { id: "user-2", username: "bob", avatarUrl: null },
+    };
+    messageMock.findUnique.mockResolvedValueOnce(null);
+    messageMock.create.mockResolvedValueOnce(mockMessage);
+
+    const client = await connectClient(makeToken("user-1"));
+
+    const ack = await new Promise<{ ok: boolean; message?: unknown }>((resolve) => {
+      client.emit(
+        "send_message",
+        { receiverId: "user-2", content: "Acked!", clientId: "client-ack-1" },
+        resolve
+      );
+    });
+
+    expect(ack.ok).toBe(true);
+    expect(ack.message).toMatchObject({ content: "Acked!", clientId: "client-ack-1" });
+    expect(messageMock.create).toHaveBeenCalledTimes(1);
+    client.disconnect();
+  });
+
+  it("is idempotent on clientId: a retried send with the same clientId does not create a duplicate", async () => {
+    const existingMessage = {
+      id: "msg-existing",
+      clientId: "client-retry-1",
+      senderId: "user-1",
+      receiverId: "user-2",
+      content: "Already sent",
+      read: false,
+      createdAt: new Date(),
+      sender: { id: "user-1", username: "alice", avatarUrl: null },
+      receiver: { id: "user-2", username: "bob", avatarUrl: null },
+    };
+    // Simulates the original write having already succeeded server-side
+    // (e.g. the ack for it was lost), so findUnique short-circuits create.
+    messageMock.findUnique.mockResolvedValueOnce(existingMessage);
+
+    const client = await connectClient(makeToken("user-1"));
+
+    const ack = await new Promise<{ ok: boolean; message?: unknown }>((resolve) => {
+      client.emit(
+        "send_message",
+        { receiverId: "user-2", content: "Already sent", clientId: "client-retry-1" },
+        resolve
+      );
+    });
+
+    expect(ack.ok).toBe(true);
+    expect(ack.message).toMatchObject({ id: "msg-existing", clientId: "client-retry-1" });
+    expect(messageMock.create).not.toHaveBeenCalled();
+    client.disconnect();
+  });
+
+  it("acks with ok:false when persisting the message fails", async () => {
+    messageMock.findUnique.mockResolvedValueOnce(null);
+    messageMock.create.mockRejectedValueOnce(new Error("db down"));
+
+    const client = await connectClient(makeToken("user-1"));
+
+    const ack = await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      client.emit(
+        "send_message",
+        { receiverId: "user-2", content: "Will fail", clientId: "client-fail-1" },
+        resolve
+      );
+    });
+
+    expect(ack.ok).toBe(false);
+    expect(ack.error).toMatch(/failed to send message/i);
     client.disconnect();
   });
 });

--- a/backend/src/socket/messageHandlers.ts
+++ b/backend/src/socket/messageHandlers.ts
@@ -14,21 +14,45 @@ export function registerMessageHandlers(
   // ─── send_message ────────────────────────────────────────────────────────────
   socket.on(
     "send_message",
-    async (payload: { receiverId: string; content: string; jobId?: string }) => {
-      const { receiverId, content, jobId } = payload;
+    async (
+      payload: { receiverId: string; content: string; jobId?: string; clientId?: string },
+      ack?: (response: { ok: boolean; message?: unknown; error?: string }) => void
+    ) => {
+      const { receiverId, content, jobId, clientId } = payload;
 
       if (!receiverId || !content) {
-        socket.emit("error", { message: "receiverId and content are required." });
+        const error = "receiverId and content are required.";
+        socket.emit("error", { message: error });
+        ack?.({ ok: false, error });
         return;
       }
 
       try {
+        // Idempotency: if this clientId was already persisted (e.g. the
+        // original ack was lost but the write actually succeeded), return
+        // the existing row instead of creating a duplicate message.
+        if (clientId) {
+          const existing = await prisma.message.findUnique({
+            where: { clientId },
+            include: {
+              sender: { select: { id: true, username: true, avatarUrl: true } },
+              receiver: { select: { id: true, username: true, avatarUrl: true } },
+            },
+          });
+
+          if (existing) {
+            ack?.({ ok: true, message: existing });
+            return;
+          }
+        }
+
         const message = await prisma.message.create({
           data: {
             senderId,
             receiverId,
             jobId: jobId ?? null,
             content,
+            clientId: clientId ?? null,
           },
           include: {
             sender: { select: { id: true, username: true, avatarUrl: true } },
@@ -40,9 +64,12 @@ export function registerMessageHandlers(
         io.to(`user:${receiverId}`).emit("new_message", message);
         // Also emit back to sender (so other sender tabs update instantly)
         socket.emit("new_message", message);
+
+        ack?.({ ok: true, message });
       } catch (err) {
         logger.error({ err, senderId, receiverId }, "send_message error");
         socket.emit("error", { message: "Failed to send message." });
+        ack?.({ ok: false, error: "Failed to send message." });
       }
     }
   );

--- a/frontend/src/app/messages/[id]/conversations/[conversationId]/page.tsx
+++ b/frontend/src/app/messages/[id]/conversations/[conversationId]/page.tsx
@@ -76,6 +76,8 @@ export default function ConversationPage() {
           currentUserId={currentUser?.id || ""}
           partnerId={partnerId}
           partnerUsername={partnerUsername || partnerId}
+          currentUsername={currentUser?.username || ""}
+          currentUserAvatarUrl={currentUser?.avatarUrl || null}
           initialMessages={messages}
         />
       </div>

--- a/frontend/src/app/messages/[id]/conversations/[conversationId]/page.tsx
+++ b/frontend/src/app/messages/[id]/conversations/[conversationId]/page.tsx
@@ -73,6 +73,7 @@ export default function ConversationPage() {
 
       <div className="flex-1 bg-theme-card border border-theme-border rounded-xl overflow-hidden flex flex-col">
         <ChatWindow
+          key={partnerId}
           currentUserId={currentUser?.id || ""}
           partnerId={partnerId}
           partnerUsername={partnerUsername || partnerId}

--- a/frontend/src/components/chat/ChatWindow.tsx
+++ b/frontend/src/components/chat/ChatWindow.tsx
@@ -5,10 +5,12 @@ import {
   useRef,
   useState,
   useCallback,
+  useMemo,
   FormEvent,
 } from "react";
-import { Send, ChevronDown } from "lucide-react";
+import { Send, ChevronDown, AlertCircle, RotateCw, Clock } from "lucide-react";
 import { useSocket } from "@/context/SocketContext";
+import { useChatOutbox, OutgoingMessage } from "@/hooks/useChatOutbox";
 import TypingIndicator from "./TypingIndicator";
 
 const TYPING_DEBOUNCE_MS = 1500;
@@ -27,6 +29,8 @@ interface ChatWindowProps {
   currentUserId: string;
   partnerId: string;
   partnerUsername: string;
+  currentUsername?: string;
+  currentUserAvatarUrl?: string | null;
   initialMessages: ChatMessage[];
 }
 
@@ -34,13 +38,18 @@ export default function ChatWindow({
   currentUserId,
   partnerId,
   partnerUsername,
+  currentUsername = "",
+  currentUserAvatarUrl = null,
   initialMessages,
 }: ChatWindowProps) {
-  const { socket } = useSocket();
+  const { socket, isConnected } = useSocket();
   const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
+  // clientIds of optimistic messages that have been reconciled with a
+  // server-confirmed message, so the outbox entry can be hidden without a
+  // duplicate flashing in before the pending map catches up.
+  const reconciledClientIdsRef = useRef<Set<string>>(new Set());
   const [input, setInput] = useState("");
   const [isPartnerTyping, setIsPartnerTyping] = useState(false);
-  const [isSending, setIsSending] = useState(false);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [showNewMessageBadge, setShowNewMessageBadge] = useState(false);
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -48,6 +57,40 @@ export default function ChatWindow({
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const isTypingRef = useRef(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const currentUser = useMemo(
+    () => ({ id: currentUserId, username: currentUsername, avatarUrl: currentUserAvatarUrl }),
+    [currentUserId, currentUsername, currentUserAvatarUrl]
+  );
+
+  const handleServerMessage = useCallback((msg: ChatMessage, clientId?: string) => {
+    if (clientId) reconciledClientIdsRef.current.add(clientId);
+    setMessages((prev) => {
+      if (prev.some((m) => m.id === msg.id)) return prev;
+      return [...prev, msg];
+    });
+  }, []);
+
+  const { pendingByClientId, send, retry } = useChatOutbox({
+    socket,
+    isConnected,
+    currentUserId,
+    partnerId,
+    currentUser,
+    onServerMessage: handleServerMessage,
+  });
+
+  // Merge confirmed history with any outbox entries not yet reconciled into
+  // `messages`, so sending/failed/queued bubbles render inline without
+  // duplicating once the server-confirmed message lands.
+  const displayMessages = useMemo(() => {
+    const pendingEntries = Object.values(pendingByClientId).filter(
+      (p) => !reconciledClientIdsRef.current.has(p.clientId)
+    );
+    return [...messages, ...pendingEntries].sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+  }, [messages, pendingByClientId]);
 
   // Track if user is at bottom using IntersectionObserver
   useEffect(() => {
@@ -76,18 +119,18 @@ export default function ChatWindow({
 
   // Handle new messages: auto-scroll if at bottom, show badge if not
   useEffect(() => {
-    if (messages.length === 0) return;
-    
+    if (displayMessages.length === 0) return;
+
     if (isAtBottom) {
       bottomRef.current?.scrollIntoView({ behavior: "smooth" });
       setShowNewMessageBadge(false);
     } else {
-      const lastMessage = messages[messages.length - 1];
+      const lastMessage = displayMessages[displayMessages.length - 1];
       if (lastMessage?.senderId !== currentUserId) {
         setShowNewMessageBadge(true);
       }
     }
-  }, [messages, isAtBottom, currentUserId]);
+  }, [displayMessages, isAtBottom, currentUserId]);
 
   const scrollToBottom = useCallback(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -164,21 +207,19 @@ export default function ChatWindow({
     (e: FormEvent) => {
       e.preventDefault();
       const content = input.trim();
-      if (!content || !socket) return;
+      if (!content) return;
 
       // Stop typing indicator
       if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
-      if (isTypingRef.current) {
+      if (isTypingRef.current && socket) {
         isTypingRef.current = false;
         socket.emit("typing_stop", { receiverId: partnerId });
       }
 
-      setIsSending(true);
-      socket.emit("send_message", { receiverId: partnerId, content });
+      send(content);
       setInput("");
-      setIsSending(false);
     },
-    [input, socket, partnerId]
+    [input, socket, partnerId, send]
   );
 
   return (
@@ -196,29 +237,57 @@ export default function ChatWindow({
         ref={messagesContainerRef}
         className="flex-1 overflow-y-auto px-4 py-4 space-y-3 relative"
       >
-        {messages.map((msg) => {
+        {displayMessages.map((msg) => {
           const isOwn = msg.senderId === currentUserId;
+          const status = (msg as OutgoingMessage).status as
+            | OutgoingMessage["status"]
+            | undefined;
+          const isFailed = status === "failed";
+
           return (
             <div
-              key={msg.id}
+              key={(msg as OutgoingMessage).clientId ?? msg.id}
               className={`flex ${isOwn ? "justify-end" : "justify-start"}`}
             >
-              <div
-                className={`max-w-[70%] px-4 py-2 rounded-2xl text-sm leading-relaxed ${isOwn
-                    ? "bg-stellar-blue text-white rounded-br-sm"
-                    : "bg-theme-card text-theme-text border border-theme-border rounded-bl-sm"
-                  }`}
-              >
-                {msg.content}
+              <div className="flex flex-col items-end max-w-[70%]">
                 <div
-                  className={`text-xs mt-1 ${isOwn ? "text-white/70" : "text-theme-text"
+                  className={`px-4 py-2 rounded-2xl text-sm leading-relaxed ${isOwn
+                      ? isFailed
+                        ? "bg-stellar-blue/50 text-white rounded-br-sm"
+                        : "bg-stellar-blue text-white rounded-br-sm"
+                      : "bg-theme-card text-theme-text border border-theme-border rounded-bl-sm"
                     }`}
                 >
-                  {new Date(msg.createdAt).toLocaleTimeString([], {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
+                  {msg.content}
+                  <div
+                    className={`text-xs mt-1 flex items-center gap-1 ${isOwn ? "text-white/70" : "text-theme-text"
+                      }`}
+                  >
+                    {new Date(msg.createdAt).toLocaleTimeString([], {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                    {status === "sending" && <span>· Sending…</span>}
+                    {status === "queued" && (
+                      <span className="flex items-center gap-0.5">
+                        <Clock size={10} /> Queued
+                      </span>
+                    )}
+                    {status === "failed" && <span>· Not delivered</span>}
+                  </div>
                 </div>
+                {isFailed && (
+                  <button
+                    type="button"
+                    onClick={() => retry((msg as OutgoingMessage).clientId)}
+                    className="mt-1 flex items-center gap-1 text-xs text-red-500 hover:text-red-400 transition-colors"
+                  >
+                    <AlertCircle size={12} />
+                    Failed to send
+                    <RotateCw size={12} className="ml-1" />
+                    Retry
+                  </button>
+                )}
               </div>
             </div>
           );
@@ -261,7 +330,7 @@ export default function ChatWindow({
         />
         <button
           type="submit"
-          disabled={!input.trim() || isSending}
+          disabled={!input.trim()}
           id="send-message-btn"
           className="btn-primary p-2.5 rounded-xl flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
         >

--- a/frontend/src/components/chat/ChatWindow.tsx
+++ b/frontend/src/components/chat/ChatWindow.tsx
@@ -23,6 +23,10 @@ export interface ChatMessage {
   read: boolean;
   createdAt: string;
   sender: { id: string; username: string; avatarUrl: string | null };
+  /** Client-generated id echoed back by the server, used to reconcile an
+   * optimistic send with its confirmed delivery. Absent on messages that
+   * originated from the legacy (non-ack) send path. */
+  clientId?: string | null;
 }
 
 interface ChatWindowProps {
@@ -71,7 +75,7 @@ export default function ChatWindow({
     });
   }, []);
 
-  const { pendingByClientId, send, retry } = useChatOutbox({
+  const { pendingByClientId, send, retry, reconcileFromBroadcast } = useChatOutbox({
     socket,
     isConnected,
     currentUserId,
@@ -153,6 +157,12 @@ export default function ChatWindow({
         (msg.senderId === partnerId && msg.receiverId === currentUserId) ||
         (msg.senderId === currentUserId && msg.receiverId === partnerId)
       ) {
+        // Reconcile against a pending optimistic send even if its ack was
+        // lost — the message still arrived, so the outbox bubble should
+        // clear instead of eventually timing out to "failed".
+        if (msg.clientId) reconciledClientIdsRef.current.add(msg.clientId);
+        reconcileFromBroadcast(msg);
+
         setMessages((prev) => {
           // Deduplicate
           if (prev.some((m) => m.id === msg.id)) return prev;

--- a/frontend/src/components/chat/__tests__/ChatWindow.test.tsx
+++ b/frontend/src/components/chat/__tests__/ChatWindow.test.tsx
@@ -79,7 +79,7 @@ describe("ChatWindow", () => {
     expect(screen.getByText("Hey there live!")).toBeInTheDocument();
   });
 
-  it("emits send_message with correct payload on form submit", async () => {
+  it("emits send_message with a client id and ack callback on form submit", async () => {
     render(<ChatWindow {...baseProps} />);
 
     const textarea = screen.getByPlaceholderText(/message bob/i);
@@ -88,10 +88,21 @@ describe("ChatWindow", () => {
     const sendBtn = screen.getByRole("button", { name: "" }); // Send icon button
     fireEvent.click(sendBtn);
 
-    expect(mockSocket.emit).toHaveBeenCalledWith("send_message", {
-      receiverId: "user-bob",
-      content: "Hi Bob!",
-    });
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      "send_message",
+      expect.objectContaining({ receiverId: "user-bob", content: "Hi Bob!" }),
+      expect.any(Function)
+    );
+  });
+
+  it("shows the message optimistically before the server acks it", async () => {
+    render(<ChatWindow {...baseProps} />);
+
+    const textarea = screen.getByPlaceholderText(/message bob/i);
+    fireEvent.change(textarea, { target: { value: "Hi Bob!" } });
+    fireEvent.click(screen.getByRole("button", { name: "" }));
+
+    expect(screen.getByText("Hi Bob!")).toBeInTheDocument();
   });
 
   it("emits typing_start when user types and typing_stop after debounce", async () => {

--- a/frontend/src/components/chat/__tests__/ChatWindow.test.tsx
+++ b/frontend/src/components/chat/__tests__/ChatWindow.test.tsx
@@ -8,6 +8,7 @@ window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
 // ─── Socket mock ──────────────────────────────────────────────────────────────
 const mockHandlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+let mockIsConnected = true;
 const mockSocket = {
   on: jest.fn((event: string, fn: (...args: unknown[]) => void) => {
     mockHandlers[event] = mockHandlers[event] ?? [];
@@ -23,8 +24,23 @@ const mockSocket = {
 };
 
 jest.mock("@/context/SocketContext", () => ({
-  useSocket: () => ({ socket: mockSocket, isConnected: true }),
+  useSocket: () => ({ socket: mockSocket, isConnected: mockIsConnected }),
 }));
+
+// localStorage is used for the offline outbox; jsdom provides a real
+// implementation, so just make sure each test starts from a clean slate.
+function clearOutboxStorage() {
+  Object.keys(window.localStorage).forEach((k) => {
+    if (k.startsWith("stellar_chat_outbox:")) window.localStorage.removeItem(k);
+  });
+}
+
+/** Grab the ack callback socket.emit("send_message", payload, ack) was called with. */
+function getLastSendAck(): ((response: unknown) => void) | undefined {
+  const calls = mockSocket.emit.mock.calls.filter((c) => c[0] === "send_message");
+  const last = calls[calls.length - 1];
+  return last?.[2] as ((response: unknown) => void) | undefined;
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 const baseProps = {
@@ -49,6 +65,8 @@ beforeEach(() => {
   jest.useFakeTimers();
   jest.clearAllMocks();
   Object.keys(mockHandlers).forEach((k) => delete mockHandlers[k]);
+  mockIsConnected = true;
+  clearOutboxStorage();
 });
 
 afterEach(() => {
@@ -133,5 +151,148 @@ describe("ChatWindow", () => {
   it("emits mark_read on mount", () => {
     render(<ChatWindow {...baseProps} />);
     expect(mockSocket.emit).toHaveBeenCalledWith("mark_read", { senderId: "user-bob" });
+  });
+
+  it("reconciles the optimistic message with the server-confirmed one on ack, without duplicating", async () => {
+    render(<ChatWindow {...baseProps} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/message bob/i), {
+      target: { value: "Confirmed please" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "" }));
+
+    expect(screen.getAllByText("Confirmed please")).toHaveLength(1);
+
+    const ack = getLastSendAck();
+    const serverMessage = makeMessage({
+      id: "server-msg-1",
+      content: "Confirmed please",
+      senderId: "user-me",
+      receiverId: "user-bob",
+    });
+
+    await act(async () => {
+      ack?.({ ok: true, message: serverMessage });
+    });
+
+    // Still exactly one bubble — the optimistic entry was replaced, not
+    // duplicated alongside the server-confirmed message.
+    expect(screen.getAllByText("Confirmed please")).toHaveLength(1);
+  });
+
+  it("marks a message failed after the ack times out, and retry re-sends it", async () => {
+    render(<ChatWindow {...baseProps} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/message bob/i), {
+      target: { value: "Will time out" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "" }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(9000); // past the 8s ack timeout
+    });
+
+    expect(screen.getByText(/not delivered/i)).toBeInTheDocument();
+
+    const sendCallsBefore = mockSocket.emit.mock.calls.filter((c) => c[0] === "send_message").length;
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    const sendCallsAfter = mockSocket.emit.mock.calls.filter((c) => c[0] === "send_message").length;
+    expect(sendCallsAfter).toBe(sendCallsBefore + 1);
+  });
+
+  it("queues a message sent while disconnected and shows a queued state", () => {
+    mockIsConnected = false;
+    render(<ChatWindow {...baseProps} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/message bob/i), {
+      target: { value: "Offline message" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "" }));
+
+    expect(screen.getByText("Offline message")).toBeInTheDocument();
+    expect(screen.getByText(/queued/i)).toBeInTheDocument();
+    expect(mockSocket.emit).not.toHaveBeenCalledWith(
+      "send_message",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("flushes a queued message automatically once the socket reconnects", async () => {
+    mockIsConnected = false;
+    const { rerender } = render(<ChatWindow {...baseProps} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/message bob/i), {
+      target: { value: "Send me on reconnect" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "" }));
+
+    expect(mockSocket.emit).not.toHaveBeenCalledWith(
+      "send_message",
+      expect.anything(),
+      expect.anything()
+    );
+
+    mockIsConnected = true;
+    await act(async () => {
+      rerender(<ChatWindow {...baseProps} />);
+    });
+
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      "send_message",
+      expect.objectContaining({ receiverId: "user-bob", content: "Send me on reconnect" }),
+      expect.any(Function)
+    );
+  });
+
+  it("does not duplicate a message when new_message arrives for an already-acked send", async () => {
+    render(<ChatWindow {...baseProps} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/message bob/i), {
+      target: { value: "Echo test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "" }));
+
+    const ack = getLastSendAck();
+    const serverMessage = makeMessage({
+      id: "server-msg-2",
+      content: "Echo test",
+      senderId: "user-me",
+      receiverId: "user-bob",
+    });
+
+    await act(async () => {
+      ack?.({ ok: true, message: serverMessage });
+    });
+
+    // Server also broadcasts new_message back to the sender's other tabs;
+    // it carries the same id already reconciled via the ack.
+    await act(async () => {
+      mockSocket._trigger("new_message", serverMessage);
+    });
+
+    expect(screen.getAllByText("Echo test")).toHaveLength(1);
+  });
+
+  it("does not leak a pending message into a different conversation opened with the same component instance", async () => {
+    mockIsConnected = false;
+    const { rerender } = render(<ChatWindow {...baseProps} partnerId="user-bob" />);
+
+    fireEvent.change(screen.getByPlaceholderText(/message bob/i), {
+      target: { value: "For Bob only" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "" }));
+
+    expect(screen.getByText("For Bob only")).toBeInTheDocument();
+
+    // Switch to a different conversation (as would happen if the parent
+    // didn't remount ChatWindow via a key change).
+    await act(async () => {
+      rerender(<ChatWindow {...baseProps} partnerId="user-carol" partnerUsername="Carol" />);
+    });
+
+    expect(screen.queryByText("For Bob only")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/useChatOutbox.ts
+++ b/frontend/src/hooks/useChatOutbox.ts
@@ -1,0 +1,247 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Socket } from "socket.io-client";
+import type { ChatMessage } from "@/components/chat/ChatWindow";
+
+const ACK_TIMEOUT_MS = 8000;
+const OUTBOX_STORAGE_PREFIX = "stellar_chat_outbox:";
+
+export type MessageStatus = "sending" | "sent" | "failed" | "queued";
+
+export interface OutgoingMessage extends ChatMessage {
+  clientId: string;
+  status: MessageStatus;
+}
+
+interface SendMessageAck {
+  ok: boolean;
+  message?: ChatMessage;
+  error?: string;
+}
+
+interface QueuedPayload {
+  clientId: string;
+  receiverId: string;
+  content: string;
+  createdAt: string;
+}
+
+function outboxKey(currentUserId: string, partnerId: string): string {
+  return `${OUTBOX_STORAGE_PREFIX}${currentUserId}:${partnerId}`;
+}
+
+function loadQueue(currentUserId: string, partnerId: string): QueuedPayload[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(outboxKey(currentUserId, partnerId));
+    return raw ? (JSON.parse(raw) as QueuedPayload[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveQueue(currentUserId: string, partnerId: string, queue: QueuedPayload[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(outboxKey(currentUserId, partnerId), JSON.stringify(queue));
+  } catch {
+    // Storage unavailable (private browsing, quota) — outbox just won't survive a reload.
+  }
+}
+
+function makeClientId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `c_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}
+
+interface UseChatOutboxOptions {
+  socket: Socket | null;
+  isConnected: boolean;
+  currentUserId: string;
+  partnerId: string;
+  currentUser: { id: string; username: string; avatarUrl: string | null };
+  onServerMessage: (message: ChatMessage, clientId?: string) => void;
+}
+
+export function useChatOutbox({
+  socket,
+  isConnected,
+  currentUserId,
+  partnerId,
+  currentUser,
+  onServerMessage,
+}: UseChatOutboxOptions) {
+  const [pendingByClientId, setPendingByClientId] = useState<Record<string, OutgoingMessage>>({});
+  const timersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const clearTimer = useCallback((clientId: string) => {
+    const timer = timersRef.current[clientId];
+    if (timer) {
+      clearTimeout(timer);
+      delete timersRef.current[clientId];
+    }
+  }, []);
+
+  const dequeue = useCallback(
+    (clientId: string) => {
+      const queue = loadQueue(currentUserId, partnerId).filter((q) => q.clientId !== clientId);
+      saveQueue(currentUserId, partnerId, queue);
+    },
+    [currentUserId, partnerId]
+  );
+
+  const enqueue = useCallback(
+    (payload: QueuedPayload) => {
+      const queue = loadQueue(currentUserId, partnerId);
+      if (queue.some((q) => q.clientId === payload.clientId)) return;
+      saveQueue(currentUserId, partnerId, [...queue, payload]);
+    },
+    [currentUserId, partnerId]
+  );
+
+  const sendOverSocket = useCallback(
+    (clientId: string, receiverId: string, content: string) => {
+      if (!socket) return;
+
+      clearTimer(clientId);
+
+      const timer = setTimeout(() => {
+        setPendingByClientId((prev) => {
+          if (!prev[clientId] || prev[clientId].status !== "sending") return prev;
+          return { ...prev, [clientId]: { ...prev[clientId], status: "failed" } };
+        });
+      }, ACK_TIMEOUT_MS);
+      timersRef.current[clientId] = timer;
+
+      socket.emit(
+        "send_message",
+        { receiverId, content, clientId },
+        (ack?: SendMessageAck) => {
+          clearTimer(clientId);
+
+          if (ack?.ok && ack.message) {
+            dequeue(clientId);
+            onServerMessage(ack.message, clientId);
+            setPendingByClientId((prev) => {
+              const next = { ...prev };
+              delete next[clientId];
+              return next;
+            });
+            return;
+          }
+
+          setPendingByClientId((prev) => {
+            if (!prev[clientId]) return prev;
+            return { ...prev, [clientId]: { ...prev[clientId], status: "failed" } };
+          });
+        }
+      );
+    },
+    [socket, clearTimer, dequeue, onServerMessage]
+  );
+
+  const send = useCallback(
+    (content: string) => {
+      const clientId = makeClientId();
+      const createdAt = new Date().toISOString();
+
+      const optimistic: OutgoingMessage = {
+        id: clientId,
+        clientId,
+        senderId: currentUserId,
+        receiverId: partnerId,
+        content,
+        read: false,
+        createdAt,
+        sender: currentUser,
+        status: isConnected ? "sending" : "queued",
+      };
+
+      setPendingByClientId((prev) => ({ ...prev, [clientId]: optimistic }));
+
+      if (!isConnected || !socket) {
+        enqueue({ clientId, receiverId: partnerId, content, createdAt });
+        return optimistic;
+      }
+
+      sendOverSocket(clientId, partnerId, content);
+      return optimistic;
+    },
+    [currentUserId, partnerId, currentUser, isConnected, socket, enqueue, sendOverSocket]
+  );
+
+  const retry = useCallback(
+    (clientId: string) => {
+      const pending = pendingByClientId[clientId];
+      if (!pending) return;
+
+      if (!isConnected || !socket) {
+        setPendingByClientId((prev) => ({
+          ...prev,
+          [clientId]: { ...prev[clientId], status: "queued" },
+        }));
+        enqueue({
+          clientId,
+          receiverId: partnerId,
+          content: pending.content,
+          createdAt: pending.createdAt,
+        });
+        return;
+      }
+
+      setPendingByClientId((prev) => ({
+        ...prev,
+        [clientId]: { ...prev[clientId], status: "sending" },
+      }));
+      sendOverSocket(clientId, partnerId, pending.content);
+    },
+    [pendingByClientId, isConnected, socket, partnerId, enqueue, sendOverSocket]
+  );
+
+  // Flush queued (offline-sent) messages once the socket reconnects.
+  useEffect(() => {
+    if (!isConnected || !socket) return;
+
+    const queued = loadQueue(currentUserId, partnerId);
+    if (queued.length === 0) return;
+
+    for (const item of queued) {
+      setPendingByClientId((prev) => {
+        const existing = prev[item.clientId];
+        if (existing && existing.status !== "queued") return prev;
+        return {
+          ...prev,
+          [item.clientId]: existing
+            ? { ...existing, status: "sending" }
+            : {
+                id: item.clientId,
+                clientId: item.clientId,
+                senderId: currentUserId,
+                receiverId: partnerId,
+                content: item.content,
+                read: false,
+                createdAt: item.createdAt,
+                sender: currentUser,
+                status: "sending",
+              },
+        };
+      });
+      sendOverSocket(item.clientId, item.receiverId, item.content);
+    }
+    // Only re-run when connectivity flips or the conversation changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isConnected, socket, currentUserId, partnerId]);
+
+  // Clean up any outstanding ack timers on unmount.
+  useEffect(() => {
+    return () => {
+      Object.values(timersRef.current).forEach(clearTimeout);
+      timersRef.current = {};
+    };
+  }, []);
+
+  return { pendingByClientId, send, retry };
+}

--- a/frontend/src/hooks/useChatOutbox.ts
+++ b/frontend/src/hooks/useChatOutbox.ts
@@ -76,6 +76,20 @@ export function useChatOutbox({
 }: UseChatOutboxOptions) {
   const [pendingByClientId, setPendingByClientId] = useState<Record<string, OutgoingMessage>>({});
   const timersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  // clientIds currently in flight over the socket, so a reconnect-flush that
+  // fires twice in quick succession can't emit the same send twice.
+  const inFlightRef = useRef<Set<string>>(new Set());
+
+  // Conversations are keyed by (currentUserId, partnerId). Reset in-memory
+  // pending state when either changes so stale "sending"/"failed" bubbles
+  // from a previous conversation can't leak into this one, and so retry()
+  // can never be called against a message that belongs elsewhere.
+  useEffect(() => {
+    Object.values(timersRef.current).forEach(clearTimeout);
+    timersRef.current = {};
+    inFlightRef.current.clear();
+    setPendingByClientId({});
+  }, [currentUserId, partnerId]);
 
   const clearTimer = useCallback((clientId: string) => {
     const timer = timersRef.current[clientId];
@@ -105,10 +119,13 @@ export function useChatOutbox({
   const sendOverSocket = useCallback(
     (clientId: string, receiverId: string, content: string) => {
       if (!socket) return;
+      if (inFlightRef.current.has(clientId)) return;
+      inFlightRef.current.add(clientId);
 
       clearTimer(clientId);
 
       const timer = setTimeout(() => {
+        inFlightRef.current.delete(clientId);
         setPendingByClientId((prev) => {
           if (!prev[clientId] || prev[clientId].status !== "sending") return prev;
           return { ...prev, [clientId]: { ...prev[clientId], status: "failed" } };
@@ -121,6 +138,7 @@ export function useChatOutbox({
         { receiverId, content, clientId },
         (ack?: SendMessageAck) => {
           clearTimer(clientId);
+          inFlightRef.current.delete(clientId);
 
           if (ack?.ok && ack.message) {
             dequeue(clientId);
@@ -173,32 +191,55 @@ export function useChatOutbox({
     [currentUserId, partnerId, currentUser, isConnected, socket, enqueue, sendOverSocket]
   );
 
+  // Reconcile a pending message against an incoming `new_message` broadcast.
+  // This covers the case where the send actually landed server-side but the
+  // ack packet itself was dropped: the pending bubble would otherwise sit at
+  // "sending" until the ack-timeout flips it to "failed" even though the
+  // message was delivered.
+  const reconcileFromBroadcast = useCallback(
+    (msg: ChatMessage & { clientId?: string | null }) => {
+      const clientId = msg.clientId;
+      if (!clientId) return false;
+
+      let matched = false;
+      setPendingByClientId((prev) => {
+        if (!prev[clientId]) return prev;
+        matched = true;
+        const next = { ...prev };
+        delete next[clientId];
+        return next;
+      });
+
+      if (matched) {
+        clearTimer(clientId);
+        inFlightRef.current.delete(clientId);
+        dequeue(clientId);
+      }
+      return matched;
+    },
+    [clearTimer, dequeue]
+  );
+
   const retry = useCallback(
     (clientId: string) => {
-      const pending = pendingByClientId[clientId];
-      if (!pending) return;
+      setPendingByClientId((prev) => {
+        const pending = prev[clientId];
+        if (!pending) return prev;
 
-      if (!isConnected || !socket) {
-        setPendingByClientId((prev) => ({
-          ...prev,
-          [clientId]: { ...prev[clientId], status: "queued" },
-        }));
-        enqueue({
-          clientId,
-          receiverId: partnerId,
-          content: pending.content,
-          createdAt: pending.createdAt,
-        });
-        return;
-      }
+        // Always resend to the recipient the message was originally
+        // addressed to, never whatever conversation happens to be open now.
+        const { receiverId, content } = pending;
 
-      setPendingByClientId((prev) => ({
-        ...prev,
-        [clientId]: { ...prev[clientId], status: "sending" },
-      }));
-      sendOverSocket(clientId, partnerId, pending.content);
+        if (!isConnected || !socket) {
+          enqueue({ clientId, receiverId, content, createdAt: pending.createdAt });
+          return { ...prev, [clientId]: { ...pending, status: "queued" } };
+        }
+
+        sendOverSocket(clientId, receiverId, content);
+        return { ...prev, [clientId]: { ...pending, status: "sending" } };
+      });
     },
-    [pendingByClientId, isConnected, socket, partnerId, enqueue, sendOverSocket]
+    [isConnected, socket, enqueue, sendOverSocket]
   );
 
   // Flush queued (offline-sent) messages once the socket reconnects.
@@ -209,6 +250,8 @@ export function useChatOutbox({
     if (queued.length === 0) return;
 
     for (const item of queued) {
+      if (inFlightRef.current.has(item.clientId)) continue;
+
       setPendingByClientId((prev) => {
         const existing = prev[item.clientId];
         if (existing && existing.status !== "queued") return prev;
@@ -243,5 +286,5 @@ export function useChatOutbox({
     };
   }, []);
 
-  return { pendingByClientId, send, retry };
+  return { pendingByClientId, send, retry, reconcileFromBroadcast };
 }


### PR DESCRIPTION
## Summary

`ChatWindow` sent messages fire-and-forget over Socket.IO with no delivery guarantee: a message was only added to the UI once the server echoed it back over `new_message`, so a dropped emit or a disconnected socket meant the message silently vanished with no indication to the user.

This PR adds a proper delivery-ack layer on top of the existing socket transport:

- **Client-generated message IDs** (`clientId`) are attached at send time and the message is added to local state immediately with a `sending`/`queued` status (optimistic local echo), instead of waiting on the server round-trip.
- **`send_message` now uses Socket.IO's ack-callback form of `emit`**, so the client knows definitively whether the server received and persisted the message. The backend returns `{ ok, message }` (or `{ ok: false, error }`) with the canonical server-assigned id/timestamp.
- **On ack timeout (8s) or explicit failure**, the message is marked `failed` in the UI with a retry action, rather than silently dropping it.
- **Offline queueing**: messages sent while the socket is disconnected are queued in a per-conversation `localStorage` outbox and automatically flushed once the socket reconnects.
- **Idempotency**: the `Message` model gains a unique `clientId` column. If a retried send's `clientId` already exists server-side (e.g. the original ack was lost but the write succeeded), the existing row is returned instead of inserting a duplicate. On the client, reconciliation between the optimistic message and the server-confirmed one is keyed by `clientId`, and the existing id-based dedup on `new_message` prevents the server echo from double-adding it.

## Changes

- `backend/prisma/schema.prisma`, new migration `20260720000000_add_message_client_id`: add nullable, unique `clientId` to `Message`.
- `backend/src/socket/messageHandlers.ts`: `send_message` accepts an optional `clientId` + ack callback; idempotent on `clientId`.
- `frontend/src/hooks/useChatOutbox.ts` (new): tracks per-message status (`sending` / `sent` / `failed` / `queued`), sends via ack-callback emit, times out lost acks, persists/flushes an offline outbox on reconnect.
- `frontend/src/components/chat/ChatWindow.tsx`: optimistic send, merges pending outbox entries into the message list, renders delivery status and a retry affordance for failed sends.
- `frontend/src/app/messages/[id]/conversations/[conversationId]/page.tsx`: passes the current user's identity through so `ChatWindow` can build the optimistic local echo.
- `frontend/src/components/chat/__tests__/ChatWindow.test.tsx`: updated the existing send assertion for the new ack-callback emit contract.

## Acceptance criteria addressed

- [x] Every sent message has a visible delivery status (sending / queued / failed) rather than either silently appearing or silently vanishing
- [x] Messages sent while disconnected are queued and auto-delivered on reconnect, not lost
- [x] Failed sends are retryable from the UI
- [x] No duplicate messages appear under retry/reconnect scenarios (idempotent `clientId` server-side + `clientId`/id-based reconciliation client-side)

closes #878