### PR TITLE
fix: unify transaction-status polling and add expired-tx resume flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@1.93.1
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@1.93.1
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@1.93.1
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.93.1
         with:
           targets: wasm32-unknown-unknown
 
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.93.1
         with:
           targets: wasm32-unknown-unknown
 
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.93.1
         with:
           targets: wasm32-unknown-unknown
 

--- a/backend/src/__tests__/pending-tx.test.ts
+++ b/backend/src/__tests__/pending-tx.test.ts
@@ -64,6 +64,11 @@ beforeEach(() => {
   mockGetLatestLedger.mockResolvedValue({ sequence: 1000 });
 });
 
+// `maxLedger` actually stores `tx.timeBounds.maxTime` — a Unix timestamp in
+// seconds — not a ledger sequence number (see submitWithPreRegistration).
+// Expiry must be checked against wall-clock time, not getLatestLedger().sequence.
+const nowSeconds = () => Math.floor(Date.now() / 1000);
+
 // ── Pre-registration idempotency ──────────────────────────────────────────────
 
 describe("pre-register upsert — idempotency", () => {
@@ -92,23 +97,24 @@ describe("pre-register upsert — idempotency", () => {
 // ── Background job — EXPIRED ──────────────────────────────────────────────────
 
 describe("checkPendingTransactions", () => {
-  it("marks EXPIRED when NOT_FOUND and current ledger > maxLedger", async () => {
+  it("marks EXPIRED when NOT_FOUND and the maxTime deadline has passed", async () => {
     mockTx.findMany.mockResolvedValue([
-      { id: "tx-1", txHash: TX_HASH_A, maxLedger: 900 },
+      { id: "tx-1", txHash: TX_HASH_A, maxLedger: nowSeconds() - 100 },
     ]);
     mockGetTransaction.mockResolvedValue({ status: "NOT_FOUND" });
-    mockGetLatestLedger.mockResolvedValue({ sequence: 950 }); // 950 > 900
 
     await checkPendingTransactions();
 
     expect(mockTx.update).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ status: "EXPIRED" }) }),
     );
+    // Expiry is wall-clock based — the ledger-sequence RPC call must not be used.
+    expect(mockGetLatestLedger).not.toHaveBeenCalled();
   });
 
   it("marks SUCCESS when RPC returns SUCCESS", async () => {
     mockTx.findMany.mockResolvedValue([
-      { id: "tx-2", txHash: TX_HASH_B, maxLedger: 2000 },
+      { id: "tx-2", txHash: TX_HASH_B, maxLedger: nowSeconds() + 1000 },
     ]);
     mockGetTransaction.mockResolvedValue({ status: "SUCCESS", ledger: 990 });
 
@@ -121,12 +127,11 @@ describe("checkPendingTransactions", () => {
     );
   });
 
-  it("does NOT expire when NOT_FOUND but current ledger <= maxLedger", async () => {
+  it("does NOT expire when NOT_FOUND but the maxTime deadline is still in the future", async () => {
     mockTx.findMany.mockResolvedValue([
-      { id: "tx-3", txHash: TX_HASH_A, maxLedger: 1500 },
+      { id: "tx-3", txHash: TX_HASH_A, maxLedger: nowSeconds() + 1000 },
     ]);
     mockGetTransaction.mockResolvedValue({ status: "NOT_FOUND" });
-    mockGetLatestLedger.mockResolvedValue({ sequence: 1000 }); // 1000 < 1500
 
     await checkPendingTransactions();
 

--- a/backend/src/jobs/pending-tx.job.ts
+++ b/backend/src/jobs/pending-tx.job.ts
@@ -28,8 +28,6 @@ async function checkPendingTransactions(): Promise<void> {
 
   logger.info({ count: pending.length }, "[PendingTxJob] Checking pending transactions");
 
-  let latestLedger: number | null = null;
-
   for (const tx of pending) {
     try {
       const result = await rpcServer.getTransaction(tx.txHash);
@@ -55,13 +53,14 @@ async function checkPendingTransactions(): Promise<void> {
         continue;
       }
 
-      // NOT_FOUND — check expiry if maxLedger is set
+      // NOT_FOUND — check expiry if maxLedger is set. `maxLedger` stores
+      // `tx.timeBounds.maxTime`, a Unix timestamp in seconds (set in
+      // submitWithPreRegistration), not a ledger sequence number, so it must
+      // be compared against wall-clock time rather than `getLatestLedger().sequence`
+      // (which is orders of magnitude smaller and would never trip this check).
       if (tx.maxLedger != null) {
-        if (latestLedger === null) {
-          const latest = await rpcServer.getLatestLedger();
-          latestLedger = latest.sequence;
-        }
-        if (latestLedger > tx.maxLedger) {
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        if (nowSeconds > tx.maxLedger) {
           await prisma.transaction.update({
             where: { id: tx.id },
             data: { status: "EXPIRED" },

--- a/backend/src/routes/__tests__/transaction.routes.test.ts
+++ b/backend/src/routes/__tests__/transaction.routes.test.ts
@@ -1,5 +1,18 @@
 import request from "supertest";
 import express from "express";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetTransaction = jest.fn() as jest.MockedFunction<any>;
+
+jest.mock("@stellar/stellar-sdk", () => ({
+  rpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      getTransaction: mockGetTransaction,
+    })),
+    Api: { GetTransactionStatus: { SUCCESS: "SUCCESS", FAILED: "FAILED", NOT_FOUND: "NOT_FOUND" } },
+  },
+}));
+
 import transactionRoutes from "../transaction.routes";
 
 // Mock Prisma
@@ -8,6 +21,7 @@ jest.mock("@prisma/client", () => {
     transaction: {
       create: jest.fn(),
       upsert: jest.fn(),
+      update: jest.fn(),
       findUnique: jest.fn(),
       findMany: jest.fn(),
       count: jest.fn(),
@@ -313,6 +327,101 @@ describe("Transaction Routes", () => {
 
       expect(response.status).toBe(404);
       expect(response.body).toHaveProperty("error", "Transaction not found");
+    });
+  });
+
+  describe("GET /api/transactions/:txHash/status", () => {
+    const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+    it("returns SUCCESS directly from the DB record without hitting RPC", async () => {
+      mockPrisma.transaction.findUnique.mockResolvedValue({
+        id: "tx1",
+        status: "SUCCESS",
+        maxLedger: null,
+        confirmedLedger: 12345,
+      });
+
+      const response = await request(app).get("/api/transactions/hash123/status");
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ status: "SUCCESS", ledger: 12345 });
+      expect(mockGetTransaction).not.toHaveBeenCalled();
+    });
+
+    it("returns FAILED with canRetry: false from the DB record", async () => {
+      mockPrisma.transaction.findUnique.mockResolvedValue({
+        id: "tx1",
+        status: "FAILED",
+        maxLedger: null,
+        confirmedLedger: null,
+      });
+
+      const response = await request(app).get("/api/transactions/hash123/status");
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ status: "FAILED", canRetry: false });
+    });
+
+    it("returns 404 when the transaction was never pre-registered", async () => {
+      mockPrisma.transaction.findUnique.mockResolvedValue(null);
+
+      const response = await request(app).get("/api/transactions/unknown/status");
+
+      expect(response.status).toBe(404);
+    });
+
+    it("marks EXPIRED and returns canRetry: true when the maxTime deadline has passed and RPC reports NOT_FOUND", async () => {
+      // maxLedger stores tx.timeBounds.maxTime (Unix seconds), not a ledger
+      // sequence number — it must be compared against wall-clock time.
+      mockPrisma.transaction.findUnique.mockResolvedValue({
+        id: "tx1",
+        status: "PENDING",
+        maxLedger: nowSeconds() - 100,
+        confirmedLedger: null,
+      });
+      mockGetTransaction.mockResolvedValue({ status: "NOT_FOUND" });
+
+      const response = await request(app).get("/api/transactions/hash123/status");
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ status: "EXPIRED", canRetry: true });
+      expect(mockPrisma.transaction.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { status: "EXPIRED" } }),
+      );
+    });
+
+    it("stays PENDING when RPC reports NOT_FOUND but the maxTime deadline is still in the future", async () => {
+      mockPrisma.transaction.findUnique.mockResolvedValue({
+        id: "tx1",
+        status: "PENDING",
+        maxLedger: nowSeconds() + 1000,
+        confirmedLedger: null,
+      });
+      mockGetTransaction.mockResolvedValue({ status: "NOT_FOUND" });
+
+      const response = await request(app).get("/api/transactions/hash123/status");
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ status: "PENDING" });
+      expect(mockPrisma.transaction.update).not.toHaveBeenCalled();
+    });
+
+    it("syncs SUCCESS from a live RPC check on a PENDING record", async () => {
+      mockPrisma.transaction.findUnique.mockResolvedValue({
+        id: "tx1",
+        status: "PENDING",
+        maxLedger: nowSeconds() + 1000,
+        confirmedLedger: null,
+      });
+      mockGetTransaction.mockResolvedValue({ status: "SUCCESS", ledger: 555 });
+
+      const response = await request(app).get("/api/transactions/hash123/status");
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ status: "SUCCESS", ledger: 555 });
+      expect(mockPrisma.transaction.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { status: "SUCCESS", confirmedLedger: 555 } }),
+      );
     });
   });
 

--- a/backend/src/routes/transaction.routes.ts
+++ b/backend/src/routes/transaction.routes.ts
@@ -58,6 +58,7 @@ const preRegisterSchema = {
     txHash: z.string().min(1),
     type: z.enum(["DEPOSIT", "RELEASE", "REFUND", "DISPUTE_PAYOUT"]),
     jobId: z.string().optional(),
+    milestoneId: z.string().optional(),
     maxLedger: z.number().int().positive().optional(),
     fromAddress: z.string().optional(),
     toAddress: z.string().optional(),
@@ -79,8 +80,17 @@ router.post(
   validate(preRegisterSchema),
   async (req: AuthRequest, res: Response) => {
     try {
-      const { txHash, type, jobId, maxLedger, fromAddress, toAddress, amount, tokenAddress } =
-        req.body;
+      const {
+        txHash,
+        type,
+        jobId,
+        milestoneId,
+        maxLedger,
+        fromAddress,
+        toAddress,
+        amount,
+        tokenAddress,
+      } = req.body;
 
       const record = await prisma.transaction.upsert({
         where: { txHash },
@@ -90,6 +100,7 @@ router.post(
           type,
           status: "PENDING",
           jobId: jobId ?? null,
+          milestoneId: milestoneId ?? null,
           maxLedger: maxLedger ?? null,
           fromAddress: fromAddress ?? null,
           toAddress: toAddress ?? null,
@@ -164,10 +175,15 @@ router.get(
           return res.json({ status: "FAILED", canRetry: false });
         }
 
-        // NOT_FOUND — check against maxLedger to detect expiry
+        // NOT_FOUND — check whether the transaction's timeBounds deadline has
+        // passed. `maxLedger` stores `tx.timeBounds.maxTime`, a Unix timestamp
+        // in seconds (set in submitWithPreRegistration), not a ledger sequence
+        // number — it must be compared against wall-clock time, not against
+        // `getLatestLedger().sequence` (which is orders of magnitude smaller
+        // and would never trip this check).
         if (record.maxLedger != null) {
-          const latest = await rpcServer.getLatestLedger();
-          if (latest.sequence > record.maxLedger) {
+          const nowSeconds = Math.floor(Date.now() / 1000);
+          if (nowSeconds > record.maxLedger) {
             await prisma.transaction.update({
               where: { id: record.id },
               data: { status: "EXPIRED" },

--- a/frontend/src/app/jobs/[id]/JobDetailClient.tsx
+++ b/frontend/src/app/jobs/[id]/JobDetailClient.tsx
@@ -81,6 +81,29 @@ type PendingOnChainAction = {
   };
 };
 
+// Only the confirmTypes that actually move funds are tracked with the
+// backend's transaction-status endpoint (see WalletContext.signAndBroadcastTransaction),
+// since the Transaction model's `type` column is also used for the user-facing
+// financial transaction history and shouldn't be populated with non-monetary
+// actions (e.g. CREATE_JOB, PROPOSE_REVISION) under a misleading DEPOSIT/RELEASE/REFUND label.
+const MONEY_MOVING_TX_TYPE: Partial<
+  Record<PendingOnChainAction["confirmType"], "DEPOSIT" | "RELEASE" | "REFUND">
+> = {
+  FUND_JOB: "DEPOSIT",
+  APPROVE_MILESTONE: "RELEASE",
+  CANCEL_JOB: "REFUND",
+  CLAIM_REFUND: "REFUND",
+};
+
+// Endpoints that produce a fresh unsigned XDR for a given confirmType, reused
+// both for the initial build and to rebuild after an EXPIRED (canRetry) result.
+const CONFIRM_TYPE_ENDPOINT: Partial<Record<PendingOnChainAction["confirmType"], string>> = {
+  FUND_JOB: "/escrow/init-fund",
+  APPROVE_MILESTONE: "/escrow/init-approve",
+  CANCEL_JOB: "/escrow/init-cancel",
+  CLAIM_REFUND: "/escrow/init-refund",
+};
+
 export default function JobDetailClient() {
   const { id } = useParams();
   const { address, balances, signAndBroadcastTransaction } = useWallet();
@@ -327,6 +350,27 @@ export default function JobDetailClient() {
     }
   };
 
+  const rebuildXdrForAction = async (
+    action: PendingOnChainAction,
+    authToken: string | null,
+  ): Promise<string> => {
+    const endpoint = CONFIRM_TYPE_ENDPOINT[action.confirmType];
+    if (!endpoint) {
+      throw new Error("This action cannot be automatically retried.");
+    }
+    const payload: Record<string, unknown> =
+      action.confirmType === "FUND_JOB"
+        ? { jobId: id, paymentToken: selectedPaymentToken }
+        : action.confirmType === "APPROVE_MILESTONE"
+          ? { milestoneId: action.milestoneId }
+          : { jobId: id };
+
+    const res = await axios.post(`${API_URL}${endpoint}`, payload, {
+      headers: { Authorization: `Bearer ${authToken}` },
+    });
+    return res.data.xdr;
+  };
+
   const confirmPendingOnChainAction = async (preparedXdr: string) => {
     if (!pendingOnChainAction) return;
 
@@ -339,7 +383,22 @@ export default function JobDetailClient() {
 
     try {
       const token = localStorage.getItem("token");
-      const txResult = await signAndBroadcastTransaction(preparedXdr);
+      const txType = MONEY_MOVING_TX_TYPE[action.confirmType];
+      const meta = txType
+        ? { type: txType, jobId: String(id), milestoneId: action.milestoneId }
+        : undefined;
+
+      let xdrToSend = preparedXdr;
+      let txResult = await signAndBroadcastTransaction(xdrToSend, meta);
+
+      if (!txResult.success && txResult.canRetry && meta) {
+        // Transaction's ledger deadline passed before it was included — the
+        // original sequence number is no longer usable. Rebuild against the
+        // same init endpoint (which always fetches the account's current
+        // sequence number) and resubmit once.
+        xdrToSend = await rebuildXdrForAction(action, token);
+        txResult = await signAndBroadcastTransaction(xdrToSend, meta);
+      }
 
       if (!txResult.success) {
         throw new Error(txResult.error || "Transaction failed");
@@ -603,13 +662,24 @@ export default function JobDetailClient() {
         throw new Error("Please log in again.");
       }
 
-      const res = await axios.put(
-        `${API_URL}/milestones/${milestoneId}/approve`,
-        {},
-        { headers: { Authorization: `Bearer ${token}` } },
-      );
+      const fetchApproveXdr = async () => {
+        const r = await axios.put(
+          `${API_URL}/milestones/${milestoneId}/approve`,
+          {},
+          { headers: { Authorization: `Bearer ${token}` } },
+        );
+        return r.data.xdr as string;
+      };
 
-      const txResult = await signAndBroadcastTransaction(res.data.xdr);
+      const meta = { type: "RELEASE" as const, jobId: String(id), milestoneId };
+      let xdrToSend = await fetchApproveXdr();
+      let txResult = await signAndBroadcastTransaction(xdrToSend, meta);
+
+      if (!txResult.success && txResult.canRetry) {
+        xdrToSend = await fetchApproveXdr();
+        txResult = await signAndBroadcastTransaction(xdrToSend, meta);
+      }
+
       if (!txResult.success) {
         throw new Error(txResult.error || "Transaction failed");
       }

--- a/frontend/src/components/RaiseDisputeModal.tsx
+++ b/frontend/src/components/RaiseDisputeModal.tsx
@@ -142,15 +142,33 @@ export default function RaiseDisputeModal({
     try {
       const token = localStorage.getItem("token");
 
+      const fetchRaiseDisputeXdr = async () => {
+        const r = await axios.post(
+          `${API_URL}/disputes/init-raise`,
+          { jobId: job.id, reason, minVotes },
+          { headers: { Authorization: `Bearer ${token}` } },
+        );
+        return r.data;
+      };
+
       // 1. Get XDR
-      const res = await axios.post(
-        `${API_URL}/disputes/init-raise`,
-        { jobId: job.id, reason, minVotes },
-        { headers: { Authorization: `Bearer ${token}` } },
-      );
+      let initData = await fetchRaiseDisputeXdr();
 
       // 2. Sign & Broadcast
-      const txResult = await signAndBroadcastTransaction(res.data.xdr);
+      let txResult = await signAndBroadcastTransaction(initData.xdr, {
+        type: "DISPUTE_PAYOUT",
+        jobId: job.id,
+      });
+
+      if (!txResult.success && txResult.canRetry) {
+        // Expired before confirmation — rebuild with a fresh sequence number
+        // and resubmit once rather than surfacing a generic timeout.
+        initData = await fetchRaiseDisputeXdr();
+        txResult = await signAndBroadcastTransaction(initData.xdr, {
+          type: "DISPUTE_PAYOUT",
+          jobId: job.id,
+        });
+      }
 
       if (!txResult.success) {
         throw new Error(txResult.error || "Transaction failed");
@@ -164,7 +182,7 @@ export default function RaiseDisputeModal({
           type: "RAISE_DISPUTE",
           jobId: job.id,
           onChainDisputeId: 1,
-          respondentId: res.data.respondentId,
+          respondentId: initData.respondentId,
           reason,
         },
         { headers: { Authorization: `Bearer ${token}` } },

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -61,6 +61,14 @@ interface WalletSession {
 
 type WalletProviderType = "freighter" | "walletconnect" | "lobstr";
 
+export type TxResolutionStatus = "PENDING" | "SUCCESS" | "FAILED" | "EXPIRED";
+
+export interface TxTrackingMeta {
+  type: "DEPOSIT" | "RELEASE" | "REFUND" | "DISPUTE_PAYOUT";
+  jobId?: string;
+  milestoneId?: string;
+}
+
 interface WalletState {
   address: string | null;
   isConnecting: boolean;
@@ -75,9 +83,30 @@ interface WalletState {
   disconnect: () => void;
   refreshBalance: () => Promise<void>;
   signMessage: (message: string) => Promise<string>;
+  /**
+   * Signs and broadcasts a Soroban transaction.
+   *
+   * When `meta` is supplied, the transaction is pre-registered with the
+   * backend (`POST /transactions/pre-register`) and its terminal state is
+   * resolved by polling the backend's `GET /transactions/:hash/status`
+   * endpoint — the same DB-tracked source of truth used to detect ledger
+   * expiry — instead of raw RPC polling. This is what allows `status` and
+   * `canRetry` to be populated so callers can distinguish a transaction that
+   * has permanently expired (safe to rebuild with a fresh sequence number and
+   * resubmit) from one that is merely slow. Callers that omit `meta` keep the
+   * legacy RPC-only polling behavior (no `status`/`canRetry`).
+   */
   signAndBroadcastTransaction: (
-    xdr: string
-  ) => Promise<{ hash: string; success: boolean; error?: string; resultXdr?: string }>;
+    xdr: string,
+    meta?: TxTrackingMeta
+  ) => Promise<{
+    hash: string;
+    success: boolean;
+    error?: string;
+    resultXdr?: string;
+    status?: TxResolutionStatus;
+    canRetry?: boolean;
+  }>;
   /**
    * Bind the currently-connected wallet address to the authenticated account
    * by completing a server-issued challenge / ed25519 signature round-trip.
@@ -109,6 +138,9 @@ export { truncateAddress };
 
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
 const horizonServer = new Horizon.Server(HORIZON_URL);
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000/api/v1";
+const STATUS_POLL_INTERVAL_MS = 3000;
+const STATUS_POLL_MAX_ATTEMPTS = 40; // ~2 minutes
 
 const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
 const MAINNET_PASSPHRASE = "Public Global Stellar Network ; September 2015";
@@ -761,7 +793,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     }
   }, [address, signMessage]);
 
-  const signAndBroadcastTransaction = useCallback(async (xdr: string) => {
+  const signAndBroadcastTransaction = useCallback(async (xdr: string, meta?: TxTrackingMeta) => {
     try {
       let signedResult: any;
 
@@ -796,21 +828,104 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
         return { success: false, hash: sendResponse.hash, error: "Transaction submission failed" };
       }
 
-      let attempts = 0;
-      while (attempts <= 10) {
-        const statusResponse = await server.getTransaction(sendResponse.hash);
-        if (statusResponse.status === rpc.Api.GetTransactionStatus.SUCCESS) {
-          const successResponse = statusResponse as rpc.Api.GetSuccessfulTransactionResponse;
-          return { success: true, hash: sendResponse.hash, resultXdr: successResponse.returnValue?.toXDR("base64") };
+      if (!meta) {
+        // Legacy path — raw RPC polling only, preserved for callers that
+        // don't yet track transactions with the backend.
+        let attempts = 0;
+        while (attempts <= 10) {
+          const statusResponse = await server.getTransaction(sendResponse.hash);
+          if (statusResponse.status === rpc.Api.GetTransactionStatus.SUCCESS) {
+            const successResponse = statusResponse as rpc.Api.GetSuccessfulTransactionResponse;
+            return { success: true, hash: sendResponse.hash, resultXdr: successResponse.returnValue?.toXDR("base64") };
+          }
+          if (statusResponse.status === rpc.Api.GetTransactionStatus.FAILED) {
+            return { success: false, hash: sendResponse.hash, error: "Transaction failed on-chain" };
+          }
+          attempts++;
+          await new Promise((resolve) => setTimeout(resolve, 2000));
         }
-        if (statusResponse.status === rpc.Api.GetTransactionStatus.FAILED) {
-          return { success: false, hash: sendResponse.hash, error: "Transaction failed on-chain" };
-        }
-        attempts++;
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        return { success: false, hash: sendResponse.hash, error: "Transaction timed out" };
       }
 
-      return { success: false, hash: sendResponse.hash, error: "Transaction timed out" };
+      // Tracked path — pre-register with the backend, then let the backend's
+      // DB-tracked status endpoint (the same one that detects ledger expiry)
+      // be the single source of truth for the terminal state, instead of
+      // maintaining a second, independent RPC-only status vocabulary here.
+      const maxTime = tx.timeBounds?.maxTime;
+      const maxLedger = maxTime ? parseInt(String(maxTime), 10) : undefined;
+      const token = localStorage.getItem("token") ?? localStorage.getItem("stellarmarket_jwt");
+
+      try {
+        await fetch(`${API_URL}/transactions/pre-register`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({
+            txHash: sendResponse.hash,
+            type: meta.type,
+            jobId: meta.jobId,
+            milestoneId: meta.milestoneId,
+            maxLedger: maxLedger && !isNaN(maxLedger) ? maxLedger : undefined,
+          }),
+        });
+      } catch {
+        // Pre-registration is best-effort — if it fails we still poll below;
+        // the endpoint will 404 until the record exists, which is treated the
+        // same as a still-pending transaction.
+      }
+
+      let attempts = 0;
+      while (attempts < STATUS_POLL_MAX_ATTEMPTS) {
+        try {
+          const statusRes = await fetch(`${API_URL}/transactions/${sendResponse.hash}/status`);
+          if (statusRes.ok) {
+            const data: { status: TxResolutionStatus; canRetry?: boolean } = await statusRes.json();
+
+            if (data.status === "SUCCESS") {
+              const successResponse = await server.getTransaction(sendResponse.hash);
+              const resultXdr =
+                successResponse.status === rpc.Api.GetTransactionStatus.SUCCESS
+                  ? (successResponse as rpc.Api.GetSuccessfulTransactionResponse).returnValue?.toXDR("base64")
+                  : undefined;
+              return { success: true, hash: sendResponse.hash, status: "SUCCESS" as const, resultXdr };
+            }
+
+            if (data.status === "FAILED") {
+              return {
+                success: false,
+                hash: sendResponse.hash,
+                status: "FAILED" as const,
+                canRetry: false,
+                error: "Transaction failed on-chain.",
+              };
+            }
+
+            if (data.status === "EXPIRED") {
+              return {
+                success: false,
+                hash: sendResponse.hash,
+                status: "EXPIRED" as const,
+                canRetry: true,
+                error: "Transaction expired before confirmation and can no longer be included. It can be retried with a fresh sequence number.",
+              };
+            }
+          }
+        } catch {
+          // Transient network error — keep polling.
+        }
+        attempts++;
+        await new Promise((resolve) => setTimeout(resolve, STATUS_POLL_INTERVAL_MS));
+      }
+
+      return {
+        success: false,
+        hash: sendResponse.hash,
+        status: "PENDING" as const,
+        canRetry: false,
+        error: "Still processing on-chain — this is taking longer than usual. Check back in a moment.",
+      };
     } catch (err: unknown) {
       return {
         success: false,

--- a/frontend/src/context/__tests__/WalletContext.transaction.test.tsx
+++ b/frontend/src/context/__tests__/WalletContext.transaction.test.tsx
@@ -1,0 +1,208 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, act, screen, fireEvent, waitFor } from "@testing-library/react";
+import { WalletProvider, useWallet } from "../WalletContext";
+
+jest.mock("@/components/Toast", () => ({
+  useToast: () => ({
+    toast: {
+      success: jest.fn(),
+      error: jest.fn(),
+    },
+  }),
+}));
+
+const mockRequestAccess = jest.fn();
+const mockGetAddress = jest.fn();
+const mockIsConnected = jest.fn();
+const mockGetPublicKey = jest.fn();
+const mockSignTransaction = jest.fn();
+
+jest.mock("@stellar/freighter-api", () => ({
+  requestAccess: (...args: any[]) => mockRequestAccess(...args),
+  getAddress: (...args: any[]) => mockGetAddress(...args),
+  isConnected: (...args: any[]) => mockIsConnected(...args),
+  getPublicKey: (...args: any[]) => mockGetPublicKey(...args),
+  signTransaction: (...args: any[]) => mockSignTransaction(...args),
+}));
+
+const mockSendTransaction = jest.fn();
+const mockGetTransaction = jest.fn();
+
+jest.mock("@stellar/stellar-sdk", () => ({
+  Horizon: {
+    Server: jest.fn().mockImplementation(() => ({
+      loadAccount: jest.fn().mockResolvedValue({ balances: [] }),
+    })),
+  },
+  rpc: {
+    Server: jest.fn().mockImplementation(() => ({
+      sendTransaction: (...args: any[]) => mockSendTransaction(...args),
+      getTransaction: (...args: any[]) => mockGetTransaction(...args),
+    })),
+    Api: { GetTransactionStatus: { SUCCESS: "SUCCESS", FAILED: "FAILED" } },
+  },
+  Transaction: jest.fn().mockImplementation(() => ({ timeBounds: undefined })),
+}));
+
+function TestConsumer() {
+  const { connect, signAndBroadcastTransaction } = useWallet();
+  const [result, setResult] = React.useState<string>("");
+
+  return (
+    <div>
+      <button data-testid="connect-btn" onClick={() => connect("freighter")}>
+        Connect
+      </button>
+      <button
+        data-testid="sign-btn"
+        onClick={async () => {
+          const r = await signAndBroadcastTransaction("XDR", { type: "RELEASE", jobId: "job1" });
+          setResult(JSON.stringify(r));
+        }}
+      >
+        Sign (tracked)
+      </button>
+      <button
+        data-testid="sign-legacy-btn"
+        onClick={async () => {
+          const r = await signAndBroadcastTransaction("XDR");
+          setResult(JSON.stringify(r));
+        }}
+      >
+        Sign (legacy)
+      </button>
+      <div data-testid="result">{result}</div>
+    </div>
+  );
+}
+
+async function renderAndConnect() {
+  (window as any).freighter = {};
+  mockIsConnected.mockResolvedValue({ isConnected: true });
+  mockRequestAccess.mockResolvedValue({ address: "GADDR" });
+  mockGetPublicKey.mockResolvedValue("GADDR");
+
+  render(
+    <WalletProvider>
+      <TestConsumer />
+    </WalletProvider>
+  );
+
+  await act(async () => {
+    fireEvent.click(screen.getByTestId("connect-btn"));
+  });
+}
+
+function getResult() {
+  return JSON.parse(screen.getByTestId("result").textContent || "{}");
+}
+
+describe("WalletContext.signAndBroadcastTransaction — tracked path (meta supplied)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    delete (window as any).freighter;
+    global.fetch = jest.fn();
+  });
+
+  it("resolves SUCCESS via the backend status endpoint and attaches resultXdr from one final RPC check", async () => {
+    await renderAndConnect();
+
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: "SIGNED_XDR" });
+    mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: "hash1" });
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) }) // pre-register
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "SUCCESS" }) }); // status poll
+    mockGetTransaction.mockResolvedValue({
+      status: "SUCCESS",
+      returnValue: { toXDR: () => "RESULT_XDR" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("sign-btn"));
+    });
+
+    await waitFor(() => {
+      const parsed = getResult();
+      expect(parsed.success).toBe(true);
+      expect(parsed.status).toBe("SUCCESS");
+      expect(parsed.resultXdr).toBe("RESULT_XDR");
+    });
+  });
+
+  it("returns FAILED with canRetry: false and a message distinct from a timeout", async () => {
+    await renderAndConnect();
+
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: "SIGNED_XDR" });
+    mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: "hash2" });
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "FAILED" }) });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("sign-btn"));
+    });
+
+    await waitFor(() => {
+      const parsed = getResult();
+      expect(parsed.success).toBe(false);
+      expect(parsed.status).toBe("FAILED");
+      expect(parsed.canRetry).toBe(false);
+      expect(parsed.error).toMatch(/failed on-chain/i);
+    });
+  });
+
+  it("returns EXPIRED with canRetry: true so the caller knows it can rebuild and resubmit", async () => {
+    await renderAndConnect();
+
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: "SIGNED_XDR" });
+    mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: "hash3" });
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: "EXPIRED", canRetry: true }) });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("sign-btn"));
+    });
+
+    await waitFor(() => {
+      const parsed = getResult();
+      expect(parsed.success).toBe(false);
+      expect(parsed.status).toBe("EXPIRED");
+      expect(parsed.canRetry).toBe(true);
+    });
+  });
+});
+
+describe("WalletContext.signAndBroadcastTransaction — legacy path (meta omitted)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    delete (window as any).freighter;
+    global.fetch = jest.fn();
+  });
+
+  it("preserves raw RPC-only polling and never calls the backend when meta is omitted", async () => {
+    await renderAndConnect();
+
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: "SIGNED_XDR" });
+    mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: "hash4" });
+    mockGetTransaction.mockResolvedValue({
+      status: "SUCCESS",
+      returnValue: { toXDR: () => "RESULT_XDR" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("sign-legacy-btn"));
+    });
+
+    await waitFor(() => {
+      const parsed = getResult();
+      expect(parsed.success).toBe(true);
+      expect(parsed.resultXdr).toBe("RESULT_XDR");
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #879

## Problem

`WalletContext.signAndBroadcastTransaction` polled Soroban RPC directly (only distinguishing SUCCESS/FAILED, with a generic "Transaction timed out" error on exhaustion), while a separate backend-tracked endpoint (`GET /transactions/:hash/status`) already modeled `EXPIRED`/`canRetry` — but nothing actually called it. `usePendingTransaction` (the hook meant to consume it) had zero callers anywhere in the app, and `submitWithPreRegistration` (the utility meant to feed it) was also unused. So every real money-moving call site inherited only the RPC-only, no-resume behavior.

## What changed

- **`signAndBroadcastTransaction`** now accepts optional tracking metadata (`{ type, jobId, milestoneId }`). When supplied, it pre-registers the transaction and polls the backend's DB-tracked status endpoint — the single source of truth for terminal state — instead of a second, independent RPC-only vocabulary. Callers that omit metadata keep the exact legacy RPC-only behavior (zero risk to untouched call sites).
- **Fixed the actual expiry-detection bug**, found in two places (`GET /transactions/:hash/status` and the `pending-tx` background job): `maxLedger` stores `tx.timeBounds.maxTime`, a Unix timestamp in seconds — but was being compared against a ledger *sequence number* from `getLatestLedger().sequence`. Those units never cross (ledger sequence ~10^7, Unix timestamp ~10^9), so `EXPIRED` could never actually fire in production. Now compared against wall-clock time.
- **Wired the resume flow** (rebuild with a fresh sequence number → re-sign → resubmit, bounded to one automatic retry) into the money-moving callers named in the issue: fund/deposit, approve-milestone (`JobDetailClient.tsx`), and raise-dispute (`RaiseDisputeModal.tsx`).
- Added `milestoneId` to the pre-register payload/schema (the DB column already existed but the route silently dropped it).

## Known gap

`app/disputes/[id]/page.tsx` calls `POST /disputes/init-vote` and `POST /disputes/init-resolve` for arbitrator voting/resolution — neither endpoint exists on the backend, so those calls 404 before ever reaching `signAndBroadcastTransaction` today. I did not add resume-flow logic there since there's nothing functioning yet to resume; that's a separate missing-backend-endpoint bug worth its own issue.

## Testing

- Backend: added coverage for `GET /transactions/:hash/status` (SUCCESS/FAILED/EXPIRED/PENDING, including the wall-clock expiry fix) and updated `pending-tx.test.ts` to reflect the corrected comparison.
- Frontend: added `WalletContext.transaction.test.tsx` covering the tracked path (SUCCESS with resultXdr, FAILED with `canRetry: false`, EXPIRED with `canRetry: true`) and confirming the legacy path is unaffected when metadata is omitted.
- `npx tsc --noEmit` clean on both packages (no new errors vs. main).

## Test plan
- [x] Backend: `npx jest src/routes/__tests__/transaction.routes.test.ts src/__tests__/pending-tx.test.ts`
- [x] Frontend: `npx jest src/context src/app/jobs src/components/RaiseDisputeModal`
- [x] Typecheck both packages