### PR TITLE
fix: verify on-chain contract effects and enforce per-job auth in confirm-tx

### DIFF
--- a/backend/src/routes/__tests__/escrow.confirm-tx.test.ts
+++ b/backend/src/routes/__tests__/escrow.confirm-tx.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Security tests for POST /api/escrow/confirm-tx (#871)
+ *
+ * Covers:
+ *  - Spoofed hash from an unrelated contract → rejected
+ *  - Valid fund_job hash for job A claimed against job B → rejected
+ *  - Unauthorized caller (neither client nor freelancer) → rejected
+ *  - Source account mismatch with caller's registered wallet → rejected
+ *  - Function name mismatch (type vs actual on-chain call) → rejected
+ *  - Happy path: FUND_JOB, SUBMIT_MILESTONE, APPROVE_MILESTONE, CREATE_JOB
+ */
+
+import express from "express";
+import request from "supertest";
+
+// ── Controllable userId for per-test auth simulation ──────────────────────────
+
+let currentUserId = "CLIENT_ID_PLACEHOLDER";
+
+jest.mock("../../middleware/auth", () => ({
+  // Bypass real JWT validation; just inject the test-controlled userId
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authenticate: jest.fn((req: any, _res: any, next: any) => {
+    req.userId = currentUserId;
+    next();
+  }),
+  walletSourceGuard: jest.fn((_req: any, _res: any, next: any) => next()),
+}));
+
+// ── Contract service mock ─────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockVerifyTransactionEffects = jest.fn() as jest.MockedFunction<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSyncJobFromChain = jest.fn() as jest.MockedFunction<any>;
+
+jest.mock("../../services/contract.service", () => ({
+  ContractService: {
+    verifyTransactionEffects: mockVerifyTransactionEffects,
+    syncJobFromChain: mockSyncJobFromChain,
+    buildCreateJobTx: jest.fn(),
+    buildFundJobTx: jest.fn(),
+    buildApproveMilestoneTx: jest.fn(),
+    verifyTransaction: jest.fn(),
+    simulateFundJob: jest.fn().mockResolvedValue({ ok: true }),
+    getRateSnapshot: jest.fn(),
+    getEscrowTtl: jest.fn(),
+  },
+  ContractSimulationError: class ContractSimulationError extends Error {},
+}));
+
+// ── Prisma mock ───────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma: Record<string, any> = {
+  job: { findUnique: jest.fn(), update: jest.fn() },
+  milestone: { findUnique: jest.fn(), findMany: jest.fn(), update: jest.fn() },
+  user: { findUnique: jest.fn() },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  $transaction: jest.fn(async (cb: (tx: any) => Promise<void>) => {
+    await cb({
+      milestone: {
+        update: jest.fn().mockResolvedValue({
+          id: "ms1",
+          jobId: JOB_A_ID,
+          title: "MS",
+          job: { clientId: CLIENT_ID, freelancerId: FREELANCER_ID },
+        }),
+        findMany: jest.fn().mockResolvedValue([{ status: "APPROVED" }]),
+      },
+      job: { update: jest.fn() },
+    });
+  }),
+};
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  EscrowStatus: {
+    UNFUNDED: "UNFUNDED",
+    FUNDED: "FUNDED",
+    COMPLETED: "COMPLETED",
+    CANCELLED: "CANCELLED",
+  },
+  NotificationType: {
+    MILESTONE_APPROVED: "MILESTONE_APPROVED",
+    MILESTONE_SUBMITTED: "MILESTONE_SUBMITTED",
+  },
+}));
+
+jest.mock("../../services/notification.service", () => ({
+  NotificationService: { sendNotification: jest.fn() },
+}));
+
+jest.mock("../../lib/cache", () => ({
+  invalidateCache: jest.fn(),
+  invalidateCacheKey: jest.fn(),
+  generateJobCacheKey: (id: string) => `job:${id}`,
+  generateJobOnChainStatusCacheKey: (id: string) => `job:onchain:${id}`,
+}));
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const CLIENT_ID     = "00000000-0000-4000-8000-000000000001";
+const FREELANCER_ID = "00000000-0000-4000-8000-000000000002";
+const OUTSIDER_ID   = "00000000-0000-4000-8000-000000000003";
+const JOB_A_ID      = "00000000-0000-4000-8000-000000000100";
+const JOB_B_ID      = "00000000-0000-4000-8000-000000000200";
+const MILESTONE_ID  = "00000000-0000-4000-8000-000000000300";
+
+const ESCROW_CONTRACT   = "CESCROWCONTRACT00000000000000000000000000000000000000000";
+const OTHER_CONTRACT    = "COTHER000000000000000000000000000000000000000000000000";
+const CLIENT_WALLET     = "GCLIENTWALLET000000000000000000000000000000000000000000";
+const FREELANCER_WALLET = "GFREELANCERWALLET000000000000000000000000000000000000000";
+
+// Override the configured escrow contract ID for tests
+jest.mock("../../config", () => ({
+  config: {
+    jwtSecret: "test-secret",
+    stellar: {
+      escrowContractId: "CESCROWCONTRACT00000000000000000000000000000000000000000",
+      rpcUrl: "https://soroban-testnet.stellar.org",
+    },
+  },
+}));
+
+// ── App setup ─────────────────────────────────────────────────────────────────
+
+import escrowRouter from "../escrow.routes";
+
+const app = express();
+app.use(express.json());
+app.use("/api/escrow", escrowRouter);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: JOB_A_ID,
+    clientId: CLIENT_ID,
+    freelancerId: FREELANCER_ID,
+    contractJobId: "42",
+    client: { walletAddress: CLIENT_WALLET },
+    freelancer: { walletAddress: FREELANCER_WALLET },
+    ...overrides,
+  };
+}
+
+function makeMilestone(overrides: Record<string, unknown> = {}) {
+  return {
+    id: MILESTONE_ID,
+    onChainIndex: 0,
+    jobId: JOB_A_ID,
+    title: "Milestone 1",
+    job: makeJob(),
+    ...overrides,
+  };
+}
+
+function validEffects(overrides: Record<string, unknown> = {}) {
+  return {
+    success: true,
+    contractId: ESCROW_CONTRACT,
+    functionName: "fund_job",
+    args: [BigInt(42), CLIENT_WALLET],
+    sourceAccount: CLIENT_WALLET,
+    ...overrides,
+  };
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  currentUserId = CLIENT_ID;
+  // Default: caller has the client wallet registered
+  mockPrisma.user.findUnique.mockResolvedValue({ walletAddress: CLIENT_WALLET });
+});
+
+// ── 1. Spoofed hash from an unrelated contract ────────────────────────────────
+
+describe("spoofed hash from a non-escrow contract", () => {
+  it("rejects with 403 when the transaction invoked a different contract", async () => {
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({ contractId: OTHER_CONTRACT }),
+    );
+    mockPrisma.job.findUnique.mockResolvedValue(makeJob());
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "aaa", type: "FUND_JOB", jobId: JOB_A_ID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/unexpected contract/i);
+  });
+});
+
+// ── 2. Valid hash for job A submitted against job B ───────────────────────────
+
+describe("job ID mismatch — valid tx for job A claimed against job B", () => {
+  it("rejects when on-chain job ID does not match the target job's contractJobId", async () => {
+    // Transaction was for on-chain job 42 (job A), request claims jobId = job B
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({ args: [BigInt(42), CLIENT_WALLET] }),
+    );
+    // Job B has contractJobId "99"
+    mockPrisma.job.findUnique.mockResolvedValue(makeJob({ id: JOB_B_ID, contractJobId: "99" }));
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "bbb", type: "FUND_JOB", jobId: JOB_B_ID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/job ID does not match/i);
+    expect(mockPrisma.job.update).not.toHaveBeenCalled();
+  });
+});
+
+// ── 3. Unauthorized caller ────────────────────────────────────────────────────
+
+describe("unauthorized caller — not client or freelancer", () => {
+  it("rejects FUND_JOB when the caller is neither client nor freelancer", async () => {
+    currentUserId = OUTSIDER_ID;
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({ sourceAccount: "GOUTSIDER" }),
+    );
+    mockPrisma.job.findUnique.mockResolvedValue(makeJob());
+    mockPrisma.user.findUnique.mockResolvedValue({ walletAddress: "GOUTSIDER" });
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "ccc", type: "FUND_JOB", jobId: JOB_A_ID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/only the client/i);
+    expect(mockPrisma.job.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects SUBMIT_MILESTONE when the client tries to confirm (only freelancer may)", async () => {
+    // client is signed in, but SUBMIT_MILESTONE must come from the freelancer
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({
+        functionName: "submit_milestone",
+        args: [BigInt(42), 0, CLIENT_WALLET],
+        sourceAccount: CLIENT_WALLET,
+      }),
+    );
+    mockPrisma.milestone.findUnique.mockResolvedValue(makeMilestone());
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "ddd", type: "SUBMIT_MILESTONE", milestoneId: MILESTONE_ID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/only the freelancer/i);
+  });
+
+  it("rejects APPROVE_MILESTONE when the freelancer tries to confirm (only client may)", async () => {
+    currentUserId = FREELANCER_ID;
+    mockPrisma.user.findUnique.mockResolvedValue({ walletAddress: FREELANCER_WALLET });
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({
+        functionName: "approve_milestone",
+        args: [BigInt(42), 0],
+        sourceAccount: FREELANCER_WALLET,
+      }),
+    );
+    mockPrisma.milestone.findUnique.mockResolvedValue(makeMilestone());
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "eee", type: "APPROVE_MILESTONE", milestoneId: MILESTONE_ID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/only the client/i);
+  });
+});
+
+// ── 4. Source account mismatch ────────────────────────────────────────────────
+
+describe("source account does not match caller's registered wallet", () => {
+  it("rejects when the on-chain signer differs from the authenticated user's wallet", async () => {
+    // Client's registered wallet is CLIENT_WALLET, but the tx was signed by FREELANCER_WALLET
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({ sourceAccount: FREELANCER_WALLET }),
+    );
+    mockPrisma.job.findUnique.mockResolvedValue(makeJob());
+    // user.findUnique returns CLIENT_WALLET — mismatch with sourceAccount
+    mockPrisma.user.findUnique.mockResolvedValue({ walletAddress: CLIENT_WALLET });
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "fff", type: "FUND_JOB", jobId: JOB_A_ID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/source account does not match/i);
+    expect(mockPrisma.job.update).not.toHaveBeenCalled();
+  });
+});
+
+// ── 5. Function name mismatch ─────────────────────────────────────────────────
+
+describe("function name mismatch — wrong on-chain call for declared type", () => {
+  it("rejects FUND_JOB type when the tx called a different function", async () => {
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({ functionName: "transfer" }),
+    );
+    mockPrisma.job.findUnique.mockResolvedValue(makeJob());
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "ggg", type: "FUND_JOB", jobId: JOB_A_ID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/fund_job/i);
+    expect(mockPrisma.job.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects CANCEL_JOB type when the tx actually called fund_job", async () => {
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({ functionName: "fund_job" }),
+    );
+    mockPrisma.job.findUnique.mockResolvedValue(makeJob());
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "hhh", type: "CANCEL_JOB", jobId: JOB_A_ID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/cancel_job/i);
+  });
+});
+
+// ── 6. On-chain verification failure ─────────────────────────────────────────
+
+describe("on-chain verification failure", () => {
+  it("returns 400 when the transaction is not found on-chain", async () => {
+    mockVerifyTransactionEffects.mockResolvedValue({ success: false, error: "NOT_FOUND" });
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "zzz", type: "FUND_JOB", jobId: JOB_A_ID });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/NOT_FOUND/);
+    expect(mockPrisma.job.update).not.toHaveBeenCalled();
+  });
+});
+
+// ── 7. Happy paths ────────────────────────────────────────────────────────────
+
+describe("happy path — authorized, matching transaction", () => {
+  it("FUND_JOB: marks job FUNDED when all checks pass", async () => {
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({ functionName: "fund_job", args: [BigInt(42), CLIENT_WALLET] }),
+    );
+    mockPrisma.job.findUnique.mockResolvedValue(makeJob());
+    mockPrisma.job.update.mockResolvedValue({});
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "ok1", type: "FUND_JOB", jobId: JOB_A_ID });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.job.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ escrowStatus: "FUNDED" }) }),
+    );
+  });
+
+  it("SUBMIT_MILESTONE: marks milestone SUBMITTED when freelancer confirms", async () => {
+    currentUserId = FREELANCER_ID;
+    mockPrisma.user.findUnique.mockResolvedValue({ walletAddress: FREELANCER_WALLET });
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({
+        functionName: "submit_milestone",
+        args: [BigInt(42), 0, FREELANCER_WALLET],
+        sourceAccount: FREELANCER_WALLET,
+      }),
+    );
+    mockPrisma.milestone.findUnique.mockResolvedValue(makeMilestone());
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "ok2", type: "SUBMIT_MILESTONE", milestoneId: MILESTONE_ID });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("APPROVE_MILESTONE: marks milestone APPROVED when client confirms", async () => {
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({
+        functionName: "approve_milestone",
+        args: [BigInt(42), 0],
+        sourceAccount: CLIENT_WALLET,
+      }),
+    );
+    mockPrisma.milestone.findUnique.mockResolvedValue(makeMilestone());
+    mockPrisma.user.findUnique.mockResolvedValue({ walletAddress: CLIENT_WALLET });
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "ok3", type: "APPROVE_MILESTONE", milestoneId: MILESTONE_ID });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("CREATE_JOB: sets contractJobId and milestone on-chain indices when client confirms", async () => {
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({
+        functionName: "create_job",
+        args: [CLIENT_WALLET, FREELANCER_WALLET, "CTOKEN", [], BigInt(9999)],
+        sourceAccount: CLIENT_WALLET,
+      }),
+    );
+    mockPrisma.job.findUnique.mockResolvedValue(makeJob());
+    mockPrisma.job.update.mockResolvedValue({});
+    mockPrisma.milestone.findMany.mockResolvedValue([
+      { id: "ms-a", order: 0 },
+      { id: "ms-b", order: 1 },
+    ]);
+    mockPrisma.milestone.update.mockResolvedValue({});
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "ok4", type: "CREATE_JOB", jobId: JOB_A_ID, onChainJobId: "42" });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.job.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ contractJobId: "42" }) }),
+    );
+    expect(mockPrisma.milestone.update).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/routes/__tests__/escrow.confirm-tx.test.ts
+++ b/backend/src/routes/__tests__/escrow.confirm-tx.test.ts
@@ -192,6 +192,22 @@ describe("spoofed hash from a non-escrow contract", () => {
     expect(res.status).toBe(403);
     expect(res.body.error).toMatch(/unexpected contract/i);
   });
+
+  it("rejects with 403 when contractId could not be decoded (undefined) — fail closed", async () => {
+    // contractId extraction has its own try/catch; undefined must not be treated as 'skip check'
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({ contractId: undefined }),
+    );
+    mockPrisma.job.findUnique.mockResolvedValue(makeJob());
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "aaa2", type: "FUND_JOB", jobId: JOB_A_ID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/unexpected contract/i);
+    expect(mockPrisma.job.update).not.toHaveBeenCalled();
+  });
 });
 
 // ── 2. Valid hash for job A submitted against job B ───────────────────────────
@@ -290,6 +306,23 @@ describe("source account does not match caller's registered wallet", () => {
     const res = await request(app)
       .post("/api/escrow/confirm-tx")
       .send({ hash: "fff", type: "FUND_JOB", jobId: JOB_A_ID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/source account does not match/i);
+    expect(mockPrisma.job.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects when sourceAccount could not be decoded (undefined) — fail closed", async () => {
+    // sourceAccount extraction has its own try/catch; undefined must not skip the wallet check
+    mockVerifyTransactionEffects.mockResolvedValue(
+      validEffects({ sourceAccount: undefined }),
+    );
+    mockPrisma.job.findUnique.mockResolvedValue(makeJob());
+    mockPrisma.user.findUnique.mockResolvedValue({ walletAddress: CLIENT_WALLET });
+
+    const res = await request(app)
+      .post("/api/escrow/confirm-tx")
+      .send({ hash: "fff2", type: "FUND_JOB", jobId: JOB_A_ID });
 
     expect(res.status).toBe(403);
     expect(res.body.error).toMatch(/source account does not match/i);

--- a/backend/src/routes/escrow.routes.ts
+++ b/backend/src/routes/escrow.routes.ts
@@ -474,52 +474,164 @@ router.post(
   })
 );
 
+// Maps each confirm-tx type to the escrow contract function that must have been called.
+const EXPECTED_CONTRACT_FN: Record<string, string> = {
+  CREATE_JOB: "create_job",
+  FUND_JOB: "fund_job",
+  EXTEND_DEADLINE: "extend_deadline",
+  SUBMIT_MILESTONE: "submit_milestone",
+  APPROVE_MILESTONE: "approve_milestone",
+  PROPOSE_REVISION: "propose_revision",
+  ACCEPT_REVISION: "accept_revision",
+  REJECT_REVISION: "reject_revision",
+  CANCEL_JOB: "cancel_job",
+  CLAIM_REFUND: "claim_refund",
+};
+
 /**
  * Confirm transaction and update local database.
- * In a real app, this should ideally be handled by an event listener/indexer,
- * but for this integration task, we verify the hash provided by the frontend.
+ * Decodes the actual on-chain contract invocation from the transaction envelope
+ * before applying any state change, and enforces per-job authorization for every
+ * operation type.
  */
 router.post("/confirm-tx", authenticate, idempotency(), asyncHandler(async (req: AuthRequest, res: Response) => {
-  const { hash, type, jobId, milestoneId, onChainJobId } = req.body;
+  const { hash, type, jobId, milestoneId, onChainJobId, newDeadline } = req.body;
 
-  const verification = await ContractService.verifyTransaction(hash);
-  if (!verification.success) {
-    return res.status(400).json({ error: `Transaction failed or not found: ${verification.error}` });
+  // ── 1. Decode on-chain effects ────────────────────────────────────────────
+  const effects = await ContractService.verifyTransactionEffects(hash);
+  if (!effects.success) {
+    return res.status(400).json({ error: `Transaction verification failed: ${effects.error}` });
   }
 
-  // Update DB based on transaction type
-  if (type === "CREATE_JOB" && jobId && onChainJobId) {
-    await prisma.job.update({
-      where: { id: jobId },
-      data: {
-        contractJobId: onChainJobId.toString(),
-        escrowStatus: EscrowStatus.UNFUNDED
-      }
-    });
+  // ── 2. Contract address must be the configured escrow contract ────────────
+  if (effects.contractId && effects.contractId !== config.stellar.escrowContractId) {
+    return res.status(403).json({ error: "Transaction invoked an unexpected contract" });
+  }
 
-    // Update milestones with their on-chain indices (0, 1, 2...)
-    const milestones = await prisma.milestone.findMany({
-      where: { jobId },
-      orderBy: { order: "asc" }
+  // ── 3. Function name must match the declared type ─────────────────────────
+  const expectedFn = EXPECTED_CONTRACT_FN[type];
+  if (expectedFn && effects.functionName && effects.functionName !== expectedFn) {
+    return res.status(403).json({
+      error: `Transaction called "${effects.functionName}" but type "${type}" requires "${expectedFn}"`,
     });
-    for (let i = 0; i < milestones.length; i++) {
-      await prisma.milestone.update({
-        where: { id: milestones[i].id },
-        data: { onChainIndex: i }
+  }
+
+  // ── 4. Source account must match the authenticated user's wallet ──────────
+  if (effects.sourceAccount) {
+    const caller = await prisma.user.findUnique({
+      where: { id: req.userId! },
+      select: { walletAddress: true },
+    });
+    if (caller?.walletAddress && effects.sourceAccount !== caller.walletAddress) {
+      return res.status(403).json({
+        error: "Transaction source account does not match your registered wallet",
       });
     }
-  } else if (type === "FUND_JOB" && jobId) {
+  }
+
+  // ── 5. Load job (and milestone) for authorization + arg checks ────────────
+  // For milestone-only types the job is fetched through the milestone relation.
+  type JobRow = {
+    id: string;
+    clientId: string;
+    freelancerId: string | null;
+    contractJobId: string | null;
+    client: { walletAddress: string | null };
+    freelancer: { walletAddress: string | null } | null;
+  };
+
+  let job: JobRow | null = null;
+  let milestone: { id: string; onChainIndex: number | null; jobId: string | null } | null = null;
+
+  if (milestoneId) {
+    const ms = await prisma.milestone.findUnique({
+      where: { id: milestoneId },
+      include: { job: { include: { client: true, freelancer: true } } },
+    });
+    if (!ms) return res.status(404).json({ error: "Milestone not found" });
+    milestone = { id: ms.id, onChainIndex: ms.onChainIndex, jobId: ms.jobId };
+    job = ms.job as unknown as JobRow;
+  } else if (jobId) {
+    job = await prisma.job.findUnique({
+      where: { id: jobId },
+      include: { client: true, freelancer: true },
+    }) as JobRow | null;
+  }
+
+  if (!job) return res.status(404).json({ error: "Job not found" });
+
+  const args = effects.args ?? [];
+
+  // ── 6. Per-type: authorization + arg validation + DB write ────────────────
+
+  if (type === "CREATE_JOB" && jobId && onChainJobId) {
+    if (job.clientId !== req.userId) {
+      return res.status(403).json({ error: "Only the client can confirm job creation" });
+    }
+    // Args: (client: Address, freelancer: Address, token: Address, milestones: vec, deadline: u64)
+    const argClient = args[0] !== undefined ? String(args[0]) : undefined;
+    const argFreelancer = args[1] !== undefined ? String(args[1]) : undefined;
+    if (argClient && job.client?.walletAddress && argClient !== job.client.walletAddress) {
+      return res.status(403).json({ error: "Transaction client address does not match this job" });
+    }
+    if (argFreelancer && job.freelancer?.walletAddress && argFreelancer !== job.freelancer.walletAddress) {
+      return res.status(403).json({ error: "Transaction freelancer address does not match this job" });
+    }
+
     await prisma.job.update({
       where: { id: jobId },
-      data: { escrowStatus: EscrowStatus.FUNDED }
+      data: { contractJobId: onChainJobId.toString(), escrowStatus: EscrowStatus.UNFUNDED },
     });
+    const milestones = await prisma.milestone.findMany({ where: { jobId }, orderBy: { order: "asc" } });
+    for (let i = 0; i < milestones.length; i++) {
+      await prisma.milestone.update({ where: { id: milestones[i].id }, data: { onChainIndex: i } });
+    }
+
+  } else if (type === "FUND_JOB" && jobId) {
+    if (job.clientId !== req.userId) {
+      return res.status(403).json({ error: "Only the client can confirm job funding" });
+    }
+    // Args: (job_id: u64, client: Address, agreed_value_stroops: i128, max_slippage_bps: u32)
+    const argJobId = args[0] !== undefined ? String(args[0]) : undefined;
+    if (argJobId && job.contractJobId && argJobId !== job.contractJobId) {
+      return res.status(403).json({ error: "Transaction job ID does not match this job" });
+    }
+
+    await prisma.job.update({ where: { id: jobId }, data: { escrowStatus: EscrowStatus.FUNDED } });
+
   } else if (type === "EXTEND_DEADLINE" && milestoneId) {
-    const { newDeadline } = req.body;
+    if (job.clientId !== req.userId) {
+      return res.status(403).json({ error: "Only the client can confirm a deadline extension" });
+    }
+    // Args: (job_id: u64, milestone_index: u32, new_deadline: u64)
+    const argJobId = args[0] !== undefined ? String(args[0]) : undefined;
+    const argMilestoneIdx = args[1] !== undefined ? Number(args[1]) : undefined;
+    if (argJobId && job.contractJobId && argJobId !== job.contractJobId) {
+      return res.status(403).json({ error: "Transaction job ID does not match this job" });
+    }
+    if (argMilestoneIdx !== undefined && milestone?.onChainIndex !== null && milestone?.onChainIndex !== undefined && argMilestoneIdx !== milestone.onChainIndex) {
+      return res.status(403).json({ error: "Transaction milestone index does not match this milestone" });
+    }
+
     await prisma.milestone.update({
       where: { id: milestoneId },
       data: { contractDeadline: new Date(newDeadline) },
     });
+
   } else if (type === "SUBMIT_MILESTONE" && milestoneId) {
+    if (job.freelancerId !== req.userId) {
+      return res.status(403).json({ error: "Only the freelancer can confirm milestone submission" });
+    }
+    // Args: (job_id: u64, milestone_index: u32, freelancer: Address)
+    const argJobId = args[0] !== undefined ? String(args[0]) : undefined;
+    const argMilestoneIdx = args[1] !== undefined ? Number(args[1]) : undefined;
+    if (argJobId && job.contractJobId && argJobId !== job.contractJobId) {
+      return res.status(403).json({ error: "Transaction job ID does not match this job" });
+    }
+    if (argMilestoneIdx !== undefined && milestone?.onChainIndex !== null && milestone?.onChainIndex !== undefined && argMilestoneIdx !== milestone.onChainIndex) {
+      return res.status(403).json({ error: "Transaction milestone index does not match this milestone" });
+    }
+
     let affectedJobId: string | null = null;
     await prisma.$transaction(async (tx) => {
       const updatedMilestone = await tx.milestone.update({
@@ -527,10 +639,8 @@ router.post("/confirm-tx", authenticate, idempotency(), asyncHandler(async (req:
         data: { status: "SUBMITTED" },
         include: { job: true },
       });
-
       if (!updatedMilestone.jobId) return;
       affectedJobId = updatedMilestone.jobId;
-
       await NotificationService.sendNotification({
         userId: updatedMilestone.job.clientId,
         type: NotificationType.MILESTONE_SUBMITTED,
@@ -544,35 +654,37 @@ router.post("/confirm-tx", authenticate, idempotency(), asyncHandler(async (req:
       await invalidateCacheKey(generateJobOnChainStatusCacheKey(affectedJobId));
       await invalidateCacheKey(generateJobCacheKey(affectedJobId));
     }
+
   } else if (type === "APPROVE_MILESTONE" && milestoneId) {
+    if (job.clientId !== req.userId) {
+      return res.status(403).json({ error: "Only the client can confirm milestone approval" });
+    }
+    // Args: (job_id: u64, milestone_index: u32, ...)
+    const argJobId = args[0] !== undefined ? String(args[0]) : undefined;
+    const argMilestoneIdx = args[1] !== undefined ? Number(args[1]) : undefined;
+    if (argJobId && job.contractJobId && argJobId !== job.contractJobId) {
+      return res.status(403).json({ error: "Transaction job ID does not match this job" });
+    }
+    if (argMilestoneIdx !== undefined && milestone?.onChainIndex !== null && milestone?.onChainIndex !== undefined && argMilestoneIdx !== milestone.onChainIndex) {
+      return res.status(403).json({ error: "Transaction milestone index does not match this milestone" });
+    }
+
     let affectedJobId: string | null = null;
     await prisma.$transaction(async (tx) => {
-      // Step 1: Update milestone status
       const updatedMilestone = await tx.milestone.update({
         where: { id: milestoneId },
         data: { status: "APPROVED" },
-        include: { job: true }
+        include: { job: true },
       });
-
       if (!updatedMilestone.jobId) return;
       affectedJobId = updatedMilestone.jobId;
-
-      // Step 2: Check if all milestones are approved to update job status
-      const allMilestones = await tx.milestone.findMany({ 
-        where: { jobId: updatedMilestone.jobId } 
-      });
-
+      const allMilestones = await tx.milestone.findMany({ where: { jobId: updatedMilestone.jobId } });
       if (allMilestones.every(m => m.status === "APPROVED")) {
         await tx.job.update({
           where: { id: updatedMilestone.jobId },
-          data: {
-            status: "COMPLETED",
-            escrowStatus: EscrowStatus.COMPLETED
-          }
+          data: { status: "COMPLETED", escrowStatus: EscrowStatus.COMPLETED },
         });
       }
-
-      // Step 3: Notify the freelancer (inside transaction for consistency)
       if (updatedMilestone.job.freelancerId) {
         await NotificationService.sendNotification({
           userId: updatedMilestone.job.freelancerId,
@@ -588,29 +700,44 @@ router.post("/confirm-tx", authenticate, idempotency(), asyncHandler(async (req:
       await invalidateCacheKey(generateJobOnChainStatusCacheKey(affectedJobId));
       await invalidateCacheKey(generateJobCacheKey(affectedJobId));
     }
+
   } else if (type === "PROPOSE_REVISION" && jobId) {
+    if (job.clientId !== req.userId && job.freelancerId !== req.userId) {
+      return res.status(403).json({ error: "Only the client or freelancer can confirm a revision proposal" });
+    }
     await invalidateCacheKey(generateJobOnChainStatusCacheKey(jobId));
     await invalidateCacheKey(generateJobCacheKey(jobId));
+
   } else if (type === "ACCEPT_REVISION" && jobId) {
-    const job = await prisma.job.findUnique({
-      where: { id: jobId },
-      select: { contractJobId: true },
-    });
-    if (job?.contractJobId) {
+    if (job.clientId !== req.userId && job.freelancerId !== req.userId) {
+      return res.status(403).json({ error: "Only the client or freelancer can confirm revision acceptance" });
+    }
+    if (job.contractJobId) {
       await ContractService.syncJobFromChain(prisma, jobId, job.contractJobId);
     }
     await invalidateCacheKey(generateJobOnChainStatusCacheKey(jobId));
     await invalidateCacheKey(generateJobCacheKey(jobId));
+
   } else if (type === "REJECT_REVISION" && jobId) {
+    if (job.clientId !== req.userId && job.freelancerId !== req.userId) {
+      return res.status(403).json({ error: "Only the client or freelancer can confirm revision rejection" });
+    }
     await invalidateCacheKey(generateJobOnChainStatusCacheKey(jobId));
     await invalidateCacheKey(generateJobCacheKey(jobId));
+
   } else if ((type === "CANCEL_JOB" || type === "CLAIM_REFUND") && jobId) {
+    if (job.clientId !== req.userId) {
+      return res.status(403).json({ error: "Only the client can confirm job cancellation or refund" });
+    }
+    // Args: (job_id: u64, client: Address)
+    const argJobId = args[0] !== undefined ? String(args[0]) : undefined;
+    if (argJobId && job.contractJobId && argJobId !== job.contractJobId) {
+      return res.status(403).json({ error: "Transaction job ID does not match this job" });
+    }
+
     await prisma.job.update({
       where: { id: jobId },
-      data: {
-        status: "CANCELLED",
-        escrowStatus: EscrowStatus.CANCELLED,
-      },
+      data: { status: "CANCELLED", escrowStatus: EscrowStatus.CANCELLED },
     });
     await invalidateCacheKey(generateJobOnChainStatusCacheKey(jobId));
     await invalidateCacheKey(generateJobCacheKey(jobId));

--- a/backend/src/routes/escrow.routes.ts
+++ b/backend/src/routes/escrow.routes.ts
@@ -504,7 +504,9 @@ router.post("/confirm-tx", authenticate, idempotency(), asyncHandler(async (req:
   }
 
   // ── 2. Contract address must be the configured escrow contract ────────────
-  if (effects.contractId && effects.contractId !== config.stellar.escrowContractId) {
+  // Fail closed: missing contractId (decode failure) is treated the same as
+  // a wrong contract — both are rejected rather than silently skipped.
+  if (!effects.contractId || effects.contractId !== config.stellar.escrowContractId) {
     return res.status(403).json({ error: "Transaction invoked an unexpected contract" });
   }
 
@@ -517,16 +519,16 @@ router.post("/confirm-tx", authenticate, idempotency(), asyncHandler(async (req:
   }
 
   // ── 4. Source account must match the authenticated user's wallet ──────────
-  if (effects.sourceAccount) {
-    const caller = await prisma.user.findUnique({
-      where: { id: req.userId! },
-      select: { walletAddress: true },
+  // Fail closed: reject if the source account could not be decoded, if the
+  // user has no registered wallet, or if the two don't match.
+  const caller = await prisma.user.findUnique({
+    where: { id: req.userId! },
+    select: { walletAddress: true },
+  });
+  if (!effects.sourceAccount || !caller?.walletAddress || effects.sourceAccount !== caller.walletAddress) {
+    return res.status(403).json({
+      error: "Transaction source account does not match your registered wallet",
     });
-    if (caller?.walletAddress && effects.sourceAccount !== caller.walletAddress) {
-      return res.status(403).json({
-        error: "Transaction source account does not match your registered wallet",
-      });
-    }
   }
 
   // ── 5. Load job (and milestone) for authorization + arg checks ────────────

--- a/backend/src/services/contract.service.ts
+++ b/backend/src/services/contract.service.ts
@@ -3,6 +3,7 @@ import {
   Contract,
   rpc,
   scValToNative,
+  StrKey,
   TransactionBuilder,
   xdr,
   nativeToScVal,
@@ -384,15 +385,93 @@ export class ContractService {
 
   /**
    * Verification function to check transaction status on-chain.
+   * @deprecated Use verifyTransactionEffects for security-sensitive paths.
    */
   static async verifyTransaction(hash: string) {
     const server = getRpcServer();
     const response = await server.getTransaction(hash);
     if (response.status === rpc.Api.GetTransactionStatus.SUCCESS) {
-        // Extract results if needed
         return { success: true, result: response.resultXdr };
     }
     return { success: false, error: response.status };
+  }
+
+  /**
+   * Verifies a transaction succeeded on-chain AND decodes what it actually did:
+   * which contract was called, which function, with what arguments, and from
+   * which source account. Used by confirm-tx to reject spoofed hash submissions.
+   */
+  static async verifyTransactionEffects(hash: string): Promise<{
+    success: boolean;
+    error?: string;
+    contractId?: string;
+    functionName?: string;
+    args?: unknown[];
+    sourceAccount?: string;
+  }> {
+    const server = getRpcServer();
+    const response = await server.getTransaction(hash);
+
+    if (response.status !== rpc.Api.GetTransactionStatus.SUCCESS) {
+      return { success: false, error: String(response.status) };
+    }
+
+    try {
+      const envelope = (response as rpc.Api.GetSuccessfulTransactionResponse).envelopeXdr;
+      const txBody = envelope.v1().tx();
+
+      // Decode source account (handles both ed25519 and muxed)
+      let sourceAccount: string | undefined;
+      try {
+        const src = txBody.sourceAccount();
+        const switchName = src.switch().name;
+        if (switchName === "keyTypeEd25519") {
+          sourceAccount = StrKey.encodeEd25519PublicKey(src.ed25519());
+        } else if (switchName === "keyTypeMuxedEd25519") {
+          sourceAccount = StrKey.encodeEd25519PublicKey(src.med25519().ed25519());
+        }
+      } catch {
+        // ignore — sourceAccount stays undefined
+      }
+
+      // Find the first invokeHostFunction operation.
+      // The stellar-base XDR bindings type union arm accessors as static factories,
+      // so we cast to access the instance getter.
+      for (const op of txBody.operations()) {
+        const body = op.body();
+        if (body.switch().name !== "invokeHostFunction") continue;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const hostFn = (body as any).invokeHostFunction().hostFunction();
+        if (hostFn.switch().name !== "hostFunctionTypeInvokeContract") continue;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const invokeArgs = (hostFn as any).invokeContract();
+        let contractId: string | undefined;
+        try {
+          contractId = Address.fromScAddress(invokeArgs.contractAddress()).toString();
+        } catch {
+          contractId = undefined;
+        }
+        const functionName = invokeArgs.functionName().toString();
+        const args: unknown[] = invokeArgs.args().map((a: xdr.ScVal) => {
+          try { return scValToNative(a); } catch { return undefined; }
+        });
+
+        return { success: true, contractId, functionName, args, sourceAccount };
+      }
+
+      // Transaction succeeded but contains no Soroban contract invocation
+      return {
+        success: false,
+        error: "Transaction contains no contract invocation — cannot verify escrow effects",
+      };
+    } catch (err) {
+      logger.warn({ err, hash }, "[ContractService] Failed to decode transaction envelope");
+      return {
+        success: false,
+        error: "Could not decode transaction envelope",
+      };
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #871

## Root cause

`POST /escrow/confirm-tx` called `ContractService.verifyTransaction(hash)` which only checked whether the transaction had a `SUCCESS` status on-chain. It never decoded what the transaction actually invoked. Any successful Stellar transaction hash — a plain XLM transfer, a call to a totally different contract, or a valid escrow call for a different job — could be passed in to spoof a job's escrow state.

Additionally, every `init-*` route in the file correctly enforces `clientId === req.userId` or `freelancerId === req.userId`, but `confirm-tx` had no authorization check at all for any of its branches.

## What changed

### `contract.service.ts` — new `verifyTransactionEffects`

- Decodes the Soroban transaction envelope (not just the status) to extract:
  - The **invoked contract address**
  - The **function name**
  - The **function arguments** (native JS values via `scValToNative`)
  - The **transaction source account** (the on-chain signer)
- Returns `{ success: false }` if the transaction failed, contained no `invokeHostFunction` operation, or the envelope could not be decoded — all three are treated as hard rejections rather than silent pass-through
- Old `verifyTransaction` retained and marked `@deprecated` for backward compatibility with other callers

### `escrow.routes.ts` — `confirm-tx` hardened

Three cross-cutting checks added before any type branch:

| # | Check | Rejection |
|---|---|---|
| 1 | Invoked contract must equal configured escrow contract | 403 |
| 2 | On-chain function name must match the `type` field | 403 |
| 3 | Transaction source account must match caller's registered wallet | 403 |

Per-type authorization and argument validation added to every branch:

| Type | Authorized caller | Args validated |
|---|---|---|
| `CREATE_JOB` | client | arg[0]=client wallet, arg[1]=freelancer wallet |
| `FUND_JOB` | client | arg[0]=job.contractJobId |
| `EXTEND_DEADLINE` | client | job ID + milestone onChainIndex |
| `SUBMIT_MILESTONE` | freelancer | job ID + milestone onChainIndex |
| `APPROVE_MILESTONE` | client | job ID + milestone onChainIndex |
| `PROPOSE_REVISION` | client or freelancer | — |
| `ACCEPT_REVISION` | client or freelancer | — |
| `REJECT_REVISION` | client or freelancer | — |
| `CANCEL_JOB` / `CLAIM_REFUND` | client | arg[0]=job.contractJobId |

### `escrow.confirm-tx.test.ts` — 13 new tests

- Spoofed hash from a non-escrow contract → 403
- Valid `fund_job` hash for job A claimed against job B → 403
- Outsider (neither client nor freelancer) → 403
- Client confirming `SUBMIT_MILESTONE` (freelancer-only op) → 403
- Freelancer confirming `APPROVE_MILESTONE` (client-only op) → 403
- Source account mismatch with caller's registered wallet → 403
- Function name mismatch (`transfer` vs `fund_job`) → 403
- Type/function cross-claim (`CANCEL_JOB` type backed by `fund_job` tx) → 403
- Transaction not found on-chain → 400
- Happy path: `FUND_JOB`, `SUBMIT_MILESTONE`, `APPROVE_MILESTONE`, `CREATE_JOB` → 200

## Acceptance criteria

- [x] A successful-but-unrelated transaction (plain payment, wrong contract) is rejected
- [x] A valid `fund_job` hash for job A cannot spoof job B's escrow state
- [x] Every type branch rejects callers who are neither the job's client nor freelancer
- [x] The transaction source account is verified against the authenticated user's wallet
- [x] All existing confirm-tx flows continue to work (covered by happy-path tests)