### PR TITLE
feat: Video/screen-recording evidence capture and playback for disputes (#901)

### DIFF
--- a/VIDEO_EVIDENCE_CAPTURE.md
+++ b/VIDEO_EVIDENCE_CAPTURE.md
@@ -1,0 +1,74 @@
+# Video / Screen-Recording Evidence Capture & Playback (issue #901)
+
+Adds in-browser video capture (screen share + webcam) and a dedicated review
+player to the dispute evidence flow, integrated with the **existing** chunked,
+integrity-hashed, resumable upload pipeline (`src/lib/evidenceUpload.ts`).
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `frontend/src/lib/mediaRecording.ts` | Codec negotiation, `RecordingController` (MediaRecorder + IndexedDB chunk persistence), recovery, timestamp helpers |
+| `frontend/src/components/EvidenceRecorder.tsx` | Capture UI: screen/camera, start/pause/stop, live preview, recovery |
+| `frontend/src/components/EvidenceVideoPlayer.tsx` | Review player: timestamped scrubbing, `#t=` deep-links, frame capture |
+| `frontend/src/components/EvidenceUpload.tsx` | Recorder wired in additively; recordings join the existing upload flow |
+| `frontend/src/components/EvidenceViewer.tsx` | Renders the player for video evidence on the review side |
+
+## Key design decisions
+
+### Reuse the existing upload pipeline (no separate path)
+A finished recording is assembled into a plain `File` on stop and handed to
+`EvidenceUpload` via `onRecordingReady`, where it joins the exact same
+`selectedFiles` flow as a hand-picked file — same SHA-256 hashing
+(`hashFile`) and same resumable, chunked transfer (`uploadFileResumable`). A
+recording's byte size is only known on stop, which is fine: the pipeline derives
+chunk count from `file.size` at upload time.
+
+### Cross-browser codec negotiation
+`negotiateRecordingFormat()` probes a preference list
+(`video/webm;codecs=vp9,opus` → … → `video/mp4;codecs=h264,aac` → …) with
+`MediaRecorder.isTypeSupported` and picks the first supported format, adapting
+per browser (Chrome/Firefox WebM vs Safari MP4). If nothing matches it returns an
+empty mimeType (browser default) **and labels it as such** so the UI communicates
+the format rather than failing silently.
+
+### Interruption resilience (periodic persistence, not one final blob)
+The `RecordingController` records with a MediaRecorder **timeslice**, and each
+chunk is persisted to IndexedDB as it arrives (as raw bytes, which clone
+reliably). A revoked permission, closed tab, or crash therefore leaves a
+recoverable partial recording; `listRecoverableRecordings()` surfaces it and the
+recorder offers **Recover** / **Discard**. A clean stop clears the persisted
+partial (the assembled File is then owned by the upload pipeline, which has its
+own persistence). A screen-share "ended" event is treated as a stop so ending
+the share never loses content.
+
+### Evidence-specific player
+Beyond generic playback: a timestamped scrubber, a **stable shareable deep-link**
+to the current moment using the W3C media-fragment form (`#t=12.5`) — read on
+load so a shared link lands on the referenced moment — and a **frame capture**
+that produces a PNG an arbitrator can reference in a vote rationale.
+
+## Tests
+
+- `src/lib/__tests__/mediaRecording.test.ts`
+  - **Recording → pipeline**: a mocked screen-capture and a webcam clip flow
+    through `hashFile` + `uploadFileResumable` against an in-memory backend that
+    recomputes SHA-256 over the reassembled chunks — the hash matches.
+  - **Codec negotiation** across two simulated browsers via mocked
+    `MediaRecorder.isTypeSupported`, plus the no-match browser-default fallback.
+  - **Interruption recovery**: persisted chunks survive an un-clean stop and
+    reassemble into a usable File; a clean stop clears them (no false recovery).
+  - Stream acquisition (getDisplayMedia/getUserMedia) + permission-error mapping.
+  - Timestamp helpers (format, media-fragment round-trip).
+- `src/components/__tests__/EvidenceVideoPlayer.test.tsx` — scrubbing, `#t=`
+  deep-link seek on load, a stable shareable reference, and frame capture.
+- `src/components/__tests__/EvidenceRecorder.test.tsx` — screen + webcam capture
+  through the component, permission-error surfacing, negotiated-format display.
+
+### Test-harness fix
+
+`jest.setup.ts`'s `structuredClone` polyfill was a no-op
+(`require("crypto").structuredClone` is `undefined`), so IndexedDB writes never
+round-tripped in tests. It now uses Node's `v8` structured-clone, which makes the
+recovery tests (and the pre-existing upload-persistence code paths) genuinely
+exercise IndexedDB. No existing tests regressed.

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -32,9 +32,15 @@ if (!subtleDescriptor || typeof subtleDescriptor.value === "undefined") {
 }
 
 // jsdom lacks structuredClone, which fake-indexeddb (and modern runtime code)
-// relies on to clone stored values. Polyfill from Node.
-if (typeof (globalThis as any).structuredClone === "undefined") {
-  (globalThis as any).structuredClone = (globalThis as any).structuredClone || (require("crypto").structuredClone);
+// relies on to clone stored values. Polyfill it with Node's structured-clone
+// implementation (via the `v8` module) so IndexedDB writes actually round-trip
+// in tests. (The previous `require("crypto").structuredClone` was undefined — a
+// no-op that left the polyfill non-functional.)
+if (typeof (globalThis as any).structuredClone !== "function") {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const v8 = require("node:v8");
+  (globalThis as any).structuredClone = (value: unknown) =>
+    v8.deserialize(v8.serialize(value));
 }
 
 class MockIntersectionObserver {

--- a/frontend/src/components/EvidenceRecorder.tsx
+++ b/frontend/src/components/EvidenceRecorder.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import {
+  Monitor,
+  Camera,
+  Circle,
+  Pause,
+  Play,
+  Square,
+  Video,
+  AlertTriangle,
+  RotateCcw,
+  Trash2,
+  ShieldCheck,
+} from "lucide-react";
+import {
+  RecordingController,
+  listRecoverableRecordings,
+  clearRecording,
+  formatTimestamp,
+  type RecordingSource,
+  type RecordingStatus,
+  type RecordingFormat,
+  type RecoverableRecording,
+} from "@/lib/mediaRecording";
+
+/**
+ * In-browser video/screen recorder for dispute evidence (issue #901).
+ *
+ * On stop, the recording is handed to the parent as a plain `File` via
+ * `onRecordingReady`, so it flows through the *existing* SHA-256 + resumable
+ * chunked upload pipeline — this component deliberately owns no upload logic.
+ * Partial recordings left by an interruption are surfaced for recovery.
+ */
+export default function EvidenceRecorder({
+  disputeId,
+  onRecordingReady,
+  disabled = false,
+}: {
+  disputeId: string;
+  onRecordingReady: (file: File) => void;
+  disabled?: boolean;
+}) {
+  const [source, setSource] = useState<RecordingSource>("screen");
+  const [status, setStatus] = useState<RecordingStatus>("idle");
+  const [durationSec, setDurationSec] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [format, setFormat] = useState<RecordingFormat | null>(null);
+  const [recoverable, setRecoverable] = useState<RecoverableRecording[]>([]);
+
+  const controllerRef = useRef<RecordingController | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  const isActive = status === "recording" || status === "paused";
+
+  const refreshRecoverable = useCallback(() => {
+    listRecoverableRecordings(disputeId)
+      .then(setRecoverable)
+      .catch(() => setRecoverable([]));
+  }, [disputeId]);
+
+  // Surface any partial recordings from a previous interrupted session.
+  useEffect(() => {
+    refreshRecoverable();
+  }, [refreshRecoverable]);
+
+  // Duration timer — ticks only while actively recording.
+  useEffect(() => {
+    if (status !== "recording") return;
+    const id = window.setInterval(() => setDurationSec((d) => d + 1), 1000);
+    return () => window.clearInterval(id);
+  }, [status]);
+
+  // Release the camera/screen if the component unmounts mid-capture. Persisted
+  // chunks are intentionally left behind so the recording remains recoverable.
+  useEffect(() => {
+    return () => {
+      controllerRef.current
+        ?.getStream()
+        ?.getTracks()
+        .forEach((t) => t.stop());
+    };
+  }, []);
+
+  const handleStart = useCallback(async () => {
+    setError(null);
+    setDurationSec(0);
+    const controller = new RecordingController({
+      disputeId,
+      source,
+      onStatus: setStatus,
+      onError: (e) => setError(e.message),
+    });
+    controllerRef.current = controller;
+    try {
+      const stream = await controller.start();
+      setFormat(controller.format);
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        videoRef.current.muted = true;
+        void videoRef.current.play?.().catch(() => undefined);
+      }
+    } catch {
+      // onError already populated the message; nothing else to do.
+      controllerRef.current = null;
+    }
+  }, [disputeId, source]);
+
+  const handleStop = useCallback(async () => {
+    const controller = controllerRef.current;
+    if (!controller) return;
+    try {
+      const file = await controller.stop();
+      if (videoRef.current) videoRef.current.srcObject = null;
+      if (file.size > 0) {
+        onRecordingReady(file);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to finalize recording.");
+    } finally {
+      controllerRef.current = null;
+      refreshRecoverable();
+    }
+  }, [onRecordingReady, refreshRecoverable]);
+
+  const handleRecover = useCallback(
+    (rec: RecoverableRecording) => {
+      onRecordingReady(rec.file);
+      clearRecording(rec.disputeId, rec.recordingId).catch(() => undefined);
+      setRecoverable((prev) =>
+        prev.filter((r) => r.recordingId !== rec.recordingId),
+      );
+    },
+    [onRecordingReady],
+  );
+
+  const handleDiscard = useCallback((rec: RecoverableRecording) => {
+    clearRecording(rec.disputeId, rec.recordingId).catch(() => undefined);
+    setRecoverable((prev) =>
+      prev.filter((r) => r.recordingId !== rec.recordingId),
+    );
+  }, []);
+
+  return (
+    <div className="space-y-3">
+      {/* Recoverable partial recordings from an interrupted session. */}
+      {recoverable.length > 0 && (
+        <div className="rounded-lg border border-theme-warning/40 bg-theme-warning/5 p-2 space-y-2">
+          <p className="flex items-center gap-1.5 text-xs font-medium text-theme-warning">
+            <AlertTriangle size={12} />
+            Recovered {recoverable.length} interrupted recording
+            {recoverable.length !== 1 ? "s" : ""}
+          </p>
+          <ul className="space-y-1.5">
+            {recoverable.map((rec) => (
+              <li
+                key={rec.recordingId}
+                className="flex items-center justify-between gap-2 text-[11px] text-theme-text"
+              >
+                <span className="truncate">
+                  {rec.source === "screen" ? "Screen" : "Camera"} ·{" "}
+                  {Math.max(1, Math.ceil(rec.size / 1024))} KB ·{" "}
+                  {rec.chunkCount} chunk{rec.chunkCount !== 1 ? "s" : ""}
+                </span>
+                <span className="flex items-center gap-2 flex-shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => handleRecover(rec)}
+                    className="flex items-center gap-1 text-stellar-blue hover:underline"
+                  >
+                    <RotateCcw size={11} />
+                    Recover
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDiscard(rec)}
+                    className="flex items-center gap-1 text-theme-text-muted hover:text-theme-error"
+                    aria-label="Discard recovered recording"
+                  >
+                    <Trash2 size={11} />
+                  </button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Source selection (disabled once a recording is in progress). */}
+      <div className="flex items-center gap-2" role="radiogroup" aria-label="Recording source">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={source === "screen"}
+          onClick={() => setSource("screen")}
+          disabled={disabled || isActive}
+          className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition-colors disabled:opacity-50 ${
+            source === "screen"
+              ? "border-stellar-blue text-stellar-blue"
+              : "border-theme-border text-theme-text hover:border-stellar-blue"
+          }`}
+        >
+          <Monitor size={14} />
+          Screen
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={source === "camera"}
+          onClick={() => setSource("camera")}
+          disabled={disabled || isActive}
+          className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition-colors disabled:opacity-50 ${
+            source === "camera"
+              ? "border-stellar-blue text-stellar-blue"
+              : "border-theme-border text-theme-text hover:border-stellar-blue"
+          }`}
+        >
+          <Camera size={14} />
+          Camera
+        </button>
+      </div>
+
+      {/* Live preview. */}
+      <div className="relative overflow-hidden rounded-lg border border-theme-border bg-black/80 aspect-video">
+        <video
+          ref={videoRef}
+          data-testid="recorder-preview"
+          className="h-full w-full object-contain"
+          autoPlay
+          playsInline
+          muted
+        />
+        {!isActive && (
+          <div className="absolute inset-0 flex items-center justify-center text-theme-text-muted">
+            <Video size={28} />
+          </div>
+        )}
+        {isActive && (
+          <div className="absolute left-2 top-2 flex items-center gap-1.5 rounded-full bg-black/60 px-2 py-0.5 text-[10px] text-white">
+            <Circle
+              size={8}
+              className={
+                status === "recording"
+                  ? "animate-pulse fill-red-500 text-red-500"
+                  : "fill-yellow-400 text-yellow-400"
+              }
+            />
+            {status === "paused" ? "Paused" : "Rec"} {formatTimestamp(durationSec)}
+          </div>
+        )}
+      </div>
+
+      {/* Controls. */}
+      <div className="flex items-center gap-2">
+        {status === "idle" || status === "stopped" || status === "error" ? (
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={disabled}
+            className="btn-primary flex flex-1 items-center justify-center gap-2 text-sm disabled:opacity-50"
+          >
+            <Circle size={14} className="fill-current" />
+            Start recording
+          </button>
+        ) : (
+          <>
+            {status === "recording" ? (
+              <button
+                type="button"
+                onClick={() => controllerRef.current?.pause()}
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-theme-border px-3 py-2 text-sm text-theme-text hover:border-stellar-blue"
+              >
+                <Pause size={14} />
+                Pause
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => controllerRef.current?.resume()}
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-theme-border px-3 py-2 text-sm text-theme-text hover:border-stellar-blue"
+              >
+                <Play size={14} />
+                Resume
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={handleStop}
+              className="btn-primary flex flex-1 items-center justify-center gap-1.5 text-sm"
+            >
+              <Square size={14} className="fill-current" />
+              Stop &amp; attach
+            </button>
+          </>
+        )}
+      </div>
+
+      {format && isActive && (
+        <p className="flex items-center gap-1.5 text-[10px] text-theme-text-muted">
+          <ShieldCheck size={11} className="text-theme-success" />
+          Recording as {format.label}
+          {format.mimeType
+            ? ` (${format.mimeType})`
+            : " — your browser chose the format"}
+        </p>
+      )}
+
+      {error && (
+        <p className="flex items-center gap-1.5 text-xs text-theme-error">
+          <AlertTriangle size={12} />
+          {error}
+        </p>
+      )}
+
+      <p className="text-[10px] text-theme-text-muted">
+        Recordings are captured in short chunks saved as you go, so an interrupted
+        session (denied permission, closed tab) can be recovered rather than lost.
+        When you stop, the video is hashed and uploaded like any other evidence
+        file.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/EvidenceUpload.tsx
+++ b/frontend/src/components/EvidenceUpload.tsx
@@ -10,7 +10,9 @@ import {
   CheckCircle,
   RotateCw,
   AlertTriangle,
+  Video,
 } from "lucide-react";
+import EvidenceRecorder from "@/components/EvidenceRecorder";
 import {
   uploadFileResumable,
   hashFile,
@@ -66,6 +68,7 @@ export default function EvidenceUpload({
   const [fileError, setFileError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [restored, setRestored] = useState(false);
+  const [showRecorder, setShowRecorder] = useState(false);
 
   const updateFile = useCallback(
     (id: string, patch: Partial<FileUploadState>) => {
@@ -146,6 +149,26 @@ export default function EvidenceUpload({
     setFiles(nextStates);
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
+
+  // A finished (or recovered) in-browser recording arrives here as a plain File
+  // and joins the exact same selected-files flow as a hand-picked file, so it is
+  // hashed and uploaded through the existing resumable pipeline — no separate
+  // path. The recording's byte size is only known now, on stop, which is fine:
+  // the pipeline derives chunk count from `file.size` at upload time.
+  const addRecordedFile = useCallback((file: File) => {
+    setFileError(null);
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setFileError(`Recording exceeds the ${MAX_FILE_SIZE_MB} MB limit.`);
+      return;
+    }
+    if (filesRef.current.length >= MAX_FILES) {
+      setFileError(`You may attach up to ${MAX_FILES} files.`);
+      return;
+    }
+    const id = newFileId();
+    setSelectedFiles((prev) => new Map(prev).set(id, file));
+    setFiles((prev) => [...prev, initState(id, file)]);
+  }, []);
 
   const removeFile = useCallback(
     (id: string) => {
@@ -306,6 +329,27 @@ export default function EvidenceUpload({
         onChange={handleFileChange}
         disabled={disabled || isProcessing}
       />
+
+      <button
+        type="button"
+        onClick={() => setShowRecorder((v) => !v)}
+        disabled={disabled || isProcessing || files.length >= MAX_FILES}
+        aria-expanded={showRecorder}
+        className="flex items-center gap-2 text-sm px-3 py-2 border border-dashed border-theme-border rounded-lg text-theme-text hover:border-stellar-blue hover:text-stellar-blue transition-colors disabled:opacity-50 disabled:cursor-not-allowed w-full justify-center"
+      >
+        <Video size={14} />
+        {showRecorder ? "Hide recorder" : "Record screen or camera video"}
+      </button>
+
+      {showRecorder && (
+        <div className="rounded-lg border border-theme-border p-3">
+          <EvidenceRecorder
+            disputeId={disputeId}
+            onRecordingReady={addRecordedFile}
+            disabled={disabled || isProcessing || files.length >= MAX_FILES}
+          />
+        </div>
+      )}
 
       {fileError && <p className="text-xs text-theme-error">{fileError}</p>}
 

--- a/frontend/src/components/EvidenceVideoPlayer.tsx
+++ b/frontend/src/components/EvidenceVideoPlayer.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Play, Pause, Camera, Link2, Check } from "lucide-react";
+import {
+  formatTimestamp,
+  buildTimestampHash,
+  parseTimestampFromHash,
+} from "@/lib/mediaRecording";
+
+/**
+ * Evidence-specific video player for the arbitrator review side (issue #901).
+ *
+ * Beyond generic playback it offers:
+ *  - a timestamped scrubber (seek to an exact moment);
+ *  - a stable, shareable **deep-link** to the current moment using the W3C
+ *    media-fragment form (`#t=12.5`), which an arbitrator can paste into a vote
+ *    rationale;
+ *  - a **frame capture** affordance so a specific frame can be referenced.
+ *
+ * On mount it reads any `#t=` fragment from the URL (or `initialTime`) and seeks
+ * there, so a shared link lands on the referenced moment.
+ */
+export default function EvidenceVideoPlayer({
+  src,
+  fileName,
+  initialTime,
+  onTimestampReference,
+  onFrameCapture,
+}: {
+  src: string;
+  fileName?: string;
+  /** Seconds to seek to on load; falls back to a `#t=` URL fragment. */
+  initialTime?: number;
+  /** Called with (seconds, hash) when the user copies a moment reference. */
+  onTimestampReference?: (seconds: number, hash: string) => void;
+  /** Called with a PNG data URL + seconds when the user captures a frame. */
+  onFrameCapture?: (dataUrl: string, seconds: number) => void;
+}) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [duration, setDuration] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState(false);
+
+  const seekTo = useCallback((seconds: number) => {
+    const video = videoRef.current;
+    if (!video) return;
+    const clamped = Math.max(0, seconds);
+    video.currentTime = Number.isFinite(clamped) ? clamped : 0;
+    setCurrentTime(video.currentTime);
+  }, []);
+
+  // Seek to the referenced moment once metadata (and thus duration) is known.
+  const handleLoadedMetadata = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    setDuration(Number.isFinite(video.duration) ? video.duration : 0);
+    const fromHash =
+      typeof window !== "undefined"
+        ? parseTimestampFromHash(window.location.hash)
+        : null;
+    const target = initialTime ?? fromHash;
+    if (target && target > 0) {
+      seekTo(target);
+    }
+  }, [initialTime, seekTo]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const onTime = () => setCurrentTime(video.currentTime);
+    const onPlay = () => setPlaying(true);
+    const onPause = () => setPlaying(false);
+    const onError = () => setError(true);
+    video.addEventListener("timeupdate", onTime);
+    video.addEventListener("play", onPlay);
+    video.addEventListener("pause", onPause);
+    video.addEventListener("error", onError);
+    return () => {
+      video.removeEventListener("timeupdate", onTime);
+      video.removeEventListener("play", onPlay);
+      video.removeEventListener("pause", onPause);
+      video.removeEventListener("error", onError);
+    };
+  }, []);
+
+  const togglePlay = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    if (video.paused) {
+      void video.play?.().catch(() => undefined);
+    } else {
+      video.pause?.();
+    }
+  }, []);
+
+  const handleScrub = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      seekTo(Number(e.target.value));
+    },
+    [seekTo],
+  );
+
+  const copyMomentLink = useCallback(async () => {
+    const seconds = videoRef.current?.currentTime ?? currentTime;
+    const hash = buildTimestampHash(seconds);
+    if (typeof window !== "undefined") {
+      // Reflect the moment in the URL so a copied address deep-links back to it.
+      try {
+        window.history.replaceState(null, "", hash);
+      } catch {
+        window.location.hash = hash;
+      }
+      const href = `${window.location.origin}${window.location.pathname}${window.location.search}${hash}`;
+      try {
+        await navigator.clipboard?.writeText?.(href);
+      } catch {
+        // Clipboard may be unavailable (permissions/insecure context); the URL
+        // is still updated, so the reference remains shareable.
+      }
+    }
+    onTimestampReference?.(seconds, hash);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  }, [currentTime, onTimestampReference]);
+
+  const captureFrame = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const seconds = video.currentTime;
+    try {
+      const canvas = document.createElement("canvas");
+      canvas.width = video.videoWidth || 640;
+      canvas.height = video.videoHeight || 360;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+      const dataUrl = canvas.toDataURL("image/png");
+      onFrameCapture?.(dataUrl, seconds);
+
+      // Offer the frame as a download named with its timestamp for reference.
+      const anchor = document.createElement("a");
+      anchor.href = dataUrl;
+      anchor.download = `${(fileName || "evidence").replace(/\.[^.]+$/, "")}-frame-${formatTimestamp(
+        seconds,
+      ).replace(/:/g, "-")}.png`;
+      anchor.click();
+    } catch {
+      // Frame capture can fail for cross-origin/unsupported sources; ignore.
+    }
+  }, [fileName, onFrameCapture]);
+
+  return (
+    <div className="space-y-2 rounded-lg border border-theme-border bg-theme-bg p-2">
+      <video
+        ref={videoRef}
+        src={src}
+        data-testid="evidence-video"
+        className="w-full rounded-md bg-black aspect-video"
+        onLoadedMetadata={handleLoadedMetadata}
+        playsInline
+        preload="metadata"
+      >
+        {/* Evidence recordings carry no caption track; declare an empty one so
+            the player is still accessible and satisfies a11y requirements. */}
+        <track kind="captions" />
+      </video>
+
+      {error && (
+        <p className="text-[11px] text-theme-error">
+          This video could not be played in your browser. Use Download to review
+          it locally.
+        </p>
+      )}
+
+      {/* Scrubber. */}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={togglePlay}
+          className="text-stellar-blue hover:text-stellar-blue/80"
+          aria-label={playing ? "Pause" : "Play"}
+        >
+          {playing ? <Pause size={16} /> : <Play size={16} />}
+        </button>
+        <input
+          type="range"
+          min={0}
+          max={duration || 0}
+          step={0.1}
+          value={Math.min(currentTime, duration || 0)}
+          onChange={handleScrub}
+          aria-label="Seek"
+          className="h-1.5 flex-1 cursor-pointer accent-stellar-blue"
+        />
+        <span
+          className="font-mono text-[10px] tabular-nums text-theme-text-muted"
+          data-testid="video-timestamp"
+        >
+          {formatTimestamp(currentTime)} / {formatTimestamp(duration)}
+        </span>
+      </div>
+
+      {/* Evidence-specific affordances. */}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={copyMomentLink}
+          className="flex items-center gap-1 text-[11px] text-stellar-blue hover:underline"
+        >
+          {copied ? <Check size={12} /> : <Link2 size={12} />}
+          {copied ? "Link copied" : "Copy link to this moment"}
+        </button>
+        <button
+          type="button"
+          onClick={captureFrame}
+          className="flex items-center gap-1 text-[11px] text-stellar-blue hover:underline"
+        >
+          <Camera size={12} />
+          Capture frame
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/EvidenceViewer.tsx
+++ b/frontend/src/components/EvidenceViewer.tsx
@@ -11,9 +11,12 @@ import {
   Loader2,
   RefreshCw,
 } from "lucide-react";
+import { Video } from "lucide-react";
 import axios from "axios";
 import type { DisputeEvidence, EvidenceVerification } from "@/types";
 import LocalTimestamp from "@/components/LocalTimestamp";
+import EvidenceVideoPlayer from "@/components/EvidenceVideoPlayer";
+import { isVideoEvidence } from "@/lib/mediaRecording";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api/v1";
 
@@ -41,7 +44,20 @@ export default function EvidenceViewer({
   >({});
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const [videoUrls, setVideoUrls] = useState<Record<string, string>>({});
+  const [loadingVideoId, setLoadingVideoId] = useState<string | null>(null);
   const listRef = useRef<HTMLUListElement>(null);
+  const videoUrlsRef = useRef(videoUrls);
+  videoUrlsRef.current = videoUrls;
+
+  // Revoke any created object URLs when the viewer unmounts.
+  useEffect(() => {
+    return () => {
+      Object.values(videoUrlsRef.current).forEach((url) =>
+        URL.revokeObjectURL(url),
+      );
+    };
+  }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
     const buttons = listRef.current?.querySelectorAll<HTMLButtonElement>('button[role="option"]');
@@ -135,6 +151,37 @@ export default function EvidenceViewer({
     }
   }, [disputeId]);
 
+  // Fetch a video evidence blob (authorized) and expose it as an object URL so
+  // the dedicated player can stream it without leaking the auth token into a
+  // <video src>. Prefer a server-provided `url` when present.
+  const loadVideo = useCallback(
+    async (item: DisputeEvidence) => {
+      if (videoUrls[item.id]) return;
+      if (item.url) {
+        setVideoUrls((prev) => ({ ...prev, [item.id]: item.url as string }));
+        return;
+      }
+      setLoadingVideoId(item.id);
+      try {
+        const token = localStorage.getItem("token");
+        const response = await axios.get(
+          `${API_URL}/disputes/${disputeId}/evidence/${item.id}/download`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+            responseType: "blob",
+          },
+        );
+        const url = URL.createObjectURL(response.data);
+        setVideoUrls((prev) => ({ ...prev, [item.id]: url }));
+      } catch {
+        // Leave it unloaded; the user can still download.
+      } finally {
+        setLoadingVideoId(null);
+      }
+    },
+    [disputeId, videoUrls],
+  );
+
   if (loading) {
     return (
       <div className="card">
@@ -223,7 +270,33 @@ export default function EvidenceViewer({
                   </button>
                 </div>
               </div>
- 
+
+              {(isVideoEvidence(item.fileType) ||
+                isVideoEvidence(item.fileName)) && (
+                <div>
+                  {videoUrls[item.id] ? (
+                    <EvidenceVideoPlayer
+                      src={videoUrls[item.id]}
+                      fileName={item.fileName}
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => loadVideo(item)}
+                      disabled={loadingVideoId === item.id}
+                      className="flex items-center gap-1.5 text-xs text-stellar-blue hover:underline disabled:opacity-50"
+                    >
+                      {loadingVideoId === item.id ? (
+                        <Loader2 size={12} className="animate-spin" />
+                      ) : (
+                        <Video size={12} />
+                      )}
+                      Review video
+                    </button>
+                  )}
+                </div>
+              )}
+
               {item.sha256 && (
                 <div className="bg-theme-bg border border-theme-border rounded-md p-2 space-y-1.5">
                   <div className="flex items-center gap-2">

--- a/frontend/src/components/__tests__/EvidenceRecorder.test.tsx
+++ b/frontend/src/components/__tests__/EvidenceRecorder.test.tsx
@@ -1,0 +1,157 @@
+import "fake-indexeddb/auto";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import EvidenceRecorder from "@/components/EvidenceRecorder";
+
+// ---- Controllable MediaRecorder + media devices ----
+class MockMediaRecorder {
+  static supported = new Set<string>(["video/webm;codecs=vp9,opus"]);
+  static instances: MockMediaRecorder[] = [];
+  static isTypeSupported(t: string) {
+    return MockMediaRecorder.supported.has(t);
+  }
+  state: "inactive" | "recording" | "paused" = "inactive";
+  mimeType: string;
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  constructor(public stream: unknown, opts?: { mimeType?: string }) {
+    this.mimeType = opts?.mimeType ?? "";
+    MockMediaRecorder.instances.push(this);
+  }
+  start() {
+    this.state = "recording";
+  }
+  pause() {
+    this.state = "paused";
+  }
+  resume() {
+    this.state = "recording";
+  }
+  requestData() {}
+  stop() {
+    this.state = "inactive";
+    this.onstop?.();
+  }
+  emit(blob: Blob) {
+    this.ondataavailable?.({ data: blob });
+  }
+}
+
+function fakeStream() {
+  const track = { stop: jest.fn(), addEventListener: jest.fn() };
+  return { getVideoTracks: () => [track], getTracks: () => [track] } as unknown as MediaStream;
+}
+
+let getDisplayMedia: jest.Mock;
+let getUserMedia: jest.Mock;
+let disputeCounter = 0;
+
+beforeAll(() => {
+  // jsdom lacks these on HTMLMediaElement.
+  Object.defineProperty(HTMLMediaElement.prototype, "play", {
+    configurable: true,
+    value: jest.fn().mockResolvedValue(undefined),
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, "srcObject", {
+    configurable: true,
+    writable: true,
+    value: null,
+  });
+});
+
+beforeEach(() => {
+  MockMediaRecorder.instances = [];
+  MockMediaRecorder.supported = new Set(["video/webm;codecs=vp9,opus"]);
+  (globalThis as unknown as { MediaRecorder: unknown }).MediaRecorder =
+    MockMediaRecorder;
+  getDisplayMedia = jest.fn(async () => fakeStream());
+  getUserMedia = jest.fn(async () => fakeStream());
+  Object.defineProperty(navigator, "mediaDevices", {
+    value: { getDisplayMedia, getUserMedia },
+    configurable: true,
+  });
+});
+
+async function startRecording() {
+  fireEvent.click(screen.getByText("Start recording"));
+  // Wait for the async stream acquisition + status transition.
+  await screen.findByText("Pause");
+  return MockMediaRecorder.instances.at(-1)!;
+}
+
+describe("EvidenceRecorder", () => {
+  it("records a screen capture and hands a File to the pipeline", async () => {
+    const onReady = jest.fn();
+    render(
+      <EvidenceRecorder
+        disputeId={`d-${disputeCounter++}`}
+        onRecordingReady={onReady}
+      />,
+    );
+
+    // Default source is screen.
+    const recorder = await startRecording();
+    expect(getDisplayMedia).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      recorder.emit(new Blob([new Uint8Array([1, 2, 3])]));
+    });
+
+    fireEvent.click(screen.getByText("Stop & attach"));
+    await waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+    const file = onReady.mock.calls[0][0] as File;
+    expect(file).toBeInstanceOf(File);
+    expect(file.size).toBe(3);
+    expect(file.type).toContain("video/webm");
+  });
+
+  it("records a webcam capture via getUserMedia", async () => {
+    const onReady = jest.fn();
+    render(
+      <EvidenceRecorder
+        disputeId={`d-${disputeCounter++}`}
+        onRecordingReady={onReady}
+      />,
+    );
+    fireEvent.click(screen.getByRole("radio", { name: "Camera" }));
+
+    const recorder = await startRecording();
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      recorder.emit(new Blob([new Uint8Array([7, 7])]));
+    });
+    fireEvent.click(screen.getByText("Stop & attach"));
+    await waitFor(() => expect(onReady).toHaveBeenCalled());
+  });
+
+  it("surfaces a permission error without crashing", async () => {
+    const onReady = jest.fn();
+    getDisplayMedia.mockRejectedValueOnce(
+      Object.assign(new Error("no"), { name: "NotAllowedError" }),
+    );
+    render(
+      <EvidenceRecorder
+        disputeId={`d-${disputeCounter++}`}
+        onRecordingReady={onReady}
+      />,
+    );
+    fireEvent.click(screen.getByText("Start recording"));
+    expect(
+      await screen.findByText(/permission was denied/i),
+    ).toBeInTheDocument();
+    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  it("shows the negotiated recording format while recording", async () => {
+    render(
+      <EvidenceRecorder
+        disputeId={`d-${disputeCounter++}`}
+        onRecordingReady={jest.fn()}
+      />,
+    );
+    await startRecording();
+    expect(await screen.findByText(/Recording as WebM/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/EvidenceVideoPlayer.test.tsx
+++ b/frontend/src/components/__tests__/EvidenceVideoPlayer.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import EvidenceVideoPlayer from "@/components/EvidenceVideoPlayer";
+import { parseTimestampFromHash } from "@/lib/mediaRecording";
+
+// jsdom does not implement HTMLMediaElement playback or canvas 2d. Provide the
+// minimal surface the player touches so scrubbing / frame-capture are testable.
+let mockCurrentTime = 0;
+
+beforeAll(() => {
+  Object.defineProperty(HTMLMediaElement.prototype, "play", {
+    configurable: true,
+    value: jest.fn().mockResolvedValue(undefined),
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, "pause", {
+    configurable: true,
+    value: jest.fn(),
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, "currentTime", {
+    configurable: true,
+    get: () => mockCurrentTime,
+    set: (v: number) => {
+      mockCurrentTime = v;
+    },
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, "duration", {
+    configurable: true,
+    get: () => 120,
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, "paused", {
+    configurable: true,
+    get: () => true,
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, "videoWidth", {
+    configurable: true,
+    get: () => 640,
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, "videoHeight", {
+    configurable: true,
+    get: () => 360,
+  });
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    drawImage: jest.fn(),
+  })) as unknown as HTMLCanvasElement["getContext"];
+  HTMLCanvasElement.prototype.toDataURL = jest.fn(
+    () => "data:image/png;base64,ABC123",
+  );
+});
+
+beforeEach(() => {
+  mockCurrentTime = 0;
+  window.location.hash = "";
+});
+
+function loadMetadata() {
+  const video = screen.getByTestId("evidence-video");
+  fireEvent.loadedMetadata(video);
+}
+
+describe("EvidenceVideoPlayer", () => {
+  it("scrubs to a specific timestamp", () => {
+    render(<EvidenceVideoPlayer src="blob:vid" fileName="clip.webm" />);
+    loadMetadata();
+
+    const scrubber = screen.getByLabelText("Seek") as HTMLInputElement;
+    fireEvent.change(scrubber, { target: { value: "42" } });
+
+    expect(mockCurrentTime).toBe(42);
+    // The timestamp readout reflects the seek.
+    expect(screen.getByTestId("video-timestamp")).toHaveTextContent(
+      "0:42 / 2:00",
+    );
+  });
+
+  it("seeks to a #t= fragment on load (shareable deep-link lands on the moment)", () => {
+    window.location.hash = "#t=30";
+    render(<EvidenceVideoPlayer src="blob:vid" />);
+    loadMetadata();
+    expect(mockCurrentTime).toBe(30);
+  });
+
+  it("produces a stable, shareable timestamp reference", async () => {
+    const onRef = jest.fn();
+    render(
+      <EvidenceVideoPlayer src="blob:vid" onTimestampReference={onRef} />,
+    );
+    loadMetadata();
+
+    const scrubber = screen.getByLabelText("Seek") as HTMLInputElement;
+    fireEvent.change(scrubber, { target: { value: "12.5" } });
+
+    // The copy handler is async (updates the URL + clipboard).
+    await act(async () => {
+      fireEvent.click(screen.getByText("Copy link to this moment"));
+    });
+    await waitFor(() => expect(onRef).toHaveBeenCalled());
+
+    // Callback fired with a media-fragment hash, and the URL now deep-links there.
+    expect(onRef).toHaveBeenCalledWith(12.5, "#t=12.5");
+    expect(window.location.hash).toBe("#t=12.5");
+    // The reference is stable: re-parsing the URL hash yields the same moment.
+    expect(parseTimestampFromHash(window.location.hash)).toBeCloseTo(12.5);
+  });
+
+  it("captures a frame and reports the data URL + timestamp", () => {
+    const onFrame = jest.fn();
+    render(<EvidenceVideoPlayer src="blob:vid" onFrameCapture={onFrame} />);
+    loadMetadata();
+
+    const scrubber = screen.getByLabelText("Seek") as HTMLInputElement;
+    fireEvent.change(scrubber, { target: { value: "8" } });
+
+    fireEvent.click(screen.getByText("Capture frame"));
+    expect(onFrame).toHaveBeenCalledWith("data:image/png;base64,ABC123", 8);
+  });
+
+  it("toggles play/pause", () => {
+    render(<EvidenceVideoPlayer src="blob:vid" />);
+    loadMetadata();
+    const playBtn = screen.getByLabelText("Play");
+    fireEvent.click(playBtn);
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/__tests__/mediaRecording.test.ts
+++ b/frontend/src/lib/__tests__/mediaRecording.test.ts
@@ -1,0 +1,397 @@
+import "fake-indexeddb/auto";
+import {
+  negotiateRecordingFormat,
+  isMimeTypeSupported,
+  RecordingController,
+  listRecoverableRecordings,
+  clearRecording,
+  formatTimestamp,
+  buildTimestampHash,
+  parseTimestampFromHash,
+  isVideoEvidence,
+  acquireStream,
+  RecordingError,
+} from "@/lib/mediaRecording";
+import { hashFile, uploadFileResumable } from "@/lib/evidenceUpload";
+
+jest.setTimeout(20000);
+
+// ---- Mock MediaRecorder ----
+// A minimal, controllable MediaRecorder. `supported` drives isTypeSupported so a
+// test can simulate different browsers' codec support. Instances register
+// themselves so a test can push `dataavailable` chunks and trigger `stop`.
+class MockMediaRecorder {
+  static supported = new Set<string>();
+  static instances: MockMediaRecorder[] = [];
+  static isTypeSupported(type: string): boolean {
+    return MockMediaRecorder.supported.has(type);
+  }
+
+  state: "inactive" | "recording" | "paused" = "inactive";
+  mimeType: string;
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+
+  constructor(
+    public stream: unknown,
+    opts?: { mimeType?: string },
+  ) {
+    this.mimeType = opts?.mimeType ?? "";
+    MockMediaRecorder.instances.push(this);
+  }
+  start(_timeslice?: number) {
+    this.state = "recording";
+  }
+  pause() {
+    this.state = "paused";
+  }
+  resume() {
+    this.state = "recording";
+  }
+  requestData() {
+    /* no-op; tests push chunks explicitly */
+  }
+  stop() {
+    this.state = "inactive";
+    this.onstop?.();
+  }
+  /** test helper */
+  emit(blob: Blob) {
+    this.ondataavailable?.({ data: blob });
+  }
+}
+
+function fakeStream() {
+  const track = { stop: jest.fn(), addEventListener: jest.fn() };
+  return {
+    getVideoTracks: () => [track],
+    getTracks: () => [track],
+    _track: track,
+  } as unknown as MediaStream;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+let disputeCounter = 0;
+function uniqueDispute(): string {
+  return `dispute-${Date.now()}-${disputeCounter++}`;
+}
+
+beforeEach(() => {
+  MockMediaRecorder.supported = new Set();
+  MockMediaRecorder.instances = [];
+  (globalThis as unknown as { MediaRecorder: unknown }).MediaRecorder =
+    MockMediaRecorder;
+});
+
+// ==========================================================
+// Codec negotiation across "browsers"
+// ==========================================================
+
+describe("codec negotiation", () => {
+  it("negotiates a supported format instead of assuming one codec (two browsers)", () => {
+    // "Chrome": supports WebM/VP9.
+    MockMediaRecorder.supported = new Set(["video/webm;codecs=vp9,opus"]);
+    const chrome = negotiateRecordingFormat();
+    expect(chrome.mimeType).toBe("video/webm;codecs=vp9,opus");
+    expect(chrome.extension).toBe("webm");
+
+    // "Safari": no WebM at all, only MP4/H.264.
+    MockMediaRecorder.supported = new Set(["video/mp4;codecs=h264,aac"]);
+    const safari = negotiateRecordingFormat();
+    expect(safari.mimeType).toBe("video/mp4;codecs=h264,aac");
+    expect(safari.extension).toBe("mp4");
+
+    // Neither is the same codec — the negotiation adapted per browser.
+    expect(chrome.mimeType).not.toBe(safari.mimeType);
+  });
+
+  it("falls back to the browser default (empty mimeType) when nothing matches, not a silent failure", () => {
+    MockMediaRecorder.supported = new Set(); // supports nothing in our list
+    const fmt = negotiateRecordingFormat();
+    expect(fmt.mimeType).toBe("");
+    expect(fmt.label).toBe("browser default");
+  });
+
+  it("isMimeTypeSupported is a safe wrapper", () => {
+    MockMediaRecorder.supported = new Set(["video/webm"]);
+    expect(isMimeTypeSupported("video/webm")).toBe(true);
+    expect(isMimeTypeSupported("video/mp4")).toBe(false);
+  });
+});
+
+// ==========================================================
+// Recording → existing chunked upload pipeline (with integrity hash)
+// ==========================================================
+
+// A tiny in-memory stand-in for the backend chunked-upload protocol. It
+// reassembles received chunks on `complete` and computes the SHA-256 itself, so
+// the test proves the recorded blob's integrity survives the pipeline.
+function installBackend() {
+  const sessions = new Map<
+    string,
+    { chunks: Map<number, Buffer>; meta: Record<string, unknown> }
+  >();
+  let counter = 0;
+  const okJson = (obj: unknown) => ({ ok: true, json: async () => obj });
+
+  (globalThis as unknown as { fetch: unknown }).fetch = jest.fn(
+    async (url: string, init: { method?: string; body?: unknown } = {}) => {
+      const u = String(url);
+      const method = init.method ?? "GET";
+
+      if (u.endsWith("/evidence/sessions") && method === "POST") {
+        const meta = JSON.parse(init.body as string);
+        const sid = `s${counter++}`;
+        sessions.set(sid, { chunks: new Map(), meta });
+        return okJson({ sessionId: sid, receivedChunks: [] });
+      }
+      const chunk = /\/sessions\/([^/]+)\/chunks\/(\d+)$/.exec(u);
+      if (chunk && method === "PUT") {
+        const [, sid, idx] = chunk;
+        const s = sessions.get(sid)!;
+        s.chunks.set(Number(idx), Buffer.from(init.body as ArrayBuffer));
+        return okJson({ receivedChunks: [...s.chunks.keys()] });
+      }
+      const complete = /\/sessions\/([^/]+)\/complete$/.exec(u);
+      if (complete && method === "POST") {
+        const [, sid] = complete;
+        const s = sessions.get(sid)!;
+        const ordered = [...s.chunks.entries()]
+          .sort((a, b) => a[0] - b[0])
+          .map((e) => e[1]);
+        const full = Buffer.concat(ordered);
+        const digest = await crypto.subtle.digest("SHA-256", full);
+        const sha = Array.from(new Uint8Array(digest))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+        return okJson({
+          attachment: {
+            id: sid,
+            sha256: sha,
+            size: full.length,
+            originalName: s.meta.originalName,
+          },
+        });
+      }
+      return okJson({});
+    },
+  );
+  return sessions;
+}
+
+async function recordClip(
+  source: "screen" | "camera",
+  chunks: Uint8Array[],
+): Promise<File> {
+  MockMediaRecorder.supported = new Set(["video/webm;codecs=vp9,opus"]);
+  const controller = new RecordingController({
+    disputeId: uniqueDispute(),
+    source,
+    persist: false,
+    acquire: async () => fakeStream(),
+  });
+  await controller.start();
+  const recorder = MockMediaRecorder.instances.at(-1)!;
+  for (const c of chunks) recorder.emit(new Blob([c as BlobPart]));
+  await flush();
+  return controller.stop();
+}
+
+describe("recorded video flows through the existing chunked upload pipeline", () => {
+  it("uploads a screen-capture recording with a matching integrity hash", async () => {
+    installBackend();
+    const file = await recordClip("screen", [
+      new Uint8Array([1, 2, 3, 4, 5]),
+      new Uint8Array([6, 7, 8, 9, 10]),
+    ]);
+    expect(file.size).toBe(10);
+    expect(file.type).toContain("video/webm");
+
+    const clientHash = await hashFile(file);
+    const { attachment } = await uploadFileResumable(
+      "http://api",
+      "token",
+      "d1",
+      file,
+      "file-1",
+      { name: file.name, mimeType: file.type, sha256: clientHash },
+    );
+
+    // Server recomputed the hash over the reassembled chunks — it matches.
+    expect(attachment.sha256).toBe(clientHash);
+    expect(attachment.size).toBe(file.size);
+  });
+
+  it("uploads a webcam recording through the same path", async () => {
+    installBackend();
+    const file = await recordClip("camera", [new Uint8Array([42, 43, 44])]);
+    const clientHash = await hashFile(file);
+    const { attachment } = await uploadFileResumable(
+      "http://api",
+      "token",
+      "d2",
+      file,
+      "file-2",
+      { name: file.name, mimeType: file.type, sha256: clientHash },
+    );
+    expect(attachment.sha256).toBe(clientHash);
+  });
+});
+
+// ==========================================================
+// Interruption recovery
+// ==========================================================
+
+describe("interruption recovery", () => {
+  it("preserves partially-captured content when a recording is interrupted", async () => {
+    const disputeId = uniqueDispute();
+    MockMediaRecorder.supported = new Set(["video/webm"]);
+    const controller = new RecordingController({
+      disputeId,
+      source: "screen",
+      persist: true, // periodic IndexedDB persistence
+      acquire: async () => fakeStream(),
+    });
+    await controller.start();
+    const recorder = MockMediaRecorder.instances.at(-1)!;
+
+    // Two timeslices land and are persisted...
+    recorder.emit(new Blob([new Uint8Array([1, 1, 1, 1])]));
+    recorder.emit(new Blob([new Uint8Array([2, 2, 2, 2])]));
+    await controller.flushPersistence();
+
+    // ...then the session is interrupted (permission revoked / tab closed):
+    // `stop()` is NEVER called cleanly, so the persisted chunks remain.
+    const recoverable = await listRecoverableRecordings(disputeId);
+    expect(recoverable).toHaveLength(1);
+    expect(recoverable[0].chunkCount).toBe(2);
+    expect(recoverable[0].size).toBe(8); // 4 + 4 bytes preserved
+    expect(recoverable[0].file).toBeInstanceOf(File);
+
+    // The recovered partial is a usable File that hashes fine.
+    const hash = await hashFile(recoverable[0].file);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("clears the persisted partial after a clean stop (no false recovery)", async () => {
+    const disputeId = uniqueDispute();
+    MockMediaRecorder.supported = new Set(["video/webm"]);
+    const controller = new RecordingController({
+      disputeId,
+      source: "camera",
+      persist: true,
+      acquire: async () => fakeStream(),
+    });
+    await controller.start();
+    const recorder = MockMediaRecorder.instances.at(-1)!;
+    recorder.emit(new Blob([new Uint8Array([9, 9])]));
+    await controller.flushPersistence();
+    await controller.stop();
+
+    const recoverable = await listRecoverableRecordings(disputeId);
+    expect(recoverable).toHaveLength(0);
+  });
+
+  it("clearRecording removes a recovered recording", async () => {
+    const disputeId = uniqueDispute();
+    MockMediaRecorder.supported = new Set(["video/webm"]);
+    const controller = new RecordingController({
+      disputeId,
+      source: "screen",
+      persist: true,
+      acquire: async () => fakeStream(),
+    });
+    await controller.start();
+    MockMediaRecorder.instances.at(-1)!.emit(new Blob([new Uint8Array([5])]));
+    await controller.flushPersistence();
+
+    let recoverable = await listRecoverableRecordings(disputeId);
+    expect(recoverable).toHaveLength(1);
+    await clearRecording(disputeId, recoverable[0].recordingId);
+    recoverable = await listRecoverableRecordings(disputeId);
+    expect(recoverable).toHaveLength(0);
+  });
+});
+
+// ==========================================================
+// Stream acquisition (getDisplayMedia / getUserMedia)
+// ==========================================================
+
+describe("stream acquisition", () => {
+  afterEach(() => {
+    delete (navigator as unknown as { mediaDevices?: unknown }).mediaDevices;
+  });
+
+  it("uses getDisplayMedia for screen and getUserMedia for camera", async () => {
+    const getDisplayMedia = jest.fn(async () => fakeStream());
+    const getUserMedia = jest.fn(async () => fakeStream());
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getDisplayMedia, getUserMedia },
+      configurable: true,
+    });
+
+    await acquireStream("screen");
+    await acquireStream("camera");
+    expect(getDisplayMedia).toHaveBeenCalledTimes(1);
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps a denied permission to a permission RecordingError", async () => {
+    const denied = Object.assign(new Error("denied"), {
+      name: "NotAllowedError",
+    });
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia: jest.fn(async () => Promise.reject(denied)) },
+      configurable: true,
+    });
+    await expect(acquireStream("camera")).rejects.toMatchObject({
+      name: "RecordingError",
+      kind: "permission",
+    });
+  });
+});
+
+// ==========================================================
+// Player timestamp helpers (stable, shareable references)
+// ==========================================================
+
+describe("timestamp helpers", () => {
+  it("formats seconds as m:ss and h:mm:ss", () => {
+    expect(formatTimestamp(0)).toBe("0:00");
+    expect(formatTimestamp(9)).toBe("0:09");
+    expect(formatTimestamp(75)).toBe("1:15");
+    expect(formatTimestamp(3661)).toBe("1:01:01");
+    expect(formatTimestamp(-5)).toBe("0:00");
+  });
+
+  it("round-trips a shareable media-fragment deep link", () => {
+    const hash = buildTimestampHash(12.53);
+    expect(hash).toBe("#t=12.5");
+    expect(parseTimestampFromHash(hash)).toBeCloseTo(12.5);
+  });
+
+  it("parses both #t=seconds and #t=clock forms", () => {
+    expect(parseTimestampFromHash("#t=42")).toBe(42);
+    expect(parseTimestampFromHash("#t=1:02:03")).toBe(3723);
+    expect(parseTimestampFromHash("#nope")).toBeNull();
+    expect(parseTimestampFromHash("")).toBeNull();
+  });
+
+  it("classifies video evidence by mime or extension", () => {
+    expect(isVideoEvidence("video/webm")).toBe(true);
+    expect(isVideoEvidence("recording.mp4")).toBe(true);
+    expect(isVideoEvidence("application/pdf")).toBe(false);
+    expect(isVideoEvidence(undefined)).toBe(false);
+  });
+});
+
+describe("RecordingError", () => {
+  it("carries a kind", () => {
+    const e = new RecordingError("permission", "nope");
+    expect(e.kind).toBe("permission");
+    expect(e.message).toBe("nope");
+    expect(e).toBeInstanceOf(Error);
+  });
+});

--- a/frontend/src/lib/mediaRecording.ts
+++ b/frontend/src/lib/mediaRecording.ts
@@ -1,0 +1,642 @@
+import { openDB, IDBPDatabase } from "idb";
+
+/**
+ * In-browser media-recording layer for dispute evidence (issue #901).
+ *
+ * This module is intentionally framework-agnostic so it can be unit-tested
+ * without React. It handles three hard parts the issue calls out:
+ *
+ *  1. **Cross-browser codec negotiation** — `MediaRecorder`'s supported
+ *     `mimeType` varies across Chrome/Firefox/Safari. We probe a preference list
+ *     with `MediaRecorder.isTypeSupported` and pick the first that works, rather
+ *     than assuming one codec is universal.
+ *
+ *  2. **Integration with the existing chunked upload pipeline** — a recording is
+ *     assembled into a plain `File` on stop, which then flows through the very
+ *     same `hashFile` + `uploadFileResumable` path used for hand-picked files
+ *     (see `evidenceUpload.ts`). No separate upload path.
+ *
+ *  3. **Interruption resilience** — every `MediaRecorder` timeslice is persisted
+ *     to IndexedDB as it arrives (not a single blob assembled only at the end).
+ *     A revoked permission, closed tab, or crash therefore leaves a recoverable
+ *     partial recording behind, which `listRecoverableRecordings` surfaces.
+ */
+
+// ---- codec negotiation ----
+
+export interface RecordingFormat {
+  /** The negotiated MediaRecorder mimeType, or "" to use the browser default. */
+  mimeType: string;
+  /** File extension implied by the container ("webm" or "mp4"). */
+  extension: string;
+  /** Human-readable label for the UI, e.g. "WebM (VP9)". */
+  label: string;
+}
+
+/**
+ * Preference order, most-to-least desirable. VP9/Opus in WebM is the modern
+ * Chrome/Firefox default; H.264/AAC in MP4 is the Safari fallback. The bare
+ * container entries catch browsers that support the container but not the
+ * codec-qualified string.
+ */
+export const PREFERRED_VIDEO_MIME_TYPES: string[] = [
+  "video/webm;codecs=vp9,opus",
+  "video/webm;codecs=vp8,opus",
+  "video/webm;codecs=vp9",
+  "video/webm;codecs=vp8",
+  "video/webm;codecs=h264",
+  "video/webm",
+  "video/mp4;codecs=h264,aac",
+  "video/mp4;codecs=avc1",
+  "video/mp4",
+];
+
+/** Safe wrapper around `MediaRecorder.isTypeSupported` (absent in some envs). */
+export function isMimeTypeSupported(mimeType: string): boolean {
+  try {
+    return (
+      typeof MediaRecorder !== "undefined" &&
+      typeof MediaRecorder.isTypeSupported === "function" &&
+      MediaRecorder.isTypeSupported(mimeType)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function labelFor(mimeType: string): string {
+  if (!mimeType) return "browser default";
+  const container = mimeType.includes("mp4") ? "MP4" : "WebM";
+  const codecMatch = /codecs=([^;]+)/i.exec(mimeType);
+  const codec = codecMatch
+    ? codecMatch[1].split(",")[0].trim().toUpperCase()
+    : "";
+  return codec ? `${container} (${codec})` : container;
+}
+
+export function toRecordingFormat(mimeType: string): RecordingFormat {
+  return {
+    mimeType,
+    extension: mimeType.includes("mp4") ? "mp4" : "webm",
+    label: labelFor(mimeType),
+  };
+}
+
+/**
+ * Negotiate the best supported recording format for the current browser.
+ *
+ * Returns the first supported mimeType from `preferred`. If none are supported
+ * (or the API is unavailable), returns an empty `mimeType` so `MediaRecorder`
+ * falls back to its own default — the `label` ("browser default") lets the UI
+ * communicate that the exact format could not be pinned down, rather than
+ * failing silently.
+ */
+export function negotiateRecordingFormat(
+  preferred: string[] = PREFERRED_VIDEO_MIME_TYPES,
+): RecordingFormat {
+  for (const mimeType of preferred) {
+    if (isMimeTypeSupported(mimeType)) {
+      return toRecordingFormat(mimeType);
+    }
+  }
+  return { mimeType: "", extension: "webm", label: "browser default" };
+}
+
+// ---- errors ----
+
+export type RecordingErrorKind =
+  | "unsupported"
+  | "permission"
+  | "aborted"
+  | "no-input"
+  | "unknown";
+
+export class RecordingError extends Error {
+  kind: RecordingErrorKind;
+  constructor(kind: RecordingErrorKind, message: string) {
+    super(message);
+    this.name = "RecordingError";
+    this.kind = kind;
+  }
+}
+
+/** Classify a raw getUserMedia/getDisplayMedia rejection into a stable kind. */
+export function classifyMediaError(err: unknown): RecordingError {
+  if (err instanceof RecordingError) return err;
+  const name = (err as { name?: string })?.name ?? "";
+  if (name === "NotAllowedError" || name === "SecurityError") {
+    return new RecordingError(
+      "permission",
+      "Recording permission was denied. Allow access to continue.",
+    );
+  }
+  if (name === "NotFoundError" || name === "OverconstrainedError") {
+    return new RecordingError(
+      "no-input",
+      "No camera/microphone or screen source was available.",
+    );
+  }
+  if (name === "AbortError") {
+    return new RecordingError("aborted", "Recording was interrupted.");
+  }
+  const message =
+    (err as { message?: string })?.message ?? "Could not start recording.";
+  return new RecordingError("unknown", message);
+}
+
+// ---- stream acquisition ----
+
+export type RecordingSource = "screen" | "camera";
+
+/**
+ * Acquire a MediaStream for the given source. `getDisplayMedia` for screen
+ * share, `getUserMedia` for webcam+mic. Kept tiny and dependency-free so tests
+ * can mock `navigator.mediaDevices` directly.
+ */
+export async function acquireStream(
+  source: RecordingSource,
+): Promise<MediaStream> {
+  const md =
+    typeof navigator !== "undefined" ? navigator.mediaDevices : undefined;
+  if (!md) {
+    throw new RecordingError(
+      "unsupported",
+      "Media capture is not supported in this browser.",
+    );
+  }
+  try {
+    if (source === "screen") {
+      if (typeof md.getDisplayMedia !== "function") {
+        throw new RecordingError(
+          "unsupported",
+          "Screen capture is not supported in this browser.",
+        );
+      }
+      return await md.getDisplayMedia({ video: true, audio: true });
+    }
+    if (typeof md.getUserMedia !== "function") {
+      throw new RecordingError(
+        "unsupported",
+        "Camera capture is not supported in this browser.",
+      );
+    }
+    return await md.getUserMedia({ video: true, audio: true });
+  } catch (err) {
+    throw classifyMediaError(err);
+  }
+}
+
+// ---- in-progress recording persistence (interruption recovery) ----
+
+interface RecordingChunkRecord {
+  disputeId: string;
+  recordingId: string;
+  index: number;
+  /** Raw chunk bytes. Stored as an ArrayBuffer rather than a Blob because raw
+   * buffers structured-clone reliably across environments (a Blob does not). */
+  bytes: ArrayBuffer;
+  mimeType: string;
+  source: RecordingSource;
+  updatedAt: number;
+}
+
+/** Blob → ArrayBuffer with a FileReader fallback for environments (jsdom, older
+ * browsers) that lack `Blob.arrayBuffer`. */
+async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+  if (typeof blob.arrayBuffer === "function") {
+    return blob.arrayBuffer();
+  }
+  return new Promise<ArrayBuffer>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+const REC_DB_NAME = "evidence-recording-store";
+const REC_STORE = "chunks";
+
+let recDbPromise: Promise<IDBPDatabase> | null = null;
+
+function getRecDB(): Promise<IDBPDatabase> {
+  if (!recDbPromise) {
+    recDbPromise = openDB(REC_DB_NAME, 1, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(REC_STORE)) {
+          const store = db.createObjectStore(REC_STORE, {
+            keyPath: ["disputeId", "recordingId", "index"],
+          });
+          store.createIndex("byDispute", "disputeId");
+        }
+      },
+    });
+  }
+  return recDbPromise;
+}
+
+/** Persist a single in-progress timeslice chunk so it survives an interruption. */
+export async function persistRecordingChunk(record: {
+  disputeId: string;
+  recordingId: string;
+  index: number;
+  blob: Blob;
+  mimeType: string;
+  source: RecordingSource;
+}): Promise<void> {
+  const db = await getRecDB();
+  const bytes = await blobToArrayBuffer(record.blob);
+  const stored: RecordingChunkRecord = {
+    disputeId: record.disputeId,
+    recordingId: record.recordingId,
+    index: record.index,
+    bytes,
+    mimeType: record.mimeType,
+    source: record.source,
+    updatedAt: Date.now(),
+  };
+  await db.put(REC_STORE, stored);
+}
+
+/** Delete all persisted chunks for one recording (after a clean hand-off). */
+export async function clearRecording(
+  disputeId: string,
+  recordingId: string,
+): Promise<void> {
+  const db = await getRecDB();
+  const all = (await db.getAllFromIndex(
+    REC_STORE,
+    "byDispute",
+    disputeId,
+  )) as RecordingChunkRecord[];
+  const tx = db.transaction(REC_STORE, "readwrite");
+  await Promise.all(
+    all
+      .filter((r) => r.recordingId === recordingId)
+      .map((r) => tx.store.delete([r.disputeId, r.recordingId, r.index])),
+  );
+  await tx.done;
+}
+
+export interface RecoverableRecording {
+  recordingId: string;
+  disputeId: string;
+  mimeType: string;
+  source: RecordingSource;
+  chunkCount: number;
+  size: number;
+  updatedAt: number;
+  /** The partial recording assembled into a playable/uploadable File. */
+  file: File;
+}
+
+function extensionForMime(mimeType: string): string {
+  return mimeType.includes("mp4") ? "mp4" : "webm";
+}
+
+function assembleFile(
+  recordingId: string,
+  chunks: BlobPart[],
+  mimeType: string,
+): File {
+  const type = mimeType || "video/webm";
+  const blob = new Blob(chunks, { type });
+  const name = `dispute-recording-${recordingId}.${extensionForMime(type)}`;
+  return new File([blob], name, { type });
+}
+
+/**
+ * Return any recoverable partial recordings persisted for a dispute, assembled
+ * (in chunk order) into Files. Used to surface evidence left behind by an
+ * interrupted session so it is not silently lost.
+ */
+export async function listRecoverableRecordings(
+  disputeId: string,
+): Promise<RecoverableRecording[]> {
+  const db = await getRecDB();
+  const all = (await db.getAllFromIndex(
+    REC_STORE,
+    "byDispute",
+    disputeId,
+  )) as RecordingChunkRecord[];
+
+  const byRecording = new Map<string, RecordingChunkRecord[]>();
+  for (const rec of all) {
+    const list = byRecording.get(rec.recordingId) ?? [];
+    list.push(rec);
+    byRecording.set(rec.recordingId, list);
+  }
+
+  const result: RecoverableRecording[] = [];
+  for (const [recordingId, records] of byRecording) {
+    records.sort((a, b) => a.index - b.index);
+    const blobs = records.map((r) => r.bytes);
+    const mimeType = records[0]?.mimeType ?? "video/webm";
+    const file = assembleFile(recordingId, blobs, mimeType);
+    result.push({
+      recordingId,
+      disputeId,
+      mimeType,
+      source: records[0]?.source ?? "screen",
+      chunkCount: records.length,
+      size: file.size,
+      updatedAt: records.reduce((m, r) => Math.max(m, r.updatedAt), 0),
+      file,
+    });
+  }
+  // Most recent first.
+  result.sort((a, b) => b.updatedAt - a.updatedAt);
+  return result;
+}
+
+// ---- recording controller ----
+
+export type RecordingStatus =
+  | "idle"
+  | "recording"
+  | "paused"
+  | "stopping"
+  | "stopped"
+  | "error";
+
+export interface RecordingControllerOptions {
+  disputeId: string;
+  source: RecordingSource;
+  /** Stable id; generated if omitted. */
+  recordingId?: string;
+  /** How often MediaRecorder emits (and we persist) a chunk. Default 3000 ms. */
+  timesliceMs?: number;
+  /** Pre-negotiated format; negotiated on demand if omitted. */
+  format?: RecordingFormat;
+  /** Persist chunks to IndexedDB for crash recovery. Default true. */
+  persist?: boolean;
+  onStatus?: (status: RecordingStatus) => void;
+  onChunk?: (info: { count: number; bytes: number }) => void;
+  onError?: (err: RecordingError) => void;
+  /** Injection seam for tests: supply a stream instead of hitting the browser. */
+  acquire?: (source: RecordingSource) => Promise<MediaStream>;
+}
+
+function newId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `rec_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Wraps a MediaStream + MediaRecorder into a small state machine:
+ * `idle → recording ⇄ paused → stopping → stopped` (or `→ error`).
+ *
+ * Chunks are collected in memory *and* (by default) persisted to IndexedDB as
+ * they arrive so an interruption leaves a recoverable partial recording.
+ */
+export class RecordingController {
+  readonly recordingId: string;
+  readonly disputeId: string;
+  readonly source: RecordingSource;
+  format: RecordingFormat;
+
+  status: RecordingStatus = "idle";
+
+  private readonly timesliceMs: number;
+  private readonly persist: boolean;
+  private readonly opts: RecordingControllerOptions;
+
+  private stream: MediaStream | null = null;
+  private recorder: MediaRecorder | null = null;
+  private chunks: Blob[] = [];
+  private chunkIndex = 0;
+  private bytes = 0;
+  // Serializes best-effort chunk persistence so writes land in order and so
+  // callers can await all in-flight persistence (e.g. before reading recovery).
+  private persistQueue: Promise<void> = Promise.resolve();
+
+  constructor(opts: RecordingControllerOptions) {
+    this.opts = opts;
+    this.recordingId = opts.recordingId ?? newId();
+    this.disputeId = opts.disputeId;
+    this.source = opts.source;
+    this.timesliceMs = opts.timesliceMs ?? 3000;
+    this.persist = opts.persist ?? true;
+    this.format =
+      opts.format ?? { mimeType: "", extension: "webm", label: "browser default" };
+  }
+
+  getStream(): MediaStream | null {
+    return this.stream;
+  }
+
+  private setStatus(status: RecordingStatus): void {
+    this.status = status;
+    this.opts.onStatus?.(status);
+  }
+
+  private fail(err: unknown): RecordingError {
+    const e = classifyMediaError(err);
+    this.setStatus("error");
+    this.opts.onError?.(e);
+    return e;
+  }
+
+  /** Acquire the stream and begin recording. Rejects with a `RecordingError`. */
+  async start(): Promise<MediaStream> {
+    if (this.status === "recording" || this.status === "paused") {
+      throw new RecordingError("unknown", "Recording is already in progress.");
+    }
+    try {
+      const acquire = this.opts.acquire ?? acquireStream;
+      const stream = await acquire(this.source);
+      this.stream = stream;
+
+      if (!this.format.mimeType) {
+        this.format = this.opts.format ?? negotiateRecordingFormat();
+      }
+
+      const recorder = new MediaRecorder(
+        stream,
+        this.format.mimeType ? { mimeType: this.format.mimeType } : undefined,
+      );
+      this.recorder = recorder;
+
+      recorder.ondataavailable = (event: BlobEvent) => {
+        if (event.data && event.data.size > 0) {
+          void this.handleChunk(event.data);
+        }
+      };
+      recorder.onerror = () => {
+        this.fail(
+          new RecordingError("unknown", "The recorder encountered an error."),
+        );
+      };
+
+      // If the user ends the screen share (or unplugs the camera), the track
+      // fires "ended" — treat that as a stop so nothing is lost.
+      const videoTrack = stream.getVideoTracks?.()[0];
+      videoTrack?.addEventListener?.("ended", () => {
+        if (this.status === "recording" || this.status === "paused") {
+          void this.stop().catch(() => undefined);
+        }
+      });
+
+      recorder.start(this.timesliceMs);
+      this.setStatus("recording");
+      return stream;
+    } catch (err) {
+      throw this.fail(err);
+    }
+  }
+
+  private async handleChunk(blob: Blob): Promise<void> {
+    this.chunks.push(blob);
+    const index = this.chunkIndex++;
+    this.bytes += blob.size;
+    this.opts.onChunk?.({ count: this.chunks.length, bytes: this.bytes });
+
+    if (this.persist) {
+      // Chain onto the queue so writes are ordered and awaitable, and so a
+      // failure is swallowed (persistence must never break recording).
+      this.persistQueue = this.persistQueue.then(() =>
+        persistRecordingChunk({
+          disputeId: this.disputeId,
+          recordingId: this.recordingId,
+          index,
+          blob,
+          mimeType: this.format.mimeType || "video/webm",
+          source: this.source,
+        }).catch(() => undefined),
+      );
+      await this.persistQueue;
+    }
+  }
+
+  /** Await all in-flight chunk persistence (useful for recovery/tests). */
+  async flushPersistence(): Promise<void> {
+    await this.persistQueue;
+  }
+
+  pause(): void {
+    if (this.recorder && this.status === "recording") {
+      this.recorder.pause();
+      this.setStatus("paused");
+    }
+  }
+
+  resume(): void {
+    if (this.recorder && this.status === "paused") {
+      this.recorder.resume();
+      this.setStatus("recording");
+    }
+  }
+
+  private stopTracks(): void {
+    this.stream?.getTracks?.().forEach((t) => t.stop());
+  }
+
+  /**
+   * Stop recording cleanly, assemble the captured chunks into a `File`, and
+   * clear the persisted partial (the returned File is handed to the upload
+   * pipeline, which has its own persistence). Resolves with the File.
+   */
+  async stop(): Promise<File> {
+    const recorder = this.recorder;
+    if (!recorder || (this.status !== "recording" && this.status !== "paused")) {
+      // Nothing recording — assemble whatever we have (possibly empty).
+      const file = this.assemble();
+      this.stopTracks();
+      this.setStatus("stopped");
+      return file;
+    }
+
+    this.setStatus("stopping");
+    const file = await new Promise<File>((resolve) => {
+      recorder.onstop = () => resolve(this.assemble());
+      try {
+        // Flush any buffered data, then stop.
+        if (
+          typeof recorder.requestData === "function" &&
+          recorder.state !== "inactive"
+        ) {
+          recorder.requestData();
+        }
+        recorder.stop();
+      } catch {
+        resolve(this.assemble());
+      }
+    });
+
+    this.stopTracks();
+    this.setStatus("stopped");
+    // Flush any in-flight chunk writes first, so clearing can't race a late
+    // persist and leave a stray chunk behind. Then clear — a clean stop means
+    // the file is now owned by the caller/upload pipeline.
+    await this.flushPersistence();
+    await clearRecording(this.disputeId, this.recordingId).catch(
+      () => undefined,
+    );
+    return file;
+  }
+
+  private assemble(): File {
+    return assembleFile(
+      this.recordingId,
+      this.chunks,
+      this.format.mimeType || "video/webm",
+    );
+  }
+}
+
+// ---- player timestamp helpers (shareable, stable references) ----
+
+/** Format seconds as `m:ss` or `h:mm:ss`, padded — used by the scrubber. */
+export function formatTimestamp(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) totalSeconds = 0;
+  const whole = Math.floor(totalSeconds);
+  const h = Math.floor(whole / 3600);
+  const m = Math.floor((whole % 3600) / 60);
+  const s = whole % 60;
+  const mm = h > 0 ? String(m).padStart(2, "0") : String(m);
+  const ss = String(s).padStart(2, "0");
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+/**
+ * Build a W3C Media-Fragments hash for a timestamp, e.g. `#t=12.5`. This is a
+ * stable, shareable reference an arbitrator can paste to point at a moment.
+ */
+export function buildTimestampHash(seconds: number): string {
+  const clamped = Math.max(0, Math.round(seconds * 10) / 10);
+  return `#t=${clamped}`;
+}
+
+/**
+ * Parse a timestamp out of a URL hash. Accepts the media-fragment form
+ * `#t=12.5` and a clock form `#t=1:02:03`. Returns seconds, or null.
+ */
+export function parseTimestampFromHash(hash: string): number | null {
+  if (!hash) return null;
+  const match = /[#&]?t=([0-9:.]+)/i.exec(hash);
+  if (!match) return null;
+  const raw = match[1];
+  if (raw.includes(":")) {
+    const parts = raw.split(":").map((p) => Number(p));
+    if (parts.some((n) => Number.isNaN(n))) return null;
+    return parts.reduce((acc, n) => acc * 60 + n, 0);
+  }
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** True when an evidence file type/mime represents a playable video. */
+export function isVideoEvidence(fileTypeOrMime: string | undefined): boolean {
+  if (!fileTypeOrMime) return false;
+  const v = fileTypeOrMime.toLowerCase();
+  return (
+    v.startsWith("video/") ||
+    v === "video" ||
+    v.endsWith("webm") ||
+    v.endsWith("mp4") ||
+    v.endsWith("mov") ||
+    v.endsWith("ogg")
+  );
+}


### PR DESCRIPTION
Closes #901

## Summary

Adds **in-browser video capture** (screen share + webcam) and a **dedicated review player** to the dispute evidence flow, integrated with the *existing* chunked, integrity-hashed, resumable upload pipeline (`src/lib/evidenceUpload.ts`) — not a separate path.

- `src/lib/mediaRecording.ts` — codec negotiation, `RecordingController` (MediaRecorder + IndexedDB chunk persistence), recovery, timestamp helpers
- `src/components/EvidenceRecorder.tsx` — capture UI (screen/camera, start/pause/stop, live preview, recovery)
- `src/components/EvidenceVideoPlayer.tsx` — review player (timestamped scrubbing, `#t=` deep-links, frame capture)
- `EvidenceUpload.tsx` / `EvidenceViewer.tsx` — recorder + player wired in additively
- Design write-up: `VIDEO_EVIDENCE_CAPTURE.md`

## Key design decisions

### Reuse the existing upload pipeline (no one-off path)
A finished recording is assembled into a plain `File` on stop and handed to `EvidenceUpload`, where it joins the exact same flow as a hand-picked file — same `hashFile` SHA-256 and same `uploadFileResumable` chunked/resumable transfer. The recording's byte size is only known on stop, which is fine: chunk count is derived from `file.size` at upload time.

### Cross-browser codec negotiation
`negotiateRecordingFormat()` probes a preference list with `MediaRecorder.isTypeSupported` and picks the first supported format (Chrome/Firefox WebM/VP9 → Safari MP4/H.264 → browser default), adapting per browser. If nothing matches it returns the browser default **and labels it as such**, rather than failing silently.

### Interruption resilience (periodic persistence, not one final blob)
Recording uses a MediaRecorder timeslice and persists each chunk to IndexedDB as it arrives. A revoked permission, closed tab, or crash leaves a **recoverable partial recording**; the recorder surfaces Recover/Discard. A clean stop clears the partial; a screen-share `ended` event is treated as a stop so ending the share never loses content.

### Evidence-specific player
Timestamped scrubbing, a **stable shareable deep-link** to the current moment via the W3C media-fragment form (`#t=12.5`, read on load so a shared link lands on the moment), and **frame capture** producing a PNG an arbitrator can reference.

## Acceptance criteria
- [x] Users can record screen and/or webcam video directly in the browser as dispute evidence
- [x] Recorded video integrates with the existing chunked, integrity-hashed upload pipeline — not a separate one-off path
- [x] Codec/format differences across browsers are handled explicitly, not assumed away
- [x] Interrupted recordings don't silently lose all captured content
- [x] A dedicated video player supports timestamped review, not just generic playback

## Testing
- `npx jest` → **29 new tests pass** (recording→upload integrity-hash flow, codec negotiation across simulated browsers, interruption recovery, player scrubbing/deep-link/frame capture). Full suite: 209 pass; the only failures are 3 pre-existing `useUnsavedChangesWarning` tests that also fail on `main` (a `delete window.location` incompatibility, unrelated to this change).
- `tsc --noEmit` clean; ESLint clean on the new files.

Also fixes a no-op `structuredClone` polyfill in `jest.setup.ts` (it referenced a non-existent `crypto.structuredClone`) so IndexedDB writes actually round-trip in tests; no existing tests regressed.