### PR TITLE
fix(backend): Add authorization check to GET /jobs/:jobId/milestones

### DIFF
--- a/backend/src/__tests__/milestone-auth.test.ts
+++ b/backend/src/__tests__/milestone-auth.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for issue: "GET /jobs/:jobId/milestones has no authorization check"
+ *
+ * Acceptance criteria:
+ *  1. GET /jobs/:jobId/milestones returns 403 for users who are neither the job's client nor freelancer
+ *  2. Existing client/freelancer access continues to work
+ *  3. A regression test covers the unauthorized case
+ */
+
+// ─── Prisma mock ──────────────────────────────────────────────────────────────
+jest.mock("@prisma/client", () => {
+  const mockPrisma = {
+    job: {
+      findUnique: jest.fn(),
+    },
+    milestone: {
+      findMany: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  return {
+    PrismaClient: jest.fn(() => mockPrisma) as any,
+  };
+});
+
+// ─── JWT mock ─────────────────────────────────────────────────────────────────
+jest.mock("jsonwebtoken", () => ({
+  verify: jest.fn(),
+  sign: jest.fn().mockReturnValue("mock-token"),
+}));
+
+// ─── Config & other mocks ─────────────────────────────────────────────────────
+jest.mock("../config", () => ({
+  config: {
+    jwtSecret: "test-secret",
+  },
+}));
+
+jest.mock("../services/notification.service", () => ({
+  NotificationService: {
+    sendNotification: jest.fn(),
+  },
+}));
+
+jest.mock("../services/contract.service", () => ({
+  ContractService: {
+    buildSubmitMilestoneTx: jest.fn(),
+    buildApproveMilestoneTx: jest.fn(),
+  },
+}));
+
+jest.mock("../socket", () => ({
+  getIo: jest.fn(() => ({
+    to: jest.fn().mockReturnThis(),
+    emit: jest.fn(),
+  })),
+}));
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+import { PrismaClient } from "@prisma/client";
+import * as jwt from "jsonwebtoken";
+import express from "express";
+import request from "supertest";
+import milestoneRouter from "../routes/milestone.routes";
+import { errorHandler } from "../middleware/error";
+
+const prismaMock = new PrismaClient() as any;
+const jwtVerify = jwt.verify as jest.Mock;
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const CLIENT_ID = "client-123";
+const FREELANCER_ID = "freelancer-456";
+const STRANGER_ID = "stranger-789";
+const JOB_ID = "job-001";
+
+const mockJob = {
+  id: JOB_ID,
+  clientId: CLIENT_ID,
+  freelancerId: FREELANCER_ID,
+};
+
+const mockMilestones = [
+  { id: "m-1", title: "Milestone 1", amount: 100 },
+  { id: "m-2", title: "Milestone 2", amount: 200 },
+];
+
+// ─── App factory ──────────────────────────────────────────────────────────────
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/milestones", milestoneRouter);
+  // Need to handle error responses properly
+  app.use(errorHandler);
+  return app;
+}
+
+// ─── Auth helpers ─────────────────────────────────────────────────────────────
+
+function mockAuthAs(userId: string) {
+  jwtVerify.mockReturnValueOnce({ userId });
+  prismaMock.user.findUnique.mockResolvedValueOnce({ id: userId, emailVerified: true });
+}
+
+afterEach(() => jest.clearAllMocks());
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/milestones/jobs/:jobId/milestones
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("GET /api/milestones/jobs/:jobId/milestones — Authorization", () => {
+  beforeEach(() => {
+    prismaMock.job.findUnique.mockResolvedValue(mockJob);
+    prismaMock.milestone.findMany.mockResolvedValue(mockMilestones);
+  });
+
+  it("returns 403 for authenticated users who are neither the client nor freelancer", async () => {
+    mockAuthAs(STRANGER_ID);
+
+    const app = buildApp();
+    const res = await request(app)
+      .get(`/api/milestones/jobs/${JOB_ID}/milestones`)
+      .set("Authorization", "Bearer mock-token");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Not authorized to view milestones for this job.");
+    // Should not fetch milestones if unauthorized
+    expect(prismaMock.milestone.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 and milestones list for the job's client", async () => {
+    mockAuthAs(CLIENT_ID);
+
+    const app = buildApp();
+    const res = await request(app)
+      .get(`/api/milestones/jobs/${JOB_ID}/milestones`)
+      .set("Authorization", "Bearer mock-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockMilestones);
+    expect(prismaMock.milestone.findMany).toHaveBeenCalledWith({
+      where: { jobId: JOB_ID },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("returns 200 and milestones list for the job's freelancer", async () => {
+    mockAuthAs(FREELANCER_ID);
+
+    const app = buildApp();
+    const res = await request(app)
+      .get(`/api/milestones/jobs/${JOB_ID}/milestones`)
+      .set("Authorization", "Bearer mock-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockMilestones);
+    expect(prismaMock.milestone.findMany).toHaveBeenCalledWith({
+      where: { jobId: JOB_ID },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("returns 404 if the job does not exist", async () => {
+    mockAuthAs(CLIENT_ID);
+    prismaMock.job.findUnique.mockResolvedValueOnce(null);
+
+    const app = buildApp();
+    const res = await request(app)
+      .get(`/api/milestones/jobs/nonexistent-job/milestones`)
+      .set("Authorization", "Bearer mock-token");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Job not found.");
+  });
+});

--- a/backend/src/routes/milestone.routes.ts
+++ b/backend/src/routes/milestone.routes.ts
@@ -46,6 +46,15 @@ router.get(
       return res.status(404).json({ error: "Job not found." });
     }
 
+    const isClient = job.clientId === req.userId;
+    const isFreelancer = job.freelancerId === req.userId;
+
+    if (!isClient && !isFreelancer) {
+      return res
+        .status(403)
+        .json({ error: "Not authorized to view milestones for this job." });
+    }
+
     const milestones = await prisma.milestone.findMany({
       where: { jobId },
       orderBy: { createdAt: "asc" },


### PR DESCRIPTION
**IDOR Fix Walkthrough**

This document summarizes the changes made to fix the Insecure Direct Object Reference (IDOR) vulnerability in the GET /api/v1/jobs/:jobId/milestones endpoint.

_Changes Made_

Added Authorization Check: I updated backend/src/routes/milestone.routes.ts to implement an ownership check on the job before returning the milestones list. We fetch the job and compare the authenticated user's ID against the job's clientId and freelancerId. If the user is neither the client nor the freelancer, a 403 Forbidden response is returned. This aligns the list endpoint with the single-milestone fetch endpoint (GET /:id).
typescript

const job = await prisma.job.findUnique({ where: { id: jobId } });
    if (!job) {
      return res.status(404).json({ error: "Job not found." });
    }
    const isClient = job.clientId === req.userId;
    const isFreelancer = job.freelancerId === req.userId;
    if (!isClient && !isFreelancer) {
      return res
        .status(403)
        .json({ error: "Not authorized to view milestones for this job." });
    }

Added Regression Tests: I created a new test suite at backend/src/__tests__/milestone-auth.test.ts. This suite uses Supertest and a mocked Prisma client to verify the authorization behavior:

_Unauthorized access: An authenticated user who is neither the client nor the freelancer receives a 403 Forbidden status.
Authorized client: The job's client correctly receives a 200 OK and the list of milestones.
Authorized freelancer: The job's freelancer correctly receives a 200 OK and the list of milestones.
Not found: A request for an invalid job ID returns a 404 Not Found._

**What Was Tested**
The new regression tests (milestone-auth.test.ts) were executed successfully via Jest.
Existing authorization boundaries were validated (clients and freelancers can still retrieve the data).

**Validation Results**
The automated tests successfully confirmed that unauthorized users are now blocked with a 403 status.
The milestone-auth.test.ts test suite ran to completion with 4 passed, 4 total tests and no errors.

closes #918