### PR TITLE
fix: accessibility and image optimization for profile, review, skill, and transaction UI

### DIFF
--- a/frontend/src/app/u/[username]/ProfileHeader.server.tsx
+++ b/frontend/src/app/u/[username]/ProfileHeader.server.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api/v1";
 
 type Props = { userPromise: Promise<any> };
@@ -8,8 +10,15 @@ export default async function ProfileHeader({ userPromise }: Props) {
     <header className="flex flex-col sm:flex-row gap-6 items-start mb-10">
       <div className="w-28 h-28 rounded-full bg-gradient-to-br from-stellar-blue to-stellar-purple flex-shrink-0 flex items-center justify-center overflow-hidden border-4 border-theme-card">
         {user.avatarUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={user.avatarUrl} alt={user.username} width={112} height={112} className="w-full h-full object-cover" />
+          <Image
+            src={user.avatarUrl}
+            alt={user.username}
+            width={112}
+            height={112}
+            className="w-full h-full object-cover"
+            priority
+            unoptimized
+          />
         ) : (
           <div className="w-full h-full flex items-center justify-center text-white/50">U</div>
         )}

--- a/frontend/src/components/ReviewModal.tsx
+++ b/frontend/src/components/ReviewModal.tsx
@@ -179,14 +179,32 @@ export default function ReviewModal({
                 role="radiogroup"
                 aria-label="Star rating"
                 aria-required="true"
+                onKeyDown={(e) => {
+                  if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+                  e.preventDefault();
+                  const current = rating || 1;
+                  const next =
+                    e.key === "ArrowRight"
+                      ? Math.min(current + 1, 5)
+                      : Math.max(current - 1, 1);
+                  setRating(next);
+                  setError(null);
+                  (
+                    e.currentTarget.querySelector(
+                      `[data-star="${next}"]`,
+                    ) as HTMLButtonElement | null
+                  )?.focus();
+                }}
               >
                 {[1, 2, 3, 4, 5].map((star) => (
                   <button
                     key={star}
+                    data-star={star}
                     type="button"
                     role="radio"
                     aria-checked={rating === star}
                     aria-label={`${star} star${star > 1 ? "s" : ""} — ${ratingLabels[star]}`}
+                    tabIndex={star === (rating || 1) ? 0 : -1}
                     onClick={() => {
                       setRating(star);
                       setError(null);

--- a/frontend/src/components/SkillCombobox.tsx
+++ b/frontend/src/components/SkillCombobox.tsx
@@ -25,12 +25,18 @@ interface SkillComboboxProps {
  * pressing Enter on free text not in the taxonomy) adds a removable chip;
  * unmatched text is still accepted as a custom skill.
  */
+let comboboxIdCounter = 0;
+
 export default function SkillCombobox({
   skills,
   onChange,
   maxSkills = 20,
   placeholder = "Add a skill (e.g., React, Node.js)",
 }: SkillComboboxProps) {
+  const [instanceId] = useState(() => `skill-combobox-${++comboboxIdCounter}`);
+  const listboxId = `${instanceId}-listbox`;
+  const getOptionId = (id: string) => `${instanceId}-option-${id}`;
+
   const [query, setQuery] = useState("");
   const [suggestions, setSuggestions] = useState<SkillSuggestion[]>([]);
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -121,14 +127,25 @@ export default function SkillCombobox({
         role="combobox"
         aria-expanded={open && suggestions.length > 0}
         aria-autocomplete="list"
+        aria-controls={listboxId}
+        aria-activedescendant={
+          activeIndex >= 0 ? getOptionId(suggestions[activeIndex]?.id) : undefined
+        }
       />
 
       {open && suggestions.length > 0 && (
-        <ul className="absolute z-10 mt-1 w-full bg-theme-card border border-theme-border rounded-lg shadow-lg max-h-56 overflow-y-auto">
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="absolute z-10 mt-1 w-full bg-theme-card border border-theme-border rounded-lg shadow-lg max-h-56 overflow-y-auto"
+        >
           {suggestions.map((suggestion, idx) => (
-            <li key={suggestion.id}>
+            <li key={suggestion.id} role="presentation">
               <button
                 type="button"
+                id={getOptionId(suggestion.id)}
+                role="option"
+                aria-selected={idx === activeIndex}
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => addSkill(suggestion.name)}
                 className={`w-full text-left px-3 py-2 text-sm flex items-center justify-between hover:bg-theme-border/40 ${

--- a/frontend/src/components/TransactionConfirmationModal.tsx
+++ b/frontend/src/components/TransactionConfirmationModal.tsx
@@ -96,11 +96,16 @@ export default function TransactionConfirmationModal({
   };
 
   return (
-    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="transaction-confirmation-title"
+    >
       <div ref={modalRef} className="w-full max-w-xl overflow-hidden rounded-2xl border border-theme-border bg-theme-bg shadow-2xl">
         <div className="flex items-center justify-between border-b border-theme-border px-5 py-4">
           <div>
-            <h2 className="text-lg font-semibold text-theme-heading">{title}</h2>
+            <h2 id="transaction-confirmation-title" className="text-lg font-semibold text-theme-heading">{title}</h2>
             <p className="text-sm text-theme-text">{description}</p>
           </div>
           <button


### PR DESCRIPTION
## Summary

Fixes four issues assigned to me:

- Closes #970 — Public profile hero avatar (likely LCP element) now uses `next/image`'s `<Image>` with `priority` instead of a raw `<img>`; removed the `@next/next/no-img-element` eslint-disable.
- Closes #969 — Star-rating radiogroup in `ReviewModal` now implements roving tabindex (only the checked/first star is a tab stop) and Arrow Left/Right moves focus + selection between stars.
- Closes #968 — `SkillCombobox` suggestions now follow the ARIA 1.2 combobox-with-listbox pattern: the listbox has `role="listbox"`, each suggestion has `role="option"`/`aria-selected`, the input has `aria-controls` pointing at the listbox, and `aria-activedescendant` tracks the arrow-key-highlighted suggestion.
- Closes #967 — `TransactionConfirmationModal`'s outer container now has `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` referencing its title heading, matching the pattern used in `ReviewModal` and `UnsavedChangesModal`.

## Test plan

- [ ] Verify the public profile avatar renders via `next/image` and is prioritized as LCP
- [ ] Verify keyboard users can navigate the star rating with Tab + Arrow Left/Right, and mouse/click behavior is unaffected
- [ ] Verify `SkillCombobox` suggestions are announced correctly by a screen reader and `aria-activedescendant` tracks the highlighted item while arrowing through results
- [ ] Verify `TransactionConfirmationModal` is announced as a dialog by assistive tech, with existing focus-trap and close-button behavior unaffected