### PR TITLE
Fix dispute reputation cache invalidation, wire up web push, add missing test coverage

### DIFF
--- a/backend/src/__tests__/dispute.test.ts
+++ b/backend/src/__tests__/dispute.test.ts
@@ -1,5 +1,6 @@
 import { DisputeService } from "../services/dispute.service";
 import { ContractService } from "../services/contract.service";
+import { ReputationCacheService } from "../services/reputation-cache.service";
 
 jest.mock("../services/contract.service", () => ({
   ContractService: {
@@ -9,6 +10,12 @@ jest.mock("../services/contract.service", () => ({
 
 jest.mock("../services/dispute-event.service", () => ({
   recordDisputeEvent: jest.fn().mockResolvedValue({ id: 1 }),
+}));
+
+jest.mock("../services/reputation-cache.service", () => ({
+  ReputationCacheService: {
+    invalidateCache: jest.fn().mockResolvedValue(undefined),
+  },
 }));
 
 // Local runtime-friendly enums for tests (use string literals to avoid TS value/type mismatch
@@ -448,6 +455,14 @@ describe("Dispute Management System", () => {
       expect(dispute.status).toBe(DisputeStatus.RESOLVED);
       expect(dispute.outcome).toBe("Resolved in favor of client");
       expect(dispute.resolvedAt).toBeDefined();
+
+      expect(ReputationCacheService.invalidateCache).toHaveBeenCalledWith(
+        mockClient.walletAddress,
+      );
+      expect(ReputationCacheService.invalidateCache).toHaveBeenCalledWith(
+        mockFreelancer.walletAddress,
+      );
+      expect(ReputationCacheService.invalidateCache).toHaveBeenCalledTimes(2);
     });
 
     it("should prevent resolving already resolved dispute", async () => {

--- a/backend/src/routes/__tests__/deadline-extension.routes.test.ts
+++ b/backend/src/routes/__tests__/deadline-extension.routes.test.ts
@@ -1,0 +1,293 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { config } from "../../config";
+import deadlineExtensionRouter from "../deadline-extension.routes";
+import { errorHandler } from "../../middleware/error";
+import { DeadlineExtensionService } from "../../services/deadline-extension.service";
+
+jest.mock("../../services/deadline-extension.service", () => ({
+  DeadlineExtensionService: {
+    requestExtension: jest.fn(),
+    approveExtension: jest.fn(),
+    rejectExtension: jest.fn(),
+    confirmExtensionTransaction: jest.fn(),
+    getJobExtensionRequests: jest.fn(),
+    getUserPendingExtensionRequests: jest.fn(),
+  },
+}));
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => ({
+    user: {
+      findUnique: jest.fn().mockResolvedValue({
+        role: "CLIENT",
+        emailVerified: true,
+        deletedAt: null,
+      }),
+    },
+  })) as any,
+}));
+
+jest.mock("../../lib/token-version", () => ({
+  getCurrentTokenVersion: jest.fn().mockResolvedValue(null),
+  invalidateTokenVersionCache: jest.fn().mockResolvedValue(undefined),
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/deadline-extensions", deadlineExtensionRouter);
+app.use(errorHandler);
+
+const USER_ID = "00000000-0000-4000-8000-000000000001";
+const JOB_ID = "00000000-0000-4000-8000-000000000100";
+const MILESTONE_ID = "00000000-0000-4000-8000-000000000200";
+const EXTENSION_ID = "00000000-0000-4000-8000-000000000300";
+
+function authHeader(userId = USER_ID) {
+  const token = jwt.sign({ userId }, config.jwtSecret, { expiresIn: "1h" });
+  return { Authorization: `Bearer ${token}` };
+}
+
+afterEach(() => jest.clearAllMocks());
+
+describe("POST /api/deadline-extensions/request", () => {
+  it("returns 401 with no auth token", async () => {
+    const res = await request(app).post("/api/deadline-extensions/request").send({
+      milestoneId: MILESTONE_ID,
+      jobId: JOB_ID,
+      newDeadline: new Date(Date.now() + 86400000).toISOString(),
+      reason: "Need more time to finish properly",
+    });
+    expect(res.status).toBe(401);
+    expect(DeadlineExtensionService.requestExtension).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the reason is too short", async () => {
+    const res = await request(app)
+      .post("/api/deadline-extensions/request")
+      .set(authHeader())
+      .send({
+        milestoneId: MILESTONE_ID,
+        jobId: JOB_ID,
+        newDeadline: new Date(Date.now() + 86400000).toISOString(),
+        reason: "short",
+      });
+
+    expect(res.status).toBe(400);
+    expect(DeadlineExtensionService.requestExtension).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when newDeadline is not a valid datetime", async () => {
+    const res = await request(app)
+      .post("/api/deadline-extensions/request")
+      .set(authHeader())
+      .send({
+        milestoneId: MILESTONE_ID,
+        jobId: JOB_ID,
+        newDeadline: "not-a-date",
+        reason: "Need more time to finish properly",
+      });
+
+    expect(res.status).toBe(400);
+    expect(DeadlineExtensionService.requestExtension).not.toHaveBeenCalled();
+  });
+
+  it("creates an extension request with valid input", async () => {
+    (DeadlineExtensionService.requestExtension as jest.Mock).mockResolvedValueOnce({
+      id: EXTENSION_ID,
+      status: "PENDING",
+    });
+
+    const res = await request(app)
+      .post("/api/deadline-extensions/request")
+      .set(authHeader())
+      .send({
+        milestoneId: MILESTONE_ID,
+        jobId: JOB_ID,
+        newDeadline: new Date(Date.now() + 86400000).toISOString(),
+        reason: "Need more time to finish properly",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ id: EXTENSION_ID, status: "PENDING" });
+    expect(DeadlineExtensionService.requestExtension).toHaveBeenCalledWith(
+      MILESTONE_ID,
+      JOB_ID,
+      USER_ID,
+      expect.any(Date),
+      "Need more time to finish properly",
+    );
+  });
+});
+
+describe("POST /api/deadline-extensions/:id/approve", () => {
+  it("returns 401 with no auth token", async () => {
+    const res = await request(app).post(
+      `/api/deadline-extensions/${EXTENSION_ID}/approve`,
+    );
+    expect(res.status).toBe(401);
+    expect(DeadlineExtensionService.approveExtension).not.toHaveBeenCalled();
+  });
+
+  it("approves an extension request when authenticated", async () => {
+    (DeadlineExtensionService.approveExtension as jest.Mock).mockResolvedValueOnce({
+      id: EXTENSION_ID,
+      status: "APPROVED_BY_CLIENT",
+    });
+
+    const res = await request(app)
+      .post(`/api/deadline-extensions/${EXTENSION_ID}/approve`)
+      .set(authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: EXTENSION_ID, status: "APPROVED_BY_CLIENT" });
+    expect(DeadlineExtensionService.approveExtension).toHaveBeenCalledWith(
+      EXTENSION_ID,
+      USER_ID,
+    );
+  });
+
+  it("propagates a 400 error from the service (e.g. self-approval)", async () => {
+    const err = new Error("You cannot approve your own extension request") as any;
+    err.statusCode = 400;
+    (DeadlineExtensionService.approveExtension as jest.Mock).mockRejectedValueOnce(err);
+
+    const res = await request(app)
+      .post(`/api/deadline-extensions/${EXTENSION_ID}/approve`)
+      .set(authHeader());
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/cannot approve your own/i);
+  });
+});
+
+describe("POST /api/deadline-extensions/:id/reject", () => {
+  it("returns 401 with no auth token", async () => {
+    const res = await request(app)
+      .post(`/api/deadline-extensions/${EXTENSION_ID}/reject`)
+      .send({ rejectionReason: "Too long a delay for this project" });
+    expect(res.status).toBe(401);
+    expect(DeadlineExtensionService.rejectExtension).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when rejectionReason is too short", async () => {
+    const res = await request(app)
+      .post(`/api/deadline-extensions/${EXTENSION_ID}/reject`)
+      .set(authHeader())
+      .send({ extensionRequestId: EXTENSION_ID, rejectionReason: "no" });
+
+    expect(res.status).toBe(400);
+    expect(DeadlineExtensionService.rejectExtension).not.toHaveBeenCalled();
+  });
+
+  it("rejects an extension request with a valid reason", async () => {
+    (DeadlineExtensionService.rejectExtension as jest.Mock).mockResolvedValueOnce({
+      id: EXTENSION_ID,
+      status: "REJECTED",
+    });
+
+    const res = await request(app)
+      .post(`/api/deadline-extensions/${EXTENSION_ID}/reject`)
+      .set(authHeader())
+      .send({
+        extensionRequestId: EXTENSION_ID,
+        rejectionReason: "Too long a delay for this project",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: EXTENSION_ID, status: "REJECTED" });
+    expect(DeadlineExtensionService.rejectExtension).toHaveBeenCalledWith(
+      EXTENSION_ID,
+      USER_ID,
+      "Too long a delay for this project",
+    );
+  });
+});
+
+describe("POST /api/deadline-extensions/:id/confirm-tx", () => {
+  it("returns 401 with no auth token", async () => {
+    const res = await request(app)
+      .post(`/api/deadline-extensions/${EXTENSION_ID}/confirm-tx`)
+      .send({ txHash: "abc123" });
+    expect(res.status).toBe(401);
+    expect(
+      DeadlineExtensionService.confirmExtensionTransaction,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when txHash is missing", async () => {
+    const res = await request(app)
+      .post(`/api/deadline-extensions/${EXTENSION_ID}/confirm-tx`)
+      .set(authHeader())
+      .send({ extensionRequestId: EXTENSION_ID });
+
+    expect(res.status).toBe(400);
+    expect(
+      DeadlineExtensionService.confirmExtensionTransaction,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("confirms the on-chain transaction", async () => {
+    (
+      DeadlineExtensionService.confirmExtensionTransaction as jest.Mock
+    ).mockResolvedValueOnce({ id: EXTENSION_ID, onChainTxHash: "abc123" });
+
+    const res = await request(app)
+      .post(`/api/deadline-extensions/${EXTENSION_ID}/confirm-tx`)
+      .set(authHeader())
+      .send({ extensionRequestId: EXTENSION_ID, txHash: "abc123" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: EXTENSION_ID, onChainTxHash: "abc123" });
+    expect(
+      DeadlineExtensionService.confirmExtensionTransaction,
+    ).toHaveBeenCalledWith(EXTENSION_ID, "abc123");
+  });
+});
+
+describe("GET /api/deadline-extensions/job/:jobId", () => {
+  it("returns 401 with no auth token", async () => {
+    const res = await request(app).get(`/api/deadline-extensions/job/${JOB_ID}`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns extension requests for the job", async () => {
+    (
+      DeadlineExtensionService.getJobExtensionRequests as jest.Mock
+    ).mockResolvedValueOnce([{ id: EXTENSION_ID }]);
+
+    const res = await request(app)
+      .get(`/api/deadline-extensions/job/${JOB_ID}`)
+      .set(authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: EXTENSION_ID }]);
+    expect(
+      DeadlineExtensionService.getJobExtensionRequests,
+    ).toHaveBeenCalledWith(JOB_ID);
+  });
+});
+
+describe("GET /api/deadline-extensions/pending", () => {
+  it("returns 401 with no auth token", async () => {
+    const res = await request(app).get("/api/deadline-extensions/pending");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns pending extension requests for the authenticated user", async () => {
+    (
+      DeadlineExtensionService.getUserPendingExtensionRequests as jest.Mock
+    ).mockResolvedValueOnce([{ id: EXTENSION_ID, status: "PENDING" }]);
+
+    const res = await request(app)
+      .get("/api/deadline-extensions/pending")
+      .set(authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: EXTENSION_ID, status: "PENDING" }]);
+    expect(
+      DeadlineExtensionService.getUserPendingExtensionRequests,
+    ).toHaveBeenCalledWith(USER_ID);
+  });
+});

--- a/backend/src/routes/__tests__/milestone.routes.test.ts
+++ b/backend/src/routes/__tests__/milestone.routes.test.ts
@@ -1,0 +1,482 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { config } from "../../config";
+import milestoneRouter from "../milestone.routes";
+import { errorHandler } from "../../middleware/error";
+
+// ─── Prisma & service mocks ────────────────────────────────────────────────────
+jest.mock("@prisma/client", () => {
+  const mockPrisma = {
+    job: {
+      findUnique: jest.fn(),
+    },
+    milestone: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    attachment: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  return {
+    PrismaClient: jest.fn(() => mockPrisma) as any,
+    NotificationType: {
+      MILESTONE_SUBMITTED: "MILESTONE_SUBMITTED",
+      MILESTONE_APPROVED: "MILESTONE_APPROVED",
+    } as any,
+  };
+});
+
+jest.mock("../../services/notification.service", () => ({
+  NotificationService: {
+    sendNotification: jest.fn().mockResolvedValue({ id: "mock-notif-id" }),
+  },
+}));
+
+jest.mock("../../services/contract.service", () => ({
+  ContractService: {
+    buildSubmitMilestoneTx: jest.fn().mockResolvedValue("SUBMIT_XDR"),
+    buildApproveMilestoneTx: jest.fn().mockResolvedValue("APPROVE_XDR"),
+  },
+}));
+
+jest.mock("../../socket", () => ({
+  getIo: jest.fn().mockReturnValue({
+    to: jest.fn().mockReturnValue({ emit: jest.fn() }),
+  }),
+}));
+
+jest.mock("../../lib/token-version", () => ({
+  getCurrentTokenVersion: jest.fn().mockResolvedValue(null),
+  invalidateTokenVersionCache: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { PrismaClient } from "@prisma/client";
+import { NotificationService } from "../../services/notification.service";
+import { ContractService } from "../../services/contract.service";
+
+const prismaMock = new PrismaClient() as any;
+const jobMock = prismaMock.job;
+const milestoneMock = prismaMock.milestone;
+const userMock = prismaMock.user;
+
+// ─── App setup ────────────────────────────────────────────────────────────────
+const app = express();
+app.use(express.json());
+app.use("/api/milestones", milestoneRouter);
+app.use(errorHandler);
+
+// ─── Stable test UUIDs ────────────────────────────────────────────────────────
+const JOB_ID = "00000000-0000-4000-8000-000000000100";
+const MILESTONE_ID = "00000000-0000-4000-8000-000000000200";
+const CLIENT_ID = "00000000-0000-4000-8000-000000000001";
+const FREELANCER_ID = "00000000-0000-4000-8000-000000000002";
+const OTHER_USER_ID = "00000000-0000-4000-8000-000000000003";
+
+function authHeader(userId: string, role: "CLIENT" | "FREELANCER" = "CLIENT") {
+  userMock.findUnique.mockResolvedValueOnce({
+    role,
+    emailVerified: true,
+    deletedAt: null,
+  });
+  const token = jwt.sign({ userId }, config.jwtSecret, { expiresIn: "1h" });
+  return { Authorization: `Bearer ${token}` };
+}
+
+afterEach(() => jest.clearAllMocks());
+
+describe("PATCH /api/milestones/:id/status", () => {
+  it("returns 401 with no auth token", async () => {
+    const res = await request(app).patch(`/api/milestones/${MILESTONE_ID}/status`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when milestone does not exist", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce(null);
+
+    const res = await request(app)
+      .patch(`/api/milestones/${MILESTONE_ID}/status`)
+      .set(authHeader(CLIENT_ID))
+      .send({ status: "APPROVED" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Milestone not found." });
+  });
+
+  it("returns 403 when caller is neither client nor freelancer on the job", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "SUBMITTED",
+      job: { id: JOB_ID, clientId: CLIENT_ID, freelancerId: FREELANCER_ID },
+    });
+
+    const res = await request(app)
+      .patch(`/api/milestones/${MILESTONE_ID}/status`)
+      .set(authHeader(OTHER_USER_ID))
+      .send({ status: "APPROVED" });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Not authorized to update this milestone." });
+    expect(milestoneMock.update).not.toHaveBeenCalled();
+  });
+
+  it("freelancer can transition PENDING -> IN_PROGRESS", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "PENDING",
+      title: "Design mockups",
+      job: { id: JOB_ID, clientId: CLIENT_ID, freelancerId: FREELANCER_ID },
+    });
+    milestoneMock.update.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      jobId: JOB_ID,
+      status: "IN_PROGRESS",
+    });
+
+    const res = await request(app)
+      .patch(`/api/milestones/${MILESTONE_ID}/status`)
+      .set(authHeader(FREELANCER_ID, "FREELANCER"))
+      .send({ status: "IN_PROGRESS" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("IN_PROGRESS");
+    expect(milestoneMock.update).toHaveBeenCalledWith({
+      where: { id: MILESTONE_ID },
+      data: { status: "IN_PROGRESS" },
+    });
+    expect(NotificationService.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("freelancer can transition IN_PROGRESS -> SUBMITTED and notifies the client", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "IN_PROGRESS",
+      title: "Design mockups",
+      job: { id: JOB_ID, clientId: CLIENT_ID, freelancerId: FREELANCER_ID },
+    });
+    milestoneMock.update.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      jobId: JOB_ID,
+      status: "SUBMITTED",
+    });
+
+    const res = await request(app)
+      .patch(`/api/milestones/${MILESTONE_ID}/status`)
+      .set(authHeader(FREELANCER_ID, "FREELANCER"))
+      .send({ status: "SUBMITTED" });
+
+    expect(res.status).toBe(200);
+    expect(NotificationService.sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: CLIENT_ID,
+        type: "MILESTONE_SUBMITTED",
+      }),
+    );
+  });
+
+  it("rejects an invalid transition for the freelancer role", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "SUBMITTED",
+      job: { id: JOB_ID, clientId: CLIENT_ID, freelancerId: FREELANCER_ID },
+    });
+
+    const res = await request(app)
+      .patch(`/api/milestones/${MILESTONE_ID}/status`)
+      .set(authHeader(FREELANCER_ID, "FREELANCER"))
+      .send({ status: "APPROVED" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/Invalid status transition/);
+    expect(milestoneMock.update).not.toHaveBeenCalled();
+  });
+
+  it("client can transition SUBMITTED -> APPROVED", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "SUBMITTED",
+      job: { id: JOB_ID, clientId: CLIENT_ID, freelancerId: FREELANCER_ID },
+    });
+    milestoneMock.update.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      jobId: JOB_ID,
+      status: "APPROVED",
+    });
+
+    const res = await request(app)
+      .patch(`/api/milestones/${MILESTONE_ID}/status`)
+      .set(authHeader(CLIENT_ID, "CLIENT"))
+      .send({ status: "APPROVED" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("APPROVED");
+  });
+
+  it("client can transition SUBMITTED -> REJECTED", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "SUBMITTED",
+      job: { id: JOB_ID, clientId: CLIENT_ID, freelancerId: FREELANCER_ID },
+    });
+    milestoneMock.update.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      jobId: JOB_ID,
+      status: "REJECTED",
+    });
+
+    const res = await request(app)
+      .patch(`/api/milestones/${MILESTONE_ID}/status`)
+      .set(authHeader(CLIENT_ID, "CLIENT"))
+      .send({ status: "REJECTED" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("REJECTED");
+  });
+
+  it("rejects an invalid transition for the client role", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "PENDING",
+      job: { id: JOB_ID, clientId: CLIENT_ID, freelancerId: FREELANCER_ID },
+    });
+
+    const res = await request(app)
+      .patch(`/api/milestones/${MILESTONE_ID}/status`)
+      .set(authHeader(CLIENT_ID, "CLIENT"))
+      .send({ status: "APPROVED" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/Invalid status transition/);
+    expect(milestoneMock.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("PUT /api/milestones/milestones/:id/submit", () => {
+  it("returns 401 with no auth token", async () => {
+    const res = await request(app).put(
+      `/api/milestones/milestones/${MILESTONE_ID}/submit`,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the milestone has no on-chain contract data", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "IN_PROGRESS",
+      job: { contractJobId: null, freelancerId: FREELANCER_ID, freelancer: {} },
+      onChainIndex: null,
+    });
+
+    const res = await request(app)
+      .put(`/api/milestones/milestones/${MILESTONE_ID}/submit`)
+      .set(authHeader(FREELANCER_ID, "FREELANCER"));
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "On-chain milestone not found." });
+  });
+
+  it("returns 403 when caller is not the assigned freelancer", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "IN_PROGRESS",
+      onChainIndex: 0,
+      job: {
+        contractJobId: "contract-1",
+        freelancerId: FREELANCER_ID,
+        freelancer: { walletAddress: "GFREELANCER" },
+      },
+    });
+
+    const res = await request(app)
+      .put(`/api/milestones/milestones/${MILESTONE_ID}/submit`)
+      .set(authHeader(OTHER_USER_ID));
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: "Only the assigned freelancer can submit milestones.",
+    });
+    expect(ContractService.buildSubmitMilestoneTx).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when milestone is not IN_PROGRESS", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "PENDING",
+      onChainIndex: 0,
+      job: {
+        contractJobId: "contract-1",
+        freelancerId: FREELANCER_ID,
+        freelancer: { walletAddress: "GFREELANCER" },
+      },
+    });
+
+    const res = await request(app)
+      .put(`/api/milestones/milestones/${MILESTONE_ID}/submit`)
+      .set(authHeader(FREELANCER_ID, "FREELANCER"));
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Milestone must be in progress to submit." });
+  });
+
+  it("returns the submit XDR for the assigned freelancer", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "IN_PROGRESS",
+      onChainIndex: 0,
+      job: {
+        contractJobId: "contract-1",
+        freelancerId: FREELANCER_ID,
+        freelancer: { walletAddress: "GFREELANCER" },
+      },
+    });
+
+    const res = await request(app)
+      .put(`/api/milestones/milestones/${MILESTONE_ID}/submit`)
+      .set(authHeader(FREELANCER_ID, "FREELANCER"));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ xdr: "SUBMIT_XDR" });
+    expect(ContractService.buildSubmitMilestoneTx).toHaveBeenCalledWith(
+      "GFREELANCER",
+      "contract-1",
+      0,
+    );
+  });
+});
+
+describe("PUT /api/milestones/milestones/:id/approve", () => {
+  it("returns 401 with no auth token", async () => {
+    const res = await request(app).put(
+      `/api/milestones/milestones/${MILESTONE_ID}/approve`,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller is not the client", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "SUBMITTED",
+      onChainIndex: 0,
+      job: {
+        contractJobId: "contract-1",
+        clientId: CLIENT_ID,
+        client: { walletAddress: "GCLIENT" },
+      },
+    });
+
+    const res = await request(app)
+      .put(`/api/milestones/milestones/${MILESTONE_ID}/approve`)
+      .set(authHeader(FREELANCER_ID, "FREELANCER"));
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: "Only the client can approve milestones.",
+    });
+    expect(ContractService.buildApproveMilestoneTx).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when milestone is not SUBMITTED", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "IN_PROGRESS",
+      onChainIndex: 0,
+      job: {
+        contractJobId: "contract-1",
+        clientId: CLIENT_ID,
+        client: { walletAddress: "GCLIENT" },
+      },
+    });
+
+    const res = await request(app)
+      .put(`/api/milestones/milestones/${MILESTONE_ID}/approve`)
+      .set(authHeader(CLIENT_ID, "CLIENT"));
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Milestone must be submitted to approve." });
+  });
+
+  it("returns the approve XDR for the client", async () => {
+    milestoneMock.findUnique.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      status: "SUBMITTED",
+      onChainIndex: 0,
+      job: {
+        contractJobId: "contract-1",
+        clientId: CLIENT_ID,
+        client: { walletAddress: "GCLIENT" },
+      },
+    });
+
+    const res = await request(app)
+      .put(`/api/milestones/milestones/${MILESTONE_ID}/approve`)
+      .set(authHeader(CLIENT_ID, "CLIENT"));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ xdr: "APPROVE_XDR" });
+    expect(ContractService.buildApproveMilestoneTx).toHaveBeenCalledWith(
+      "GCLIENT",
+      "contract-1",
+      0,
+    );
+  });
+});
+
+describe("POST /api/milestones (create)", () => {
+  it("returns 403 when caller is not the job's client", async () => {
+    jobMock.findUnique.mockResolvedValueOnce({ id: JOB_ID, clientId: CLIENT_ID });
+
+    const res = await request(app)
+      .post("/api/milestones")
+      .set(authHeader(OTHER_USER_ID))
+      .send({
+        jobId: JOB_ID,
+        title: "Initial design",
+        description: "Deliver the initial design mockups for review.",
+        amount: 100,
+        dueDate: new Date(Date.now() + 86400000).toISOString(),
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: "Not authorized to create milestones for this job.",
+    });
+    expect(milestoneMock.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a milestone for the job's client", async () => {
+    jobMock.findUnique.mockResolvedValueOnce({ id: JOB_ID, clientId: CLIENT_ID });
+    milestoneMock.count.mockResolvedValueOnce(0);
+    milestoneMock.create.mockResolvedValueOnce({
+      id: MILESTONE_ID,
+      jobId: JOB_ID,
+      title: "Initial design",
+      order: 1,
+    });
+
+    const res = await request(app)
+      .post("/api/milestones")
+      .set(authHeader(CLIENT_ID, "CLIENT"))
+      .send({
+        jobId: JOB_ID,
+        title: "Initial design",
+        description: "Deliver the initial design mockups for review.",
+        amount: 100,
+        dueDate: new Date(Date.now() + 86400000).toISOString(),
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe(MILESTONE_ID);
+  });
+});

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -555,7 +555,13 @@ router.patch(
         typeof overrideDisputeSchema
       >;
 
-      const dispute = await prisma.dispute.findUnique({ where: { id } });
+      const dispute = await prisma.dispute.findUnique({
+        where: { id },
+        include: {
+          client: { select: { walletAddress: true } },
+          freelancer: { select: { walletAddress: true } },
+        },
+      });
       if (!dispute) {
         res.status(404).json({ error: "Dispute not found" });
         return;
@@ -574,6 +580,17 @@ router.patch(
         outcome,
         status,
       });
+
+      if (dispute.client?.walletAddress) {
+        await ReputationCacheService.invalidateCache(
+          dispute.client.walletAddress,
+        );
+      }
+      if (dispute.freelancer?.walletAddress) {
+        await ReputationCacheService.invalidateCache(
+          dispute.freelancer.walletAddress,
+        );
+      }
 
       res.json({
         message: "Dispute outcome overridden successfully",
@@ -942,7 +959,13 @@ router.patch(
       const id = req.params.id as string;
       const { outcome, status } = overrideDisputeSchema.parse(req.body);
 
-      const dispute = await prisma.dispute.findUnique({ where: { id } });
+      const dispute = await prisma.dispute.findUnique({
+        where: { id },
+        include: {
+          client: { select: { walletAddress: true } },
+          freelancer: { select: { walletAddress: true } },
+        },
+      });
       if (!dispute) {
         res.status(404).json({ error: "Dispute not found" });
         return;
@@ -961,6 +984,17 @@ router.patch(
         outcome,
         status,
       });
+
+      if (dispute.client?.walletAddress) {
+        await ReputationCacheService.invalidateCache(
+          dispute.client.walletAddress,
+        );
+      }
+      if (dispute.freelancer?.walletAddress) {
+        await ReputationCacheService.invalidateCache(
+          dispute.freelancer.walletAddress,
+        );
+      }
 
       res.json({
         message: "Dispute outcome overridden successfully",

--- a/backend/src/services/__tests__/deadline-extension.service.test.ts
+++ b/backend/src/services/__tests__/deadline-extension.service.test.ts
@@ -1,0 +1,410 @@
+import { DeadlineExtensionService } from "../deadline-extension.service";
+import { ContractService } from "../contract.service";
+
+jest.mock("../contract.service", () => ({
+  ContractService: {
+    buildExtendDeadlineTx: jest.fn(),
+  },
+}));
+
+jest.mock("../notification.service", () => ({
+  NotificationService: {
+    sendNotification: jest.fn().mockResolvedValue({ id: "mock-notif-id" }),
+  },
+}));
+
+const DeadlineExtensionStatus = {
+  PENDING: "PENDING",
+  APPROVED_BY_CLIENT: "APPROVED_BY_CLIENT",
+  APPROVED_BY_FREELANCER: "APPROVED_BY_FREELANCER",
+  APPROVED_BY_BOTH: "APPROVED_BY_BOTH",
+  REJECTED: "REJECTED",
+  EXPIRED: "EXPIRED",
+} as const;
+
+jest.mock("@prisma/client", () => {
+  const mockPrisma: any = {
+    milestone: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    deadlineExtensionRequest: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  return {
+    PrismaClient: jest.fn(() => mockPrisma) as any,
+    DeadlineExtensionStatus: {
+      PENDING: "PENDING",
+      APPROVED_BY_CLIENT: "APPROVED_BY_CLIENT",
+      APPROVED_BY_FREELANCER: "APPROVED_BY_FREELANCER",
+      APPROVED_BY_BOTH: "APPROVED_BY_BOTH",
+      REJECTED: "REJECTED",
+      EXPIRED: "EXPIRED",
+    } as any,
+    JobStatus: {
+      OPEN: "OPEN",
+      IN_PROGRESS: "IN_PROGRESS",
+      COMPLETED: "COMPLETED",
+    } as any,
+  };
+});
+
+import { PrismaClient } from "@prisma/client";
+import { NotificationService } from "../notification.service";
+const prismaMock = new PrismaClient() as any;
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+const clientId = "00000000-0000-4000-8000-000000000001";
+const freelancerId = "00000000-0000-4000-8000-000000000002";
+const jobId = "00000000-0000-4000-8000-000000000100";
+const milestoneId = "00000000-0000-4000-8000-000000000200";
+const extensionRequestId = "00000000-0000-4000-8000-000000000300";
+const futureDeadline = new Date(Date.now() + 7 * 86400000);
+
+const mockJob = {
+  id: jobId,
+  clientId,
+  freelancerId,
+  contractJobId: "contract-1",
+  client: { id: clientId, walletAddress: "GCLIENT123" },
+  freelancer: { id: freelancerId, walletAddress: "GFREELANCER123" },
+};
+
+const mockMilestone = {
+  id: milestoneId,
+  jobId,
+  title: "Design mockups",
+  onChainIndex: 0,
+  job: mockJob,
+};
+
+const mockExtensionRequest = {
+  id: extensionRequestId,
+  milestoneId,
+  jobId,
+  requestedById: clientId,
+  newDeadline: futureDeadline,
+  reason: "Need more time to finish the deliverables properly",
+  status: DeadlineExtensionStatus.PENDING,
+  clientApprovedAt: null,
+  freelancerApprovedAt: null,
+  rejectedBy: null,
+  rejectionReason: null,
+  onChainTxHash: null,
+  milestone: mockMilestone,
+  job: mockJob,
+  requestedBy: { id: clientId, username: "client" },
+};
+
+afterEach(() => jest.resetAllMocks());
+
+describe("DeadlineExtensionService", () => {
+  describe("requestExtension", () => {
+    it("creates a request and notifies the other party", async () => {
+      prismaMock.milestone.findUnique.mockResolvedValueOnce(mockMilestone);
+      prismaMock.deadlineExtensionRequest.findFirst.mockResolvedValueOnce(null);
+      prismaMock.deadlineExtensionRequest.create.mockResolvedValueOnce(
+        mockExtensionRequest,
+      );
+
+      const result = await DeadlineExtensionService.requestExtension(
+        milestoneId,
+        jobId,
+        clientId,
+        futureDeadline,
+        "Need more time to finish the deliverables properly",
+      );
+
+      expect(result).toEqual(mockExtensionRequest);
+      expect(NotificationService.sendNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: freelancerId, skipBatching: true }),
+      );
+    });
+
+    it("rejects a request for a milestone that does not belong to the job", async () => {
+      prismaMock.milestone.findUnique.mockResolvedValueOnce({
+        ...mockMilestone,
+        jobId: "different-job",
+      });
+
+      await expect(
+        DeadlineExtensionService.requestExtension(
+          milestoneId,
+          jobId,
+          clientId,
+          futureDeadline,
+          "Need more time to finish the deliverables properly",
+        ),
+      ).rejects.toThrow("Milestone does not belong to this job");
+    });
+
+    it("rejects a request from a non-participant", async () => {
+      prismaMock.milestone.findUnique.mockResolvedValueOnce(mockMilestone);
+
+      await expect(
+        DeadlineExtensionService.requestExtension(
+          milestoneId,
+          jobId,
+          "00000000-0000-4000-8000-000000009999",
+          futureDeadline,
+          "Need more time to finish the deliverables properly",
+        ),
+      ).rejects.toThrow("Only job participants can request deadline extensions");
+    });
+
+    it("rejects a new deadline that is not in the future", async () => {
+      prismaMock.milestone.findUnique.mockResolvedValueOnce(mockMilestone);
+
+      await expect(
+        DeadlineExtensionService.requestExtension(
+          milestoneId,
+          jobId,
+          clientId,
+          new Date(Date.now() - 1000),
+          "Need more time to finish the deliverables properly",
+        ),
+      ).rejects.toThrow("New deadline must be in the future");
+    });
+
+    it("rejects when a pending extension request already exists", async () => {
+      prismaMock.milestone.findUnique.mockResolvedValueOnce(mockMilestone);
+      prismaMock.deadlineExtensionRequest.findFirst.mockResolvedValueOnce(
+        mockExtensionRequest,
+      );
+
+      await expect(
+        DeadlineExtensionService.requestExtension(
+          milestoneId,
+          jobId,
+          clientId,
+          futureDeadline,
+          "Need more time to finish the deliverables properly",
+        ),
+      ).rejects.toThrow(
+        "A pending extension request already exists for this milestone",
+      );
+    });
+  });
+
+  describe("approveExtension", () => {
+    it("rejects self-approval by the original requester", async () => {
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce(
+        mockExtensionRequest,
+      );
+
+      await expect(
+        DeadlineExtensionService.approveExtension(extensionRequestId, clientId),
+      ).rejects.toThrow("You cannot approve your own extension request");
+      expect(prismaMock.deadlineExtensionRequest.update).not.toHaveBeenCalled();
+    });
+
+    it("records client approval when freelancer requested (order: freelancer requests, client approves)", async () => {
+      const request = { ...mockExtensionRequest, requestedById: freelancerId };
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce(request);
+      prismaMock.deadlineExtensionRequest.update.mockResolvedValueOnce({
+        ...request,
+        status: DeadlineExtensionStatus.APPROVED_BY_CLIENT,
+        clientApprovedAt: new Date(),
+      });
+
+      const result = await DeadlineExtensionService.approveExtension(
+        extensionRequestId,
+        clientId,
+      );
+
+      expect(result.status).toBe(DeadlineExtensionStatus.APPROVED_BY_CLIENT);
+      expect(prismaMock.deadlineExtensionRequest.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: extensionRequestId },
+          data: expect.objectContaining({
+            status: DeadlineExtensionStatus.APPROVED_BY_CLIENT,
+          }),
+        }),
+      );
+      expect(ContractService.buildExtendDeadlineTx).not.toHaveBeenCalled();
+    });
+
+    it("records freelancer approval when client requested (order: client requests, freelancer approves)", async () => {
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce(
+        mockExtensionRequest,
+      );
+      prismaMock.deadlineExtensionRequest.update.mockResolvedValueOnce({
+        ...mockExtensionRequest,
+        status: DeadlineExtensionStatus.APPROVED_BY_FREELANCER,
+        freelancerApprovedAt: new Date(),
+      });
+
+      const result = await DeadlineExtensionService.approveExtension(
+        extensionRequestId,
+        freelancerId,
+      );
+
+      expect(result.status).toBe(DeadlineExtensionStatus.APPROVED_BY_FREELANCER);
+      expect(ContractService.buildExtendDeadlineTx).not.toHaveBeenCalled();
+    });
+
+    it("triggers on-chain execution once both parties have approved (client already approved, freelancer approves)", async () => {
+      const partiallyApproved = {
+        ...mockExtensionRequest,
+        clientApprovedAt: new Date(),
+      };
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce(
+        partiallyApproved,
+      );
+      const fullyApproved = {
+        ...partiallyApproved,
+        status: DeadlineExtensionStatus.APPROVED_BY_BOTH,
+        freelancerApprovedAt: new Date(),
+      };
+      prismaMock.deadlineExtensionRequest.update
+        .mockResolvedValueOnce(fullyApproved) // status update
+        .mockResolvedValueOnce(fullyApproved); // executeExtensionOnChain's internal update
+      (ContractService.buildExtendDeadlineTx as jest.Mock).mockResolvedValueOnce(
+        "EXTEND_XDR",
+      );
+
+      const result = await DeadlineExtensionService.approveExtension(
+        extensionRequestId,
+        freelancerId,
+      );
+
+      expect(result.status).toBe(DeadlineExtensionStatus.APPROVED_BY_BOTH);
+      expect(ContractService.buildExtendDeadlineTx).toHaveBeenCalledWith(
+        mockJob.client.walletAddress,
+        mockJob.contractJobId,
+        mockMilestone.onChainIndex,
+        Math.floor(fullyApproved.newDeadline.getTime() / 1000),
+      );
+    });
+
+    it("triggers on-chain execution once both parties have approved (freelancer already approved, client approves)", async () => {
+      const partiallyApproved = {
+        ...mockExtensionRequest,
+        requestedById: freelancerId,
+        freelancerApprovedAt: new Date(),
+      };
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce(
+        partiallyApproved,
+      );
+      const fullyApproved = {
+        ...partiallyApproved,
+        status: DeadlineExtensionStatus.APPROVED_BY_BOTH,
+        clientApprovedAt: new Date(),
+      };
+      prismaMock.deadlineExtensionRequest.update
+        .mockResolvedValueOnce(fullyApproved)
+        .mockResolvedValueOnce(fullyApproved);
+      (ContractService.buildExtendDeadlineTx as jest.Mock).mockResolvedValueOnce(
+        "EXTEND_XDR",
+      );
+
+      const result = await DeadlineExtensionService.approveExtension(
+        extensionRequestId,
+        clientId,
+      );
+
+      expect(result.status).toBe(DeadlineExtensionStatus.APPROVED_BY_BOTH);
+      expect(ContractService.buildExtendDeadlineTx).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects approving a request that is not pending", async () => {
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce({
+        ...mockExtensionRequest,
+        status: DeadlineExtensionStatus.REJECTED,
+      });
+
+      await expect(
+        DeadlineExtensionService.approveExtension(extensionRequestId, freelancerId),
+      ).rejects.toThrow(
+        "Cannot approve extension request with status: REJECTED",
+      );
+    });
+
+    it("rejects approval from a non-participant", async () => {
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce(
+        mockExtensionRequest,
+      );
+
+      await expect(
+        DeadlineExtensionService.approveExtension(
+          extensionRequestId,
+          "00000000-0000-4000-8000-000000009999",
+        ),
+      ).rejects.toThrow("Only job participants can approve extension requests");
+    });
+  });
+
+  describe("rejectExtension", () => {
+    it("rejects a pending request and notifies the requester", async () => {
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce(
+        mockExtensionRequest,
+      );
+      prismaMock.deadlineExtensionRequest.update.mockResolvedValueOnce({
+        ...mockExtensionRequest,
+        status: DeadlineExtensionStatus.REJECTED,
+        rejectedBy: freelancerId,
+        rejectionReason: "Too long",
+      });
+
+      const result = await DeadlineExtensionService.rejectExtension(
+        extensionRequestId,
+        freelancerId,
+        "Too long",
+      );
+
+      expect(result.status).toBe(DeadlineExtensionStatus.REJECTED);
+      expect(NotificationService.sendNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: mockExtensionRequest.requestedById }),
+      );
+    });
+
+    it("rejects rejecting a request that is not pending", async () => {
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce({
+        ...mockExtensionRequest,
+        status: DeadlineExtensionStatus.APPROVED_BY_BOTH,
+      });
+
+      await expect(
+        DeadlineExtensionService.rejectExtension(
+          extensionRequestId,
+          freelancerId,
+          "Too long",
+        ),
+      ).rejects.toThrow(
+        "Cannot reject extension request with status: APPROVED_BY_BOTH",
+      );
+    });
+
+    it("rejects rejection from a non-participant", async () => {
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce(
+        mockExtensionRequest,
+      );
+
+      await expect(
+        DeadlineExtensionService.rejectExtension(
+          extensionRequestId,
+          "00000000-0000-4000-8000-000000009999",
+          "Too long",
+        ),
+      ).rejects.toThrow("Only job participants can reject extension requests");
+    });
+
+    it("throws when the extension request does not exist", async () => {
+      prismaMock.deadlineExtensionRequest.findUnique.mockResolvedValueOnce(null);
+
+      await expect(
+        DeadlineExtensionService.rejectExtension(
+          extensionRequestId,
+          freelancerId,
+          "Too long",
+        ),
+      ).rejects.toThrow("Extension request not found");
+    });
+  });
+});

--- a/backend/src/services/__tests__/notification-push.test.ts
+++ b/backend/src/services/__tests__/notification-push.test.ts
@@ -1,0 +1,150 @@
+import { NotificationService } from "../notification.service";
+import webpush from "web-push";
+import { config } from "../../config";
+
+jest.mock("web-push", () => ({
+  __esModule: true,
+  default: {
+    setVapidDetails: jest.fn(),
+    sendNotification: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock("../../config", () => ({
+  config: {
+    vapidPublicKey: "",
+    vapidPrivateKey: "",
+    vapidSubject: "mailto:admin@stellarmarket.io",
+  },
+}));
+
+jest.mock("../email.service", () => ({
+  EmailService: { send: jest.fn().mockResolvedValue(undefined) },
+}));
+
+jest.mock("../../socket", () => ({
+  getIo: jest.fn().mockReturnValue({
+    to: jest.fn().mockReturnValue({ emit: jest.fn() }),
+  }),
+}));
+
+jest.mock("../../lib/notification-queue", () => ({
+  notificationQueue: { add: jest.fn().mockResolvedValue(undefined) },
+  getNotificationPriority: jest.fn().mockReturnValue(3),
+}));
+
+const mockPushSubscriptionFindMany = jest.fn();
+const mockNotificationCreate = jest.fn();
+
+jest.mock("@prisma/client", () => {
+  const mockPrisma: any = {
+    notification: {
+      create: (...args: any[]) => mockNotificationCreate(...args),
+    },
+    pushSubscription: {
+      findMany: (...args: any[]) => mockPushSubscriptionFindMany(...args),
+      delete: jest.fn(),
+    },
+    $transaction: jest.fn(async (cb: any) => cb(mockPrisma)),
+  };
+  return {
+    PrismaClient: jest.fn(() => mockPrisma),
+    NotificationType: {
+      MILESTONE_APPROVED: "MILESTONE_APPROVED",
+      NEW_MESSAGE: "NEW_MESSAGE",
+    },
+  };
+});
+
+const webpushMocked = webpush as unknown as {
+  setVapidDetails: jest.Mock;
+  sendNotification: jest.Mock;
+};
+
+describe("NotificationService push dispatch", () => {
+  const userId = "user-1";
+  const subscription = {
+    id: "sub-1",
+    userId,
+    endpoint: "https://push.example.com/abc",
+    p256dh: "p256dh-key",
+    auth: "auth-key",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (config as any).vapidPublicKey = "";
+    (config as any).vapidPrivateKey = "";
+    mockNotificationCreate.mockResolvedValue({
+      id: "notif-1",
+      userId,
+      type: "MILESTONE_APPROVED",
+      title: "Milestone Approved",
+      message: "Your milestone was approved",
+      metadata: {},
+    });
+    mockPushSubscriptionFindMany.mockResolvedValue([subscription]);
+  });
+
+  it("sends a push notification for a qualifying type when VAPID is configured", async () => {
+    (config as any).vapidPublicKey = "public-key";
+    (config as any).vapidPrivateKey = "private-key";
+
+    await NotificationService.sendNotification({
+      userId,
+      type: "MILESTONE_APPROVED" as any,
+      title: "Milestone Approved",
+      message: "Your milestone was approved",
+      skipBatching: true,
+    });
+
+    expect(mockPushSubscriptionFindMany).toHaveBeenCalledWith({
+      where: { userId },
+    });
+    expect(webpushMocked.sendNotification).toHaveBeenCalledTimes(1);
+    expect(webpushMocked.sendNotification).toHaveBeenCalledWith(
+      {
+        endpoint: subscription.endpoint,
+        keys: { p256dh: subscription.p256dh, auth: subscription.auth },
+      },
+      expect.stringContaining("Milestone Approved"),
+    );
+  });
+
+  it("does not push for notification types outside the push-enabled list", async () => {
+    (config as any).vapidPublicKey = "public-key";
+    (config as any).vapidPrivateKey = "private-key";
+    mockNotificationCreate.mockResolvedValueOnce({
+      id: "notif-2",
+      userId,
+      type: "NEW_MESSAGE",
+      title: "New message",
+      message: "hi",
+      metadata: {},
+    });
+
+    await NotificationService.sendNotification({
+      userId,
+      type: "SOME_OTHER_TYPE" as any,
+      title: "Other",
+      message: "Not push-enabled",
+      skipBatching: true,
+    });
+
+    expect(webpushMocked.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips push gracefully when VAPID keys are not configured", async () => {
+    const result = await NotificationService.sendNotification({
+      userId,
+      type: "MILESTONE_APPROVED" as any,
+      title: "Milestone Approved",
+      message: "Your milestone was approved",
+      skipBatching: true,
+    });
+
+    expect(result).toBeTruthy();
+    expect(webpushMocked.sendNotification).not.toHaveBeenCalled();
+    expect(mockPushSubscriptionFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/dispute.service.ts
+++ b/backend/src/services/dispute.service.ts
@@ -14,6 +14,7 @@ import { NotificationService } from "./notification.service";
 import { ContractService } from "./contract.service";
 import { logger } from "../lib/logger";
 import { recordDisputeEvent } from "./dispute-event.service";
+import { ReputationCacheService } from "./reputation-cache.service";
 
 const prisma = new PrismaClient();
 
@@ -764,6 +765,18 @@ export class DisputeService {
     await recordDisputeEvent(disputeId, DisputeEventType.VERDICT_REACHED, {
       outcome,
     });
+
+    // Invalidate reputation cache for both parties (dispute outcome affects reputation)
+    if (updatedDispute.client?.walletAddress) {
+      await ReputationCacheService.invalidateCache(
+        updatedDispute.client.walletAddress,
+      );
+    }
+    if (updatedDispute.freelancer?.walletAddress) {
+      await ReputationCacheService.invalidateCache(
+        updatedDispute.freelancer.walletAddress,
+      );
+    }
 
     return updatedDispute;
   }

--- a/backend/src/services/notification.service.ts
+++ b/backend/src/services/notification.service.ts
@@ -31,6 +31,16 @@ export class NotificationService {
   private static batches = new Map<string, NotificationBatch>();
   private static readonly BATCH_WINDOW_MS = 5000; // 5 seconds
   private static readonly MAX_BATCH_SIZE = 10;
+  private static readonly PUSH_ENABLED_TYPES: NotificationType[] = [
+    "JOB_APPLIED",
+    "APPLICATION_ACCEPTED",
+    "APPLICATION_REJECTED",
+    "MILESTONE_SUBMITTED",
+    "MILESTONE_APPROVED",
+    "DISPUTE_RAISED",
+    "DISPUTE_RESOLVED",
+    "NEW_MESSAGE",
+  ];
 
   /**
    * Creates a notification in the database and sends it in real-time via Socket.IO.
@@ -127,6 +137,17 @@ export class NotificationService {
     );
 
     logger.info({ userId, type, title, notificationId: notification.id }, "Notification enqueued");
+
+    if (this.PUSH_ENABLED_TYPES.includes(type)) {
+      await this.sendPushNotification(userId, {
+        title,
+        body: message,
+        icon: "/icon-192.png",
+        badge: "/favicon.svg",
+        data: { notificationId: notification.id, type, metadata },
+      });
+    }
+
     return notification;
   }
 
@@ -610,45 +631,5 @@ export class NotificationService {
     }
   }
 
-  /**
-   * Enhanced sendImmediateNotification to include push notifications
-   */
-  private static async sendImmediateNotificationWithPush(params: {
-    userId: string;
-    type: NotificationType;
-    title: string;
-    message: string;
-    metadata?: any;
-  }) {
-    const notification = await this.sendImmediateNotification(params);
-
-    // Send push notification for specific types
-    const pushEnabledTypes: NotificationType[] = [
-      "JOB_APPLIED",
-      "APPLICATION_ACCEPTED",
-      "APPLICATION_REJECTED",
-      "MILESTONE_SUBMITTED",
-      "MILESTONE_APPROVED",
-      "DISPUTE_RAISED",
-      "DISPUTE_RESOLVED",
-      "NEW_MESSAGE",
-    ];
-
-    if (pushEnabledTypes.includes(params.type)) {
-      await this.sendPushNotification(params.userId, {
-        title: params.title,
-        body: params.message,
-        icon: "/icon-192.png",
-        badge: "/favicon.svg",
-        data: {
-          notificationId: notification?.id,
-          type: params.type,
-          metadata: params.metadata,
-        },
-      });
-    }
-
-    return notification;
-  }
 }
 


### PR DESCRIPTION
## Summary

This PR resolves four Stellar Wave issues:

- **#940 — Dispute resolution never invalidates the reputation cache.** `DisputeService.resolveDispute` and both admin `PATCH /disputes/:id/override` handlers (`admin.ts:545` and the duplicate at `admin.ts:938`) now call `ReputationCacheService.invalidateCache` for both the client and freelancer wallet addresses, mirroring the existing on-chain `DisputeResolved` handler in `horizon-listener.service.ts`.
- **#939 — Web-push notifications are dead code and never fire.** Folded push-dispatch logic directly into `NotificationService.sendImmediateNotification` — the single low-level function every dispatch path goes through (direct `sendNotification` calls, single-notification batch flush, and multi-notification batch flush) — and removed the `sendImmediateNotificationWithPush` wrapper, which was defined but never called anywhere. Subscribed users on `pushEnabledTypes` (`JOB_APPLIED`, `MILESTONE_APPROVED`, `DISPUTE_RAISED`, etc.) now actually receive a push. The VAPID-not-configured graceful skip is preserved.
- **#937 — `deadline-extension.routes.ts` / `deadline-extension.service.ts` have zero test coverage.** Added `deadline-extension.service.test.ts` (request/approve/reject flows, self-approval rejection, both approval orderings triggering the on-chain execution trigger) and `deadline-extension.routes.test.ts` (auth/validation guards on every endpoint).
- **#936 — `milestone.routes.ts` has zero test coverage.** Added `milestone.routes.test.ts` covering the status-transition state machine for both roles (client/freelancer), the submit/approve on-chain XDR flows, and ownership/authorization checks on each endpoint.

## Test plan

- [x] `npm test` — all new/modified test files pass (dispute: 19/19, notification-push: 3/3, deadline-extension service: 16/16, deadline-extension routes: 17/17, milestone routes: 20/20)
- [x] Ran the full backend suite; the only failures present (`roomCleanup.test.ts`, `user.delete.test.ts`, `api-versioning.test.ts` timeouts, `user.routes.test.ts` hoisting error, `skill.routes.test.ts` assertion) are pre-existing and unrelated to these changes — none touch dispute, notification, milestone, or deadline-extension code.

Closes #940
Closes #939
Closes #937
Closes #936