### PR TITLE
fix(backend): gate /metrics behind requireAdmin, mount compression, s…

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -129,6 +129,7 @@ const corsOptions: cors.CorsOptions = {
 
 // Security middleware
 app.use(helmet());
+app.use(compression());
 
 // Swagger UI setup (disabled in production)
 if (process.env.NODE_ENV !== "production") {
@@ -152,19 +153,9 @@ app.get("/health", async (_req, res) => {
   res.status(health.status === "ok" ? 200 : 503).json(health);
 });
 
-app.get("/metrics", metricsHandler);
+app.get("/metrics", requireAdmin, metricsHandler);
 
 app.use(requestDurationMiddleware);
-// Metrics endpoint — exposes pool stats and process counters
-app.get("/metrics", (_req, res) => {
-  res.json({
-    db_pool_size: poolMetrics.active,
-    db_pool_waiting: poolMetrics.waiting,
-    db_pool_exhausted_total: poolMetrics.exhaustedCount,
-    process_uptime_seconds: Math.floor(process.uptime()),
-    process_memory_rss_bytes: process.memoryUsage().rss,
-  });
-});
 
 // Database-only health probe (used by some platforms/LB checks)
 app.get("/health/db", async (_req, res) => {


### PR DESCRIPTION

#932: Gate /metrics endpoint behind requireAdmin middleware — unauthenticated requests now receive 401/403. Remove the dead duplicate /metrics handler that was registered after requestDurationMiddleware and was never reachable.

#929: Mount compression() middleware immediately after helmet() so all HTTP responses are gzip/brotli compressed when the client sends Accept-Encoding. Removes the previously unused import.

#928: Shared PrismaClient — single instance exported from lib/db.ts so all route and service files share one connection pool and the soft-delete/pool- exhaustion middleware registered in index.ts applies everywhere.

#916: Scope GET /applications to the requesting user — freelancers only see their own applications; clients only see applications for jobs they own. Mirrors the ownership check already present in GET /jobs/:jobId/applications.

Closes #932
Closes #929
Closes #928
Closes #916