### PR TITLE
fix: AES-GCM encryption, N+1 notifications, job status transitions, a…

### DIFF
--- a/backend/src/routes/application.routes.ts
+++ b/backend/src/routes/application.routes.ts
@@ -256,20 +256,22 @@ router.put(
           data: { status: "REJECTED" },
         });
 
-        // Notify each rejected freelancer
-        for (const rejectedApp of rejectedApplications) {
-          await NotificationService.sendNotification({
-            userId: rejectedApp.freelancerId,
-            type: NotificationType.APPLICATION_REJECTED,
-            title: "Application Rejected",
-            message: `Your application for "${application.job.title}" has been rejected. Another candidate was selected.`,
-            metadata: { jobId: application.jobId, applicationId: rejectedApp.id },
-          });
-        }
+        // Notify all rejected freelancers in parallel (fire-and-forget after response)
+        void Promise.all(
+          rejectedApplications.map((rejectedApp) =>
+            NotificationService.sendNotification({
+              userId: rejectedApp.freelancerId,
+              type: NotificationType.APPLICATION_REJECTED,
+              title: "Application Rejected",
+              message: `Your application for "${application.job.title}" has been rejected. Another candidate was selected.`,
+              metadata: { jobId: application.jobId, applicationId: rejectedApp.id },
+            })
+          )
+        );
       }
 
-      // Notify the freelancer
-      await NotificationService.sendNotification({
+      // Notify the accepted freelancer (fire-and-forget after response)
+      void NotificationService.sendNotification({
         userId: application.freelancerId,
         type: NotificationType.APPLICATION_ACCEPTED,
         title: "Application Accepted",

--- a/backend/src/utils/encryption.ts
+++ b/backend/src/utils/encryption.ts
@@ -1,27 +1,61 @@
 import crypto from "crypto";
 import { config } from "../config";
 
-const ALGORITHM = "aes-256-cbc";
+/**
+ * AES-256-GCM authenticated encryption.
+ *
+ * Format: <ivHex>:<authTagHex>:<ciphertextHex>
+ *
+ * The 16-byte auth tag is verified before any plaintext is returned, so
+ * tampered ciphertext throws instead of silently producing garbage.
+ *
+ * Migration note: the decrypt function detects the legacy AES-256-CBC format
+ * (iv:ciphertext — no auth tag field) and falls back to CBC decryption so
+ * existing encrypted values continue to work.  New writes always use GCM.
+ */
+
+const ALGORITHM_GCM = "aes-256-gcm";
+const ALGORITHM_CBC = "aes-256-cbc"; // kept for backward-compatible reads only
+const GCM_IV_BYTES = 12; // 96-bit IV recommended for GCM
+const GCM_TAG_BYTES = 16;
 
 function getKey(): Buffer {
-  // Validation is performed at startup in config/index.ts
-  // This should never throw if the application started successfully
-  const hex = config.encryptionKey;
-  return Buffer.from(hex, "hex");
+  return Buffer.from(config.encryptionKey, "hex");
 }
 
 export function encrypt(plaintext: string): string {
-  const iv = crypto.randomBytes(16);
-  const cipher = crypto.createCipheriv(ALGORITHM, getKey(), iv);
+  const iv = crypto.randomBytes(GCM_IV_BYTES);
+  const cipher = crypto.createCipheriv(ALGORITHM_GCM, getKey(), iv);
   const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
-  return `${iv.toString("hex")}:${encrypted.toString("hex")}`;
+  const tag = cipher.getAuthTag();
+  return `${iv.toString("hex")}:${tag.toString("hex")}:${encrypted.toString("hex")}`;
 }
 
 export function decrypt(encryptedText: string): string {
-  const [ivHex, cipherHex] = encryptedText.split(":");
-  const iv = Buffer.from(ivHex, "hex");
-  const encrypted = Buffer.from(cipherHex, "hex");
-  const decipher = crypto.createDecipheriv(ALGORITHM, getKey(), iv);
-  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-  return decrypted.toString("utf8");
+  const parts = encryptedText.split(":");
+
+  if (parts.length === 3) {
+    // GCM format: iv:authTag:ciphertext
+    const [ivHex, tagHex, cipherHex] = parts;
+    const iv = Buffer.from(ivHex, "hex");
+    const tag = Buffer.from(tagHex, "hex");
+    const encrypted = Buffer.from(cipherHex, "hex");
+    const decipher = crypto.createDecipheriv(ALGORITHM_GCM, getKey(), iv);
+    decipher.setAuthTag(tag);
+    // If the tag doesn't match, createDecipheriv will throw — tampered data is rejected.
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    return decrypted.toString("utf8");
+  }
+
+  // Legacy CBC format: iv:ciphertext — backward-compatible reads only
+  if (parts.length === 2) {
+    const [ivHex, cipherHex] = parts;
+    const iv = Buffer.from(ivHex, "hex");
+    const encrypted = Buffer.from(cipherHex, "hex");
+    const decipher = crypto.createDecipheriv(ALGORITHM_CBC, getKey(), iv);
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    return decrypted.toString("utf8");
+  }
+
+  throw new Error("Invalid encrypted text format");
 }


### PR DESCRIPTION

Closes #927 — Switch encryption.ts from AES-256-CBC to AES-256-GCM
- Replace aes-256-cbc cipher with aes-256-gcm (authenticated encryption)
- New format: iv:authTag:ciphertext — auth tag verified before any plaintext is returned; tampered ciphertext throws instead of producing garbage
- Backward-compatible: decrypt detects legacy 2-part iv:ciphertext format and falls back to CBC so existing encrypted values continue to work
- New writes always use GCM; no data migration needed for existing values

Closes #917 — Fix N+1 notification sends when rejecting other applicants
- Replace sequential for/await loop over rejected applicants with Promise.all (parallel) fired as void after response is sent
- Response time for accepting an application no longer scales linearly with applicant count; all rejected applicants still receive notifications

Closes #915 — Application accept flow race condition and missing transaction
- Wrap accept flow in prisma.$transaction with status: PENDING guard so concurrent accepts are rejected with 409 instead of silently succeeding
- Job update + reject-others run atomically inside the transaction

Closes #914 — PATCH /jobs/:id/status allows arbitrary status transitions
- Add explicit allowed-transitions map per role (CLIENT/FREELANCER/ADMIN) mirroring the milestone routes pattern
- Illegal transitions (e.g. COMPLETED -> OPEN) rejected with 409
- Legal transitions continue to work as before