### PR TITLE
refactor(dispute): remove unused InvalidVoteChoice error variant

### DIFF
--- a/contracts/dispute/src/lib.rs
+++ b/contracts/dispute/src/lib.rs
@@ -46,8 +46,10 @@ pub enum DisputeError {
     AppealNotFound = 21,
     NonceReplay = 22,
     DuplicateArbitrator = 23,
-    /// Returned when a vote_choice value does not map to a defined VoteChoice variant.
-    InvalidVoteChoice = 24,
+    // Note: Error code 24 (InvalidVoteChoice) was removed as unreachable.
+    // VoteChoice is a #[contracttype] enum; the SDK's deserialization layer
+    // traps on invalid discriminants before the function body executes, so
+    // no code path could ever construct or return this error variant.
 }
 
 #[contracttype]

--- a/contracts/dispute/src/test.rs
+++ b/contracts/dispute/src/test.rs
@@ -2873,13 +2873,6 @@ fn test_cast_vote_valid_choices_accepted() {
 }
 
 #[test]
-fn test_invalid_vote_choice_error_code_is_24() {
-    // Verify that InvalidVoteChoice maps to discriminant 24.
-    // This ensures the on-chain ABI is stable and clients can reliably detect the error.
-    assert_eq!(DisputeError::InvalidVoteChoice as u32, 24);
-}
-
-#[test]
 fn test_cast_vote_split_award_bps_validation() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
- Remove InvalidVoteChoice from DisputeError enum (error code 24)
- Remove test_invalid_vote_choice_error_code_is_24 test
- Add comment documenting the removal reasoning

The InvalidVoteChoice error variant was unreachable because:
- VoteChoice is a #[contracttype] enum
- The SDK's deserialization layer traps on invalid discriminants before function execution
- cast_vote and cast_appeal_vote use exhaustive matches over VoteChoice variants
- No code path could construct or return this error

All 99 dispute tests pass (1 pre-existing failure unrelated to this change).

Closes #997
