### PR TITLE
feat(security): enforce password max length cap and extend writeRateLimiter to all mutation HTTP methods

### DIFF
--- a/backend/src/__tests__/write-rate-limiter.test.ts
+++ b/backend/src/__tests__/write-rate-limiter.test.ts
@@ -1,0 +1,73 @@
+import express from "express";
+import request from "supertest";
+import { writeRateLimiter, resetAllRateLimiters } from "../middleware/rate-limit";
+
+jest.mock("../config/redis", () => ({
+  getRedisClient: jest.fn(() => null),
+}));
+
+jest.mock("../lib/logger", () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+  installRequestIdConsolePatch: jest.fn(),
+}));
+
+describe("writeRateLimiter HTTP Methods (Issue #931)", () => {
+  let app: express.Application;
+
+  beforeEach(async () => {
+    await resetAllRateLimiters();
+    app = express();
+    app.use(express.json());
+
+    app.get("/api/v1/jobs/:id", writeRateLimiter, (_req, res) => {
+      res.json({ message: "read job" });
+    });
+    app.post("/api/v1/jobs", writeRateLimiter, (_req, res) => {
+      res.json({ message: "created job" });
+    });
+    app.put("/api/v1/jobs/:id", writeRateLimiter, (_req, res) => {
+      res.json({ message: "updated job" });
+    });
+    app.patch("/api/v1/jobs/:id/status", writeRateLimiter, (_req, res) => {
+      res.json({ message: "patched job status" });
+    });
+    app.delete("/api/v1/jobs/:id", writeRateLimiter, (_req, res) => {
+      res.json({ message: "deleted job" });
+    });
+  });
+
+  it("skips rate limiting for GET requests", async () => {
+    for (let i = 0; i < 35; i++) {
+      const response = await request(app).get("/api/v1/jobs/123");
+      expect(response.status).toBe(200);
+    }
+  });
+
+  it("applies rate limiting to PUT requests after limit (max 30)", async () => {
+    for (let i = 0; i < 30; i++) {
+      const res = await request(app).put("/api/v1/jobs/123").send({ title: "Updated" });
+      expect(res.status).toBe(200);
+    }
+    const rateLimitedRes = await request(app).put("/api/v1/jobs/123").send({ title: "Updated" });
+    expect(rateLimitedRes.status).toBe(429);
+    expect(rateLimitedRes.body).toEqual({ error: "Too many write requests" });
+  });
+
+  it("applies rate limiting to PATCH requests", async () => {
+    for (let i = 0; i < 30; i++) {
+      const res = await request(app).patch("/api/v1/jobs/123/status").send({ status: "COMPLETED" });
+      expect(res.status).toBe(200);
+    }
+    const rateLimitedRes = await request(app).patch("/api/v1/jobs/123/status").send({ status: "COMPLETED" });
+    expect(rateLimitedRes.status).toBe(429);
+  });
+
+  it("applies rate limiting to DELETE requests", async () => {
+    for (let i = 0; i < 30; i++) {
+      const res = await request(app).delete("/api/v1/jobs/123");
+      expect(res.status).toBe(200);
+    }
+    const rateLimitedRes = await request(app).delete("/api/v1/jobs/123");
+    expect(rateLimitedRes.status).toBe(429);
+  });
+});

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -104,7 +104,7 @@ export const writeRateLimiter = rateLimit({
     return ip;
   },
   validate: { ip: false }, // IP is normalized in keyGenerator above
-  skip: (req: Request) => req.method !== "POST",
+  skip: (req: Request) => req.method === "GET" || req.method === "HEAD" || req.method === "OPTIONS",
   handler: sendTooManyWrites,
 });
 

--- a/backend/src/schemas/__tests__/password-max-length.test.ts
+++ b/backend/src/schemas/__tests__/password-max-length.test.ts
@@ -1,0 +1,54 @@
+import { passwordSchema } from "../common";
+import { loginSchema, changePasswordSchema } from "../auth";
+
+describe("Password Max Length Validation (Issue #930)", () => {
+  const valid8Char = "Password123";
+  const valid128Char = "A".repeat(100) + "a".repeat(20) + "12345678";
+  const invalid129Char = "A".repeat(100) + "a".repeat(20) + "123456789";
+
+  describe("passwordSchema", () => {
+    it("accepts valid passwords up to 128 characters", () => {
+      expect(passwordSchema.safeParse(valid8Char).success).toBe(true);
+      expect(passwordSchema.safeParse(valid128Char).success).toBe(true);
+    });
+
+    it("rejects passwords exceeding 128 characters", () => {
+      const result = passwordSchema.safeParse(invalid129Char);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toMatch(/128 characters/i);
+      }
+    });
+  });
+
+  describe("loginSchema", () => {
+    it("accepts valid login credentials with password <= 128 chars", () => {
+      const result = loginSchema.safeParse({
+        email: "user@example.com",
+        password: valid128Char,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects login with password > 128 chars", () => {
+      const result = loginSchema.safeParse({
+        email: "user@example.com",
+        password: invalid129Char,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toMatch(/128 characters/i);
+      }
+    });
+  });
+
+  describe("changePasswordSchema", () => {
+    it("rejects currentPassword exceeding 128 characters", () => {
+      const result = changePasswordSchema.safeParse({
+        currentPassword: invalid129Char,
+        newPassword: valid8Char,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/backend/src/schemas/auth.ts
+++ b/backend/src/schemas/auth.ts
@@ -15,7 +15,7 @@ export const registerSchema = z.object({
 
 export const loginSchema = z.object({
   email: emailSchema,
-  password: z.string().min(1, "Password is required"),
+  password: z.string().min(1, "Password is required").max(128, "Password must be at most 128 characters long"),
 });
 
 export const walletAuthSchema = z.object({
@@ -45,7 +45,7 @@ export const resetPasswordSchema = z.object({
 });
 
 export const changePasswordSchema = z.object({
-  currentPassword: z.string().min(1, "Current password is required"),
+  currentPassword: z.string().min(1, "Current password is required").max(128, "Password must be at most 128 characters long"),
   newPassword: passwordSchema,
 });
 
@@ -58,7 +58,7 @@ export const twoFactorVerifySchema = z.object({
 });
 
 export const twoFactorDisableSchema = z.object({
-  password: z.string().min(1, "Password is required"),
+  password: z.string().min(1, "Password is required").max(128, "Password must be at most 128 characters long"),
 });
 
 export const twoFactorValidateSchema = z.object({

--- a/backend/src/schemas/common.ts
+++ b/backend/src/schemas/common.ts
@@ -16,6 +16,7 @@ export const emailSchema = z.string().email("Invalid email address");
 export const passwordSchema = z
   .string()
   .min(8, "Password must be at least 8 characters long")
+  .max(128, "Password must be at most 128 characters long")
   .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
   .regex(/[a-z]/, "Password must contain at least one lowercase letter")
   .regex(/[0-9]/, "Password must contain at least one number");


### PR DESCRIPTION
## Description
This pull request addresses security and rate-limiting issues #930 and #931.

1. **Password Max Length Cap (Issue #930)**:
   - Added `.max(128, "Password must be at most 128 characters long")` validation to `passwordSchema` (`backend/src/schemas/common.ts`) and password fields in `loginSchema`, `changePasswordSchema`, and `twoFactorDisableSchema` (`backend/src/schemas/auth.ts`).
   - Prevents sending multi-megabyte payloads to `bcrypt.hash` / `bcrypt.compare` to close low-cost CPU/memory DoS vectors.

2. **Write Rate Limiter Method Coverage (Issue #931)**:
   - Updated `writeRateLimiter` (`backend/src/middleware/rate-limit.ts`) skip predicate to only skip read/safe HTTP methods (`GET`, `HEAD`, `OPTIONS`).
   - Ensures `POST`, `PUT`, `PATCH`, and `DELETE` endpoints are properly throttled by the write rate limiter.

Closes #930
Closes #931