### PR TITLE
Add trigram GIN indexes on User columns to fix sequential scans in fr…

### DIFF
--- a/backend/prisma/migrations/20260730000000_add_user_trigram_search/migration.sql
+++ b/backend/prisma/migrations/20260730000000_add_user_trigram_search/migration.sql
@@ -1,0 +1,21 @@
+-- Migration: Enable pg_trgm extension and add GIN trigram indexes on User columns
+-- for freelancer search performance. Follows the same pattern as
+-- 20260425000000_add_job_search_and_token_filter/migration.sql.
+
+-- 1. Enable pg_trgm extension (idempotent)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- 2. GIN trigram index on username for fast ILIKE '%token%' search
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "User_username_trgm_idx"
+  ON "User" USING GIN ("username" gin_trgm_ops);
+
+-- 3. GIN trigram index on bio for fast ILIKE '%token%' search
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "User_bio_trgm_idx"
+  ON "User" USING GIN ("bio" gin_trgm_ops);
+
+-- 4. GIN trigram index on skills (converted to space-separated text) for fast
+--    ILIKE skill filtering. The expression index allows ILIKE queries on
+--    array_to_string("skills", ' ') to use a GIN trigram scan instead of
+--    unnest + sequential scan.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "User_skills_trgm_idx"
+  ON "User" USING GIN (array_to_string("skills", ' ') gin_trgm_ops);

--- a/backend/src/services/freelancer-search.service.ts
+++ b/backend/src/services/freelancer-search.service.ts
@@ -51,7 +51,7 @@ function buildWhereSql(input: FreelancerSearchInput): Prisma.Sql {
     if (!token) continue;
     const pattern = `%${token}%`;
     parts.push(
-      Prisma.sql`EXISTS (SELECT 1 FROM unnest(u.skills) AS sk WHERE sk ILIKE ${pattern})`
+      Prisma.sql`array_to_string(u.skills, ' ') ILIKE ${pattern}`
     );
   }
 


### PR DESCRIPTION
…eelancer search

- Enable pg_trgm extension
- Add GIN trigram index on User.username for fast ILIKE '%token%' queries
- Add GIN trigram index on User.bio for fast ILIKE '%token%' queries
- Add GIN trigram index on array_to_string(User.skills, ' ') for indexed skill filtering
- Refactor skill WHERE clause from unnest subquery to array_to_string ILIKE so the new expression index is used instead of a sequential scan

Fixes sequential scan on User table when text query or skill filter is provided.

closes #948