### PR TITLE
Exclude soft-deleted jobs from feed; add dispute elapsed/countdown UI

### DIFF
--- a/backend/src/__tests__/job-soft-delete-filter.test.ts
+++ b/backend/src/__tests__/job-soft-delete-filter.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for: "Soft-deleted jobs still appear in the main job feed"
+ *
+ * GET /api/jobs must exclude jobs with a non-null deletedAt, for both the
+ * offset-based and cursor-based pagination paths.
+ */
+
+// ─── Prisma mock ──────────────────────────────────────────────────────────────
+type MockPrismaClient = {
+  job: {
+    findMany: jest.Mock;
+    count: jest.Mock;
+    findUnique: jest.Mock;
+  };
+  user: {
+    findUnique: jest.Mock;
+  };
+  $queryRaw: jest.Mock;
+  $disconnect: jest.Mock;
+};
+
+jest.mock("@prisma/client", () => {
+  const mockPrisma: MockPrismaClient = {
+    job: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+    },
+    $queryRaw: jest.fn(),
+    $disconnect: jest.fn(),
+  };
+
+  return {
+    PrismaClient: jest.fn(() => mockPrisma),
+    UserRole: { CLIENT: "CLIENT", FREELANCER: "FREELANCER", ADMIN: "ADMIN" },
+  };
+});
+
+// ─── Config mock ──────────────────────────────────────────────────────────────
+jest.mock("../config", () => ({
+  config: {
+    jwtSecret: "test-secret",
+    platformMinBudgetXlm: 1,
+  },
+  MAX_PAGE_SIZE: 100,
+}));
+
+// ─── Cache mock (bypass Redis for tests) ─────────────────────────────────────
+jest.mock("../lib/cache", () => ({
+  cache: jest.fn((_key: string, _ttl: number, fn: () => Promise<unknown>) =>
+    fn().then((data: unknown) => ({ data, hit: false })),
+  ),
+  invalidateCache: jest.fn().mockResolvedValue(undefined),
+  invalidateCacheKey: jest.fn().mockResolvedValue(undefined),
+  generateJobsCacheKey: jest.fn().mockReturnValue("jobs:list:test"),
+  generateJobCacheKey: jest.fn().mockReturnValue("job:test"),
+  generateJobOnChainStatusCacheKey: jest.fn().mockReturnValue("job:on-chain:test"),
+}));
+
+// ─── ContractService mock ─────────────────────────────────────────────────────
+jest.mock("../services/contract.service", () => ({
+  ContractService: {
+    getOnChainJobStatus: jest.fn().mockResolvedValue("FUNDED"),
+    getRevisionProposal: jest.fn().mockResolvedValue(null),
+  },
+}));
+
+// ─── RecommendationQueueService mock ─────────────────────────────────────────
+jest.mock("../services/recommendation-queue.service", () => ({
+  RecommendationQueueService: {
+    enqueueRebuild: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { PrismaClient } from "@prisma/client";
+import express from "express";
+import request from "supertest";
+import jobRouter from "../routes/job.routes";
+
+const prismaMock = new PrismaClient() as unknown as MockPrismaClient;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/jobs", jobRouter);
+  return app;
+}
+
+afterEach(() => jest.clearAllMocks());
+
+describe("GET /api/jobs — soft-delete filtering", () => {
+  beforeEach(() => {
+    prismaMock.job.findMany.mockResolvedValue([]);
+    prismaMock.job.count.mockResolvedValue(0);
+  });
+
+  it("excludes soft-deleted jobs on the offset pagination path", async () => {
+    const app = buildApp();
+    await request(app).get("/api/jobs?page=1&limit=20");
+
+    const findManyCall = prismaMock.job.findMany.mock.calls[0][0];
+    const countCall = prismaMock.job.count.mock.calls[0][0];
+
+    expect(findManyCall.where).toMatchObject({ deletedAt: null });
+    expect(countCall.where).toMatchObject({ deletedAt: null });
+  });
+
+  it("excludes soft-deleted jobs on the cursor pagination path", async () => {
+    prismaMock.job.findUnique.mockResolvedValue({
+      id: "job-anchor",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const app = buildApp();
+    await request(app).get("/api/jobs?cursor=job-anchor");
+
+    const findManyCall = prismaMock.job.findMany.mock.calls[0][0];
+    const countCall = prismaMock.job.count.mock.calls[0][0];
+
+    expect(findManyCall.where.AND).toEqual(
+      expect.arrayContaining([expect.anything()]),
+    );
+    expect(findManyCall.where).toMatchObject({ deletedAt: null });
+    expect(countCall.where).toMatchObject({ deletedAt: null });
+  });
+});

--- a/backend/src/routes/job.routes.ts
+++ b/backend/src/routes/job.routes.ts
@@ -344,7 +344,7 @@ router.get(
     });
 
     const { data, hit } = await cache(cacheKey, 30, async () => {
-      const where: Prisma.JobWhereInput = {};
+      const where: Prisma.JobWhereInput = { deletedAt: null };
 
       // Full-text search using PostgreSQL tsvector/tsquery with relevance ranking.
       // Falls back to Prisma contains (LIKE) if raw query fails.

--- a/frontend/src/app/disputes/[id]/page.tsx
+++ b/frontend/src/app/disputes/[id]/page.tsx
@@ -13,6 +13,7 @@ import EvidenceViewer from "@/components/EvidenceViewer";
 import EvidenceUpload from "@/components/EvidenceUpload";
 import DisputeOutcomeBanner from "@/components/DisputeOutcomeBanner";
 import DisputeTimeline from "@/components/DisputeTimeline";
+import { DisputeOpenedElapsed, VoteDeadlineCountdown } from "@/components/DisputeElapsedTime";
 import { useDisputeStream } from "@/hooks/useDisputeStream";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api/v1";
@@ -235,7 +236,13 @@ export default function DisputeDetailPage() {
               <div className="flex items-center gap-2 mb-2">
                 <UserIcon size={16} className="text-theme-text" />
                 <span className="font-medium text-theme-heading pr-2 border-r border-theme-border">Initiated by {dispute.initiator.username}</span>
-                <span className="text-sm text-theme-text">{new Date(dispute.createdAt).toLocaleString()}</span>
+                <DisputeOpenedElapsed isoString={dispute.createdAt} className="text-sm text-theme-text" />
+                {dispute.voteDeadline && (
+                  <VoteDeadlineCountdown
+                    deadlineIso={dispute.voteDeadline}
+                    className="text-sm font-medium pl-2 ml-2 border-l border-theme-border"
+                  />
+                )}
               </div>
               <p className="text-theme-text whitespace-pre-line text-sm leading-relaxed">
                 {dispute.reason}

--- a/frontend/src/components/DisputeElapsedTime.tsx
+++ b/frontend/src/components/DisputeElapsedTime.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { formatLocalTimestamp, formatUtcTimestamp } from "@/components/LocalTimestamp";
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Formats how long ago `isoString` was, e.g. "Opened 3 days ago".
+ */
+export function formatElapsed(isoString: string, now: Date = new Date()): string {
+  const diffMs = Math.max(0, now.getTime() - new Date(isoString).getTime());
+
+  if (diffMs < MINUTE_MS) return "Opened just now";
+
+  if (diffMs < HOUR_MS) {
+    const minutes = Math.floor(diffMs / MINUTE_MS);
+    return `Opened ${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+  }
+
+  if (diffMs < DAY_MS) {
+    const hours = Math.floor(diffMs / HOUR_MS);
+    return `Opened ${hours} hour${hours === 1 ? "" : "s"} ago`;
+  }
+
+  const days = Math.floor(diffMs / DAY_MS);
+  return `Opened ${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+export interface VoteCountdown {
+  text: string;
+  /** True when the deadline is under 24 hours away — used for amber styling. */
+  urgent: boolean;
+  expired: boolean;
+}
+
+/**
+ * Formats the time remaining until a vote deadline, e.g. "Vote closes in 2 hours".
+ */
+export function formatVoteCountdown(
+  deadlineIso: string,
+  now: Date = new Date(),
+): VoteCountdown {
+  const diffMs = new Date(deadlineIso).getTime() - now.getTime();
+
+  if (diffMs <= 0) {
+    return { text: "Vote deadline has passed", urgent: true, expired: true };
+  }
+
+  const urgent = diffMs < DAY_MS;
+
+  if (diffMs < HOUR_MS) {
+    const minutes = Math.max(1, Math.round(diffMs / MINUTE_MS));
+    return { text: `Vote closes in ${minutes} minute${minutes === 1 ? "" : "s"}`, urgent, expired: false };
+  }
+
+  if (diffMs < DAY_MS) {
+    const hours = Math.floor(diffMs / HOUR_MS);
+    return { text: `Vote closes in ${hours} hour${hours === 1 ? "" : "s"}`, urgent, expired: false };
+  }
+
+  const days = Math.floor(diffMs / DAY_MS);
+  return { text: `Vote closes in ${days} day${days === 1 ? "" : "s"}`, urgent, expired: false };
+}
+
+/** Ticks a `Date` once a minute so relative-time text stays fresh without refetching. */
+function useMinuteTick(): Date {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), MINUTE_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return now;
+}
+
+interface DisputeOpenedElapsedProps {
+  isoString: string;
+  className?: string;
+}
+
+/** Renders "Opened X days ago", updating every minute, with the exact time as a tooltip. */
+export function DisputeOpenedElapsed({ isoString, className }: DisputeOpenedElapsedProps) {
+  const now = useMinuteTick();
+
+  return (
+    <time
+      dateTime={isoString}
+      title={`${formatLocalTimestamp(isoString)} (${formatUtcTimestamp(isoString)})`}
+      className={className}
+    >
+      {formatElapsed(isoString, now)}
+    </time>
+  );
+}
+
+interface VoteDeadlineCountdownProps {
+  deadlineIso: string;
+  className?: string;
+}
+
+/** Renders a live "Vote closes in X hours" countdown, styled amber under 24 hours. */
+export function VoteDeadlineCountdown({ deadlineIso, className = "" }: VoteDeadlineCountdownProps) {
+  const now = useMinuteTick();
+  const { text, urgent } = formatVoteCountdown(deadlineIso, now);
+
+  return (
+    <span
+      title={formatLocalTimestamp(deadlineIso)}
+      className={`${urgent ? "text-theme-warning" : "text-theme-text"} ${className}`}
+    >
+      {text}
+    </span>
+  );
+}

--- a/frontend/src/components/__tests__/DisputeElapsedTime.test.tsx
+++ b/frontend/src/components/__tests__/DisputeElapsedTime.test.tsx
@@ -1,0 +1,113 @@
+import "@testing-library/jest-dom";
+import { act, render, screen } from "@testing-library/react";
+import {
+  DisputeOpenedElapsed,
+  VoteDeadlineCountdown,
+  formatElapsed,
+  formatVoteCountdown,
+} from "@/components/DisputeElapsedTime";
+
+const NOW = new Date("2026-06-15T12:00:00Z");
+
+describe("formatElapsed", () => {
+  it('shows "Opened 3 days ago" for a dispute opened 3 days ago', () => {
+    const openedAt = new Date(NOW.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    expect(formatElapsed(openedAt, NOW)).toBe("Opened 3 days ago");
+  });
+
+  it('shows "Opened just now" for a dispute opened seconds ago', () => {
+    const openedAt = new Date(NOW.getTime() - 5000).toISOString();
+    expect(formatElapsed(openedAt, NOW)).toBe("Opened just now");
+  });
+
+  it('shows hours when under a day old', () => {
+    const openedAt = new Date(NOW.getTime() - 5 * 60 * 60 * 1000).toISOString();
+    expect(formatElapsed(openedAt, NOW)).toBe("Opened 5 hours ago");
+  });
+});
+
+describe("formatVoteCountdown", () => {
+  it('shows amber-eligible "Vote closes in 2 hours" for a deadline 2 hours away', () => {
+    const deadline = new Date(NOW.getTime() + 2 * 60 * 60 * 1000).toISOString();
+    const result = formatVoteCountdown(deadline, NOW);
+    expect(result.text).toBe("Vote closes in 2 hours");
+    expect(result.urgent).toBe(true);
+  });
+
+  it("is not urgent when the deadline is more than 24 hours away", () => {
+    const deadline = new Date(NOW.getTime() + 48 * 60 * 60 * 1000).toISOString();
+    const result = formatVoteCountdown(deadline, NOW);
+    expect(result.text).toBe("Vote closes in 2 days");
+    expect(result.urgent).toBe(false);
+  });
+
+  it("reports expired once the deadline has passed", () => {
+    const deadline = new Date(NOW.getTime() - 60 * 1000).toISOString();
+    const result = formatVoteCountdown(deadline, NOW);
+    expect(result.expired).toBe(true);
+    expect(result.urgent).toBe(true);
+  });
+});
+
+describe("DisputeOpenedElapsed component", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('renders "Opened 3 days ago" for a dispute opened 3 days ago', () => {
+    const openedAt = new Date(NOW.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    render(<DisputeOpenedElapsed isoString={openedAt} />);
+    expect(screen.getByRole("time")).toHaveTextContent("Opened 3 days ago");
+  });
+
+  it("updates the displayed text every minute without unmounting", () => {
+    const openedAt = new Date(NOW.getTime() - 59 * 60 * 1000).toISOString();
+    render(<DisputeOpenedElapsed isoString={openedAt} />);
+    expect(screen.getByRole("time")).toHaveTextContent("Opened 59 minutes ago");
+
+    act(() => {
+      jest.setSystemTime(new Date(NOW.getTime() + 2 * 60 * 1000));
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(screen.getByRole("time")).toHaveTextContent("Opened 1 hour ago");
+  });
+});
+
+describe("VoteDeadlineCountdown component", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('shows amber "Vote closes in 2 hours" when the deadline is under 24 hours away', () => {
+    const deadline = new Date(NOW.getTime() + 2 * 60 * 60 * 1000).toISOString();
+    render(<VoteDeadlineCountdown deadlineIso={deadline} />);
+
+    const el = screen.getByText("Vote closes in 2 hours");
+    expect(el).toHaveClass("text-theme-warning");
+  });
+
+  it("does not use the amber styling when the deadline is more than 24 hours away", () => {
+    const deadline = new Date(NOW.getTime() + 48 * 60 * 60 * 1000).toISOString();
+    render(<VoteDeadlineCountdown deadlineIso={deadline} />);
+
+    const el = screen.getByText("Vote closes in 2 days");
+    expect(el).not.toHaveClass("text-theme-warning");
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -251,6 +251,7 @@ export interface Dispute {
   minVotes: number;
   createdAt: string;
   updatedAt: string;
+  voteDeadline?: string;
   job: Job;
   initiator: User;
   respondent: User;


### PR DESCRIPTION
## Summary

- Fixes the public `GET /api/v1/jobs` feed so it excludes soft-deleted jobs (`deletedAt: null`), matching every other job-scoped route in `job.routes.ts`. Covers both offset and cursor pagination paths, with a regression test.
- Adds an "Opened X days ago" elapsed-time display and an optional vote-deadline countdown (amber under 24h) to the dispute detail page, updating every minute without a full refetch.

Closes #807, Closes #913

## Test plan

- [x] Backend: `npm run lint`, `tsc --noEmit`, and `npm test` (including new `job-soft-delete-filter.test.ts`) all pass
- [x] Frontend: full `npm test` suite (226 tests) and `npm run build` pass, including new `DisputeElapsedTime.test.tsx`