### PR TITLE
fix: shared Redis cache and automated remediation for earnings reconciliation

### DIFF
--- a/EARNINGS_RECONCILIATION_IMPLEMENTATION.md
+++ b/EARNINGS_RECONCILIATION_IMPLEMENTATION.md
@@ -4,6 +4,10 @@ Extends the freelancer earnings dashboard (#603, #477) with time-series
 decomposition, on-chain reconciliation against the Stellar ledger, and a
 tax-period CSV export. Closes #672.
 
+Reconciliation was originally read-only and process-local (see below); #874
+made the payment cache shared across instances and made reconciliation
+proactive and self-healing rather than a passive report.
+
 ## Why
 
 The earnings page previously read from PostgreSQL only. With on-chain
@@ -28,9 +32,13 @@ Now accepts optional `from`/`to` ISO dates and additionally returns:
 Fetches inbound payments to the freelancer's wallet from Horizon for the window
 and matches each to a DB earnings record by transaction hash or by the `jobId`
 carried in the transaction memo. Returns `matched`, `onChainOnly`, and `dbOnly`
-buckets plus a summary. `onChainOnly` entries indicate a DB sync failure and are
-logged as warnings; each carries a Horizon transaction URL. Returns `502` if
-Horizon is unreachable.
+buckets plus a summary. Returns `502` if Horizon is unreachable.
+
+As of #874 this is no longer read-only: the response also includes a
+`remediation` summary (`{ backfilled, alreadyRemediated, flaggedForReview }`)
+reporting what was automatically corrected on this call. See
+[Proactive reconciliation & remediation (#874)](#proactive-reconciliation--remediation-874)
+below.
 
 ### `GET /api/freelancers/earnings/export?from=<ISO>&to=<ISO>&format=csv`
 
@@ -41,6 +49,58 @@ unreachable rows are marked `unverified` and the export still succeeds.
 
 Horizon access is encapsulated in
 `src/services/earnings-reconciliation.service.ts`.
+
+## Proactive reconciliation & remediation (#874)
+
+The original implementation had two gaps: the Horizon payment cache was a
+module-level `Map`, so under horizontal scaling each backend instance built its
+own independent, possibly-stale view; and reconciliation only ever *reported*
+`onChainOnly`/`dbOnly` discrepancies — nothing wrote a correction back, and
+nothing ran unless a freelancer happened to load the earnings page.
+
+**Shared cache.** `fetchOnChainPayments` now caches through the same Redis
+helper (`src/lib/cache.ts`) already used for job listings and user profiles, so
+a payment window fetched by one instance is immediately visible to every other
+instance (60s TTL). Falls back to a direct Horizon fetch — never a hard
+failure — if Redis is unreachable, matching the existing cache-aside
+convention.
+
+**Shared reconciliation core.** The bucket-matching logic (`matched` /
+`onChainOnly` / `dbOnly`) that used to live inline in the route handler is now
+`reconcileEarnings()` in the service, so both the on-demand route and the new
+background job compute it identically.
+
+**Automated remediation.** `reconcileAndRemediate()` wraps `reconcileEarnings`
+and, for every result:
+
+- **`onChainOnly`** (Horizon confirms a payment, the DB has no record) —
+  `remediateOnChainOnly()` backfills the missing `Transaction` row directly
+  from the on-chain data (`createdAt` is the on-chain settlement time, not the
+  backfill's insertion time, so historical charts stay accurate). Idempotent:
+  `Transaction.txHash` is uniquely constrained, so the backfill is an
+  `upsert(..., update: {})` — replaying reconciliation for the same payment is
+  a no-op, never a duplicate. `jobId` is only attached when the memo actually
+  names a real, existing `Job`; an unrelated or malformed memo never corrupts
+  the ledger with a false link.
+- **`dbOnly`** (a DB record with no matching on-chain payment in the window) —
+  deliberately **not** auto-corrected. `flagDbOnlyForReview()` only writes an
+  audit entry; the missing on-chain match could mean the payment hasn't
+  settled yet, settled outside the window, or the DB record is genuinely
+  wrong, and an automated job can't safely tell which. A human reviewer
+  triages from the audit trail.
+
+Both remediation paths write through the existing tamper-evident, hash-chained
+`AuditService` (`src/services/audit.service.ts`, #875) with `actorId: "system"`
+— every automated correction is traceable and independently verifiable via
+`AuditService.verifyChain()`.
+
+**Proactive scheduling.** `src/jobs/earnings-reconciliation.job.ts` follows the
+existing `setInterval`-based job convention (`pending-tx.job.ts`,
+`escrow-ttl.job.ts`): every 15 minutes it reconciles every active freelancer
+(has a wallet, not deleted, not suspended — deliberately *not* gated on recent
+login, since the entire point is catching freelancers who are *not* currently
+loading the page) over a trailing 48-hour window, batched (25 at a time) so one
+freelancer's failure doesn't stop the sweep for everyone else.
 
 ## Frontend
 
@@ -61,7 +121,19 @@ Horizon access is encapsulated in
 ## Tests
 
 - `backend/src/routes/__tests__/freelancer.earnings.test.ts` — reconciliation
-  bucket classification, memo-based matching, Horizon-failure handling, range
-  validation, role gating, and CSV export shape/escaping.
+  response shape (including the `remediation` summary), Horizon-failure
+  handling, range validation, role gating, and CSV export shape/escaping.
+- `backend/src/services/__tests__/earnings-reconciliation.service.test.ts`
+  (#874) — the Redis cache write from one simulated backend instance is
+  visible to another without a second Horizon call (and gracefully falls back
+  when Redis is down); `onChainOnly` backfill is idempotent and only jobId-links
+  a memo that resolves to a real `Job`; the on-chain settlement date is
+  preserved on backfill; `dbOnly` discrepancies are audit-flagged and never
+  touch the `Transaction` table.
+- `backend/src/__tests__/earnings-reconciliation-job.test.ts` (#874) — the
+  scheduled sweep reconciles an inactive freelancer (no page load, no route
+  call — only the job) purely on its own schedule; batches active freelancers
+  and one failure doesn't stop the sweep; no-ops when there are no active
+  freelancers or a user has no wallet.
 - `frontend/src/app/dashboard/earnings/__tests__/earnings-utils.test.ts` —
   zero-gap filling and partial-window moving average.

--- a/backend/src/__tests__/earnings-reconciliation-job.test.ts
+++ b/backend/src/__tests__/earnings-reconciliation-job.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the proactive earnings reconciliation background job (issue #874).
+ *
+ * The whole point of this job is to catch and fix discrepancies for
+ * freelancers who are *not* currently loading the earnings page — these tests
+ * call the sweep directly and never touch the `/earnings/reconcile` route, to
+ * prove reconciliation genuinely happens without a page load.
+ */
+
+const mockUser = {
+  findMany: jest.fn(),
+};
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    user: mockUser,
+  })),
+}));
+
+jest.mock("../lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const mockReconcileAndRemediate = jest.fn();
+jest.mock("../services/earnings-reconciliation.service", () => ({
+  reconcileAndRemediate: (...args: unknown[]) => mockReconcileAndRemediate(...args),
+}));
+
+import { runEarningsReconciliationSweep } from "../jobs/earnings-reconciliation.job";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("runEarningsReconciliationSweep", () => {
+  it("reconciles an inactive freelancer (no page load) purely from the scheduled sweep", async () => {
+    const inactiveFreelancer = {
+      id: "freelancer-inactive-1",
+      walletAddress: "GINACTIVE1",
+    };
+    mockUser.findMany.mockResolvedValue([inactiveFreelancer]);
+    mockReconcileAndRemediate.mockResolvedValue({
+      range: { from: "2026-01-01T00:00:00.000Z", to: "2026-01-03T00:00:00.000Z" },
+      summary: {
+        onChainCount: 1,
+        dbCount: 0,
+        matchedCount: 0,
+        onChainOnlyCount: 1,
+        dbOnlyCount: 0,
+        allMatched: false,
+      },
+      matched: [],
+      onChainOnly: [
+        {
+          txHash: "HASH_INACTIVE_USER_PAYMENT",
+          memoJobId: null,
+          amount: 300,
+          assetCode: "XLM",
+          createdAt: "2026-01-02T00:00:00.000Z",
+          horizonUrl: "https://horizon-testnet.stellar.org/transactions/HASH_INACTIVE_USER_PAYMENT",
+        },
+      ],
+      dbOnly: [],
+      remediation: { backfilled: 1, alreadyRemediated: 0, flaggedForReview: 0 },
+    });
+
+    // No route, no request, no page load — only the sweep itself.
+    await runEarningsReconciliationSweep();
+
+    expect(mockUser.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          role: "FREELANCER",
+          walletAddress: { not: null },
+          deletedAt: null,
+          isSuspended: false,
+        }),
+      }),
+    );
+    expect(mockReconcileAndRemediate).toHaveBeenCalledTimes(1);
+    expect(mockReconcileAndRemediate).toHaveBeenCalledWith(
+      "GINACTIVE1",
+      expect.any(Date),
+      expect.any(Date),
+    );
+  });
+
+  it("reconciles active freelancers in batches and does not stop the sweep when one fails", async () => {
+    const freelancers = Array.from({ length: 30 }, (_, i) => ({
+      id: `freelancer-${i}`,
+      walletAddress: `GWALLET${i}`,
+    }));
+    mockUser.findMany.mockResolvedValue(freelancers);
+
+    mockReconcileAndRemediate.mockImplementation(async (wallet: string) => {
+      if (wallet === "GWALLET5") {
+        throw new Error("Horizon unreachable for this wallet");
+      }
+      return {
+        range: { from: "", to: "" },
+        summary: {
+          onChainCount: 0,
+          dbCount: 0,
+          matchedCount: 0,
+          onChainOnlyCount: 0,
+          dbOnlyCount: 0,
+          allMatched: true,
+        },
+        matched: [],
+        onChainOnly: [],
+        dbOnly: [],
+        remediation: { backfilled: 0, alreadyRemediated: 0, flaggedForReview: 0 },
+      };
+    });
+
+    await expect(runEarningsReconciliationSweep()).resolves.not.toThrow();
+
+    // All 30 freelancers attempted despite one failure among them.
+    expect(mockReconcileAndRemediate).toHaveBeenCalledTimes(30);
+  });
+
+  it("does nothing when there are no active freelancers", async () => {
+    mockUser.findMany.mockResolvedValue([]);
+
+    await runEarningsReconciliationSweep();
+
+    expect(mockReconcileAndRemediate).not.toHaveBeenCalled();
+  });
+
+  it("skips freelancers without a wallet address at the query level", async () => {
+    mockUser.findMany.mockResolvedValue([{ id: "freelancer-no-wallet", walletAddress: null }]);
+
+    await runEarningsReconciliationSweep();
+
+    // The where-clause already excludes null wallets; this guards against a
+    // regression where a null slips through and crashes reconcileAndRemediate.
+    expect(mockReconcileAndRemediate).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import { initYjsServer } from "./socket/yjsServer";
 import { startExpiryJob } from "./jobs/expiry.job";
 import { startPendingTxJob } from "./jobs/pending-tx.job";
 import { startEscrowTtlJob } from "./jobs/escrow-ttl.job";
+import { startEarningsReconciliationJob } from "./jobs/earnings-reconciliation.job";
 import {
   startHorizonListener,
   stopHorizonListener,
@@ -227,6 +228,7 @@ async function startServer(): Promise<void> {
     startExpiryJob();
     startPendingTxJob();
     startEscrowTtlJob();
+    startEarningsReconciliationJob();
     startHorizonListener();
     RecommendationQueueService.startWorker();
     AuditService.startWorker();

--- a/backend/src/jobs/earnings-reconciliation.job.ts
+++ b/backend/src/jobs/earnings-reconciliation.job.ts
@@ -1,0 +1,94 @@
+import { PrismaClient } from "@prisma/client";
+import { logger } from "../lib/logger";
+import { reconcileAndRemediate } from "../services/earnings-reconciliation.service";
+
+const prisma = new PrismaClient();
+
+// Reconciliation is heavier than a plain DB poll (it calls out to Horizon per
+// freelancer), so this runs far less often than pending-tx/escrow-ttl's 30s.
+const POLL_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
+// Trailing window re-checked every sweep. Wider than the poll interval so a
+// payment that settles on-chain slightly late, or a sweep that runs behind
+// schedule, still gets caught on the next pass instead of falling through a
+// gap between two non-overlapping windows.
+const RECONCILIATION_WINDOW_MS = 48 * 60 * 60 * 1000; // 48 hours
+const BATCH_SIZE = 25;
+
+/**
+ * "Active" freelancers eligible for proactive reconciliation: have a wallet
+ * (reconciliation is meaningless without one), and are not deleted or
+ * suspended. Deliberately not gated on any "recently logged in" signal — the
+ * entire point of this job (issue #874) is to catch discrepancies for
+ * freelancers who are *not* currently loading the earnings page, so gating on
+ * recent activity would defeat its purpose.
+ */
+async function loadActiveFreelancerWallets(): Promise<Array<{ id: string; walletAddress: string }>> {
+  const users = await prisma.user.findMany({
+    where: {
+      role: "FREELANCER",
+      walletAddress: { not: null },
+      deletedAt: null,
+      isSuspended: false,
+    },
+    select: { id: true, walletAddress: true },
+  });
+  return users.filter((u): u is { id: string; walletAddress: string } => u.walletAddress !== null);
+}
+
+/**
+ * Proactively reconcile every active freelancer's earnings against Horizon on
+ * a fixed interval, rather than only when a freelancer happens to load the
+ * earnings page (issue #874). Each freelancer is processed independently so
+ * one failure (a bad wallet, a transient Horizon error) does not stop the
+ * sweep for everyone else.
+ */
+export async function runEarningsReconciliationSweep(): Promise<void> {
+  const freelancers = await loadActiveFreelancerWallets();
+  if (freelancers.length === 0) return;
+
+  logger.info(
+    { count: freelancers.length },
+    "[EarningsReconciliationJob] Starting proactive reconciliation sweep",
+  );
+
+  const to = new Date();
+  const from = new Date(to.getTime() - RECONCILIATION_WINDOW_MS);
+
+  let processed = 0;
+  let backfilled = 0;
+  let flagged = 0;
+  let failed = 0;
+
+  for (let i = 0; i < freelancers.length; i += BATCH_SIZE) {
+    const batch = freelancers.slice(i, i + BATCH_SIZE);
+    await Promise.all(
+      batch.map(async (freelancer) => {
+        try {
+          const result = await reconcileAndRemediate(freelancer.walletAddress, from, to);
+          processed += 1;
+          backfilled += result.remediation.backfilled;
+          flagged += result.remediation.flaggedForReview;
+        } catch (err) {
+          failed += 1;
+          logger.error(
+            { err, userId: freelancer.id, wallet: freelancer.walletAddress },
+            "[EarningsReconciliationJob] Failed to reconcile freelancer",
+          );
+        }
+      }),
+    );
+  }
+
+  logger.info(
+    { processed, backfilled, flagged, failed },
+    "[EarningsReconciliationJob] Sweep complete",
+  );
+}
+
+export function startEarningsReconciliationJob(): void {
+  void runEarningsReconciliationSweep();
+  setInterval(() => {
+    void runEarningsReconciliationSweep();
+  }, POLL_INTERVAL_MS);
+  logger.info("[EarningsReconciliationJob] Scheduled — runs every 15 minutes");
+}

--- a/backend/src/lib/cache.ts
+++ b/backend/src/lib/cache.ts
@@ -152,3 +152,17 @@ export function generateJobCacheKey(jobId: string): string {
 export function generateJobOnChainStatusCacheKey(jobId: string): string {
   return `job:onchain-status:${jobId}`;
 }
+
+/**
+ * Generate cache key for a freelancer's Horizon on-chain payment window
+ * (issue #874). Shared across every backend instance via Redis so a payment
+ * fetched by one instance is visible to all others, rather than each process
+ * building its own independent, inconsistent view.
+ */
+export function generateOnChainPaymentsCacheKey(
+  walletAddress: string,
+  from: Date,
+  to: Date,
+): string {
+  return `earnings:onchain:${walletAddress}:${from.toISOString()}:${to.toISOString()}`;
+}

--- a/backend/src/routes/__tests__/freelancer.earnings.test.ts
+++ b/backend/src/routes/__tests__/freelancer.earnings.test.ts
@@ -11,8 +11,13 @@ jest.mock("../../middleware/auth", () => ({
 }));
 
 // ── Mock the Horizon reconciliation service ──
+// `reconcileAndRemediate` now owns matching + remediation for the reconcile
+// route (issue #874); `fetchOnChainPayments`/`loadDbEarnings` remain mocked
+// separately since the export route still calls them directly.
 jest.mock("../../services/earnings-reconciliation.service", () => ({
   fetchOnChainPayments: jest.fn(),
+  loadDbEarnings: jest.fn(),
+  reconcileAndRemediate: jest.fn(),
 }));
 
 // ── Mock Prisma ──
@@ -20,7 +25,6 @@ jest.mock("@prisma/client", () => {
   const actual = jest.requireActual("@prisma/client") as typeof import("@prisma/client");
   const mockPrisma = {
     user: { findUnique: jest.fn() },
-    transaction: { findMany: jest.fn() },
     $queryRaw: jest.fn(),
   };
   return {
@@ -31,15 +35,20 @@ jest.mock("@prisma/client", () => {
 
 import { PrismaClient } from "@prisma/client";
 import freelancerRouter from "../freelancer.routes";
-import { fetchOnChainPayments } from "../../services/earnings-reconciliation.service";
+import {
+  fetchOnChainPayments,
+  loadDbEarnings,
+  reconcileAndRemediate,
+} from "../../services/earnings-reconciliation.service";
 import type { ApiError } from "../../middleware/error";
 
 const prismaMock = new PrismaClient() as unknown as {
   user: { findUnique: jest.Mock };
-  transaction: { findMany: jest.Mock };
   $queryRaw: jest.Mock;
 };
 const fetchOnChainMock = fetchOnChainPayments as jest.Mock;
+const loadDbEarningsMock = loadDbEarnings as jest.Mock;
+const reconcileAndRemediateMock = reconcileAndRemediate as jest.Mock;
 
 const app = express();
 app.use(express.json());
@@ -55,40 +64,85 @@ const freelancer = {
   walletAddress: "GFREELANCER",
 };
 
+function reconciliationResult(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    range: { from: "2026-01-01T00:00:00.000Z", to: "2026-01-31T00:00:00.000Z" },
+    summary: {
+      onChainCount: 0,
+      dbCount: 0,
+      matchedCount: 0,
+      onChainOnlyCount: 0,
+      dbOnlyCount: 0,
+      allMatched: true,
+    },
+    matched: [],
+    onChainOnly: [],
+    dbOnly: [],
+    remediation: { backfilled: 0, alreadyRemediated: 0, flaggedForReview: 0 },
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   prismaMock.user.findUnique.mockResolvedValue(freelancer);
 });
 
 describe("GET /api/freelancers/earnings/reconcile", () => {
-  it("classifies matched, on-chain-only, and db-only payments", async () => {
-    prismaMock.transaction.findMany.mockResolvedValue([
-      {
-        txHash: "HASH_MATCHED",
-        jobId: "job-1",
-        amount: 100,
-        createdAt: new Date("2026-01-10T00:00:00Z"),
-        job: { id: "job-1", title: "Build API", category: "Backend", client: { username: "acme" } },
-      },
-      {
-        txHash: "HASH_DB_ONLY",
-        jobId: "job-2",
-        amount: 50,
-        createdAt: new Date("2026-01-12T00:00:00Z"),
-        job: { id: "job-2", title: "Frontend", category: "Frontend", client: { username: "acme" } },
-      },
-    ]);
-
-    fetchOnChainMock.mockResolvedValue([
-      { txHash: "HASH_MATCHED", memoJobId: "job-1", amount: 100, assetCode: "XLM", createdAt: "2026-01-10T00:00:00Z", from: "GCLIENT" },
-      { txHash: "HASH_ONCHAIN_ONLY", memoJobId: "job-9", amount: 75, assetCode: "XLM", createdAt: "2026-01-11T00:00:00Z", from: "GCLIENT" },
-    ]);
+  it("returns the classification and remediation summary from reconcileAndRemediate", async () => {
+    reconcileAndRemediateMock.mockResolvedValue(
+      reconciliationResult({
+        summary: {
+          onChainCount: 2,
+          dbCount: 2,
+          matchedCount: 1,
+          onChainOnlyCount: 1,
+          dbOnlyCount: 1,
+          allMatched: false,
+        },
+        matched: [
+          {
+            txHash: "HASH_MATCHED",
+            jobId: "job-1",
+            jobTitle: "Build API",
+            amount: 100,
+            onChainAmount: 100,
+            createdAt: "2026-01-10T00:00:00Z",
+          },
+        ],
+        onChainOnly: [
+          {
+            txHash: "HASH_ONCHAIN_ONLY",
+            memoJobId: "job-9",
+            amount: 75,
+            assetCode: "XLM",
+            createdAt: "2026-01-11T00:00:00Z",
+            horizonUrl: "https://horizon-testnet.stellar.org/transactions/HASH_ONCHAIN_ONLY",
+          },
+        ],
+        dbOnly: [
+          {
+            txHash: "HASH_DB_ONLY",
+            jobId: "job-2",
+            jobTitle: "Frontend",
+            amount: 50,
+            createdAt: "2026-01-12T00:00:00Z",
+          },
+        ],
+        remediation: { backfilled: 1, alreadyRemediated: 0, flaggedForReview: 1 },
+      }),
+    );
 
     const res = await request(app).get(
       "/api/freelancers/earnings/reconcile?from=2026-01-01&to=2026-01-31",
     );
 
     expect(res.status).toBe(200);
+    expect(reconcileAndRemediateMock).toHaveBeenCalledWith(
+      "GFREELANCER",
+      new Date("2026-01-01"),
+      new Date("2026-01-31"),
+    );
     expect(res.body.summary).toMatchObject({
       onChainCount: 2,
       dbCount: 2,
@@ -101,31 +155,17 @@ describe("GET /api/freelancers/earnings/reconcile", () => {
     expect(res.body.onChainOnly[0].txHash).toBe("HASH_ONCHAIN_ONLY");
     expect(res.body.onChainOnly[0].horizonUrl).toContain("HASH_ONCHAIN_ONLY");
     expect(res.body.dbOnly[0].txHash).toBe("HASH_DB_ONLY");
-  });
-
-  it("matches by memo jobId when tx hashes differ", async () => {
-    prismaMock.transaction.findMany.mockResolvedValue([
-      {
-        txHash: "DB_HASH",
-        jobId: "job-1",
-        amount: 100,
-        createdAt: new Date("2026-01-10T00:00:00Z"),
-        job: { id: "job-1", title: "Build API", category: "Backend", client: { username: "acme" } },
-      },
-    ]);
-    fetchOnChainMock.mockResolvedValue([
-      { txHash: "CHAIN_HASH", memoJobId: "job-1", amount: 100, assetCode: "XLM", createdAt: "2026-01-10T00:00:00Z", from: "GCLIENT" },
-    ]);
-
-    const res = await request(app).get("/api/freelancers/earnings/reconcile");
-
-    expect(res.status).toBe(200);
-    expect(res.body.summary).toMatchObject({ matchedCount: 1, onChainOnlyCount: 0, dbOnlyCount: 0, allMatched: true });
+    // The route is no longer read-only: the remediation summary comes back
+    // to the caller too (issue #874).
+    expect(res.body.remediation).toEqual({
+      backfilled: 1,
+      alreadyRemediated: 0,
+      flaggedForReview: 1,
+    });
   });
 
   it("returns 502 when Horizon is unreachable", async () => {
-    prismaMock.transaction.findMany.mockResolvedValue([]);
-    fetchOnChainMock.mockRejectedValue(new Error("horizon down"));
+    reconcileAndRemediateMock.mockRejectedValue(new Error("horizon down"));
 
     const res = await request(app).get("/api/freelancers/earnings/reconcile");
     expect(res.status).toBe(502);
@@ -136,24 +176,28 @@ describe("GET /api/freelancers/earnings/reconcile", () => {
       "/api/freelancers/earnings/reconcile?from=2026-02-01&to=2026-01-01",
     );
     expect(res.status).toBe(400);
+    expect(reconcileAndRemediateMock).not.toHaveBeenCalled();
   });
 
   it("returns 403 for non-freelancers", async () => {
     prismaMock.user.findUnique.mockResolvedValue({ ...freelancer, role: "CLIENT" });
     const res = await request(app).get("/api/freelancers/earnings/reconcile");
     expect(res.status).toBe(403);
+    expect(reconcileAndRemediateMock).not.toHaveBeenCalled();
   });
 });
 
 describe("GET /api/freelancers/earnings/export", () => {
   it("returns a downloadable CSV with all required fields", async () => {
-    prismaMock.transaction.findMany.mockResolvedValue([
+    loadDbEarningsMock.mockResolvedValue([
       {
         txHash: "HASH_1",
         jobId: "job-1",
+        jobTitle: "Smart Contract, Dev",
+        clientName: "acme",
+        category: "Smart Contract",
         amount: 120.5,
         createdAt: new Date("2026-01-10T00:00:00Z"),
-        job: { id: "job-1", title: "Smart Contract, Dev", category: "Smart Contract", client: { username: "acme" } },
       },
     ]);
     fetchOnChainMock.mockResolvedValue([
@@ -176,13 +220,15 @@ describe("GET /api/freelancers/earnings/export", () => {
   });
 
   it("marks rows unverified when Horizon is unreachable", async () => {
-    prismaMock.transaction.findMany.mockResolvedValue([
+    loadDbEarningsMock.mockResolvedValue([
       {
         txHash: "HASH_1",
         jobId: "job-1",
+        jobTitle: "Job",
+        clientName: "acme",
+        category: "X",
         amount: 10,
         createdAt: new Date("2026-01-10T00:00:00Z"),
-        job: { id: "job-1", title: "Job", category: "X", client: { username: "acme" } },
       },
     ]);
     fetchOnChainMock.mockRejectedValue(new Error("down"));

--- a/backend/src/routes/freelancer.routes.ts
+++ b/backend/src/routes/freelancer.routes.ts
@@ -7,14 +7,16 @@ import { validate } from "../middleware/validation";
 import { freelancerSearchQuerySchema, getUserByIdParamSchema } from "../schemas";
 import { searchFreelancers } from "../services/freelancer-search.service";
 import { ReputationService } from "../services/reputation.service";
-import { fetchOnChainPayments } from "../services/earnings-reconciliation.service";
+import {
+  fetchOnChainPayments,
+  loadDbEarnings,
+  reconcileAndRemediate,
+} from "../services/earnings-reconciliation.service";
 import { logger } from "../lib/logger";
-import { config, MAX_PAGE_SIZE } from "../config";
+import { MAX_PAGE_SIZE } from "../config";
 
 const router = Router();
 const prisma = new PrismaClient();
-
-const EARNING_TX_TYPES = [TransactionType.RELEASE, TransactionType.DISPUTE_PAYOUT] as const;
 
 /**
  * Default reconciliation/export window: last 90 days.
@@ -368,52 +370,6 @@ async function requireFreelancerWallet(
   return { userId: user.id, wallet: user.walletAddress };
 }
 
-interface EarningsRecord {
-  txHash: string;
-  jobId: string | null;
-  jobTitle: string | null;
-  clientName: string | null;
-  category: string | null;
-  amount: number;
-  createdAt: Date;
-}
-
-/** Load DB earnings (RELEASE / DISPUTE_PAYOUT) for a wallet within a date range. */
-async function loadDbEarnings(
-  wallet: string,
-  from: Date,
-  to: Date,
-): Promise<EarningsRecord[]> {
-  const txs = await prisma.transaction.findMany({
-    where: {
-      toAddress: wallet,
-      type: { in: [...EARNING_TX_TYPES] },
-      createdAt: { gte: from, lte: to },
-    },
-    orderBy: { createdAt: "desc" },
-    include: {
-      job: {
-        select: {
-          id: true,
-          title: true,
-          category: true,
-          client: { select: { username: true } },
-        },
-      },
-    },
-  });
-
-  return txs.map((tx) => ({
-    txHash: tx.txHash,
-    jobId: tx.jobId,
-    jobTitle: tx.job?.title ?? null,
-    clientName: tx.job?.client?.username ?? null,
-    category: tx.job?.category ?? null,
-    amount: tx.amount ?? 0,
-    createdAt: tx.createdAt,
-  }));
-}
-
 /**
  * GET /api/freelancers/earnings/reconcile?from=<ISO>&to=<ISO>
  * Cross-check DB earnings records against on-chain escrow releases from Horizon.
@@ -422,6 +378,13 @@ async function loadDbEarnings(
  *  - matched: present in both Horizon and the DB (joined by jobId memo / txHash)
  *  - onChainOnly: settled on-chain but missing from the DB (indicates a sync failure)
  *  - dbOnly: recorded in the DB but not found on-chain in the window
+ *
+ * Unlike before #874, this is no longer read-only: `onChainOnly` discrepancies
+ * are automatically backfilled (idempotently) and `dbOnly` discrepancies are
+ * flagged in the audit trail for manual review, via the same
+ * `reconcileAndRemediate` the proactive background job uses — so loading this
+ * page fixes discrepancies immediately rather than only reporting them, and a
+ * freelancer who never loads it still gets fixed by the scheduled sweep.
  */
 router.get(
   "/earnings/reconcile",
@@ -436,99 +399,15 @@ router.get(
     const from = q.from ?? fallback.from;
     const to = q.to ?? fallback.to;
 
-    const dbRecords = await loadDbEarnings(auth.wallet, from, to);
-
-    let onChainPayments: Awaited<ReturnType<typeof fetchOnChainPayments>>;
+    let result: Awaited<ReturnType<typeof reconcileAndRemediate>>;
     try {
-      onChainPayments = await fetchOnChainPayments(auth.wallet, from, to);
+      result = await reconcileAndRemediate(auth.wallet, from, to);
     } catch (err) {
       logger.error({ err, wallet: auth.wallet }, "[Reconciliation] Horizon fetch failed");
       return res.status(502).json({ error: "Unable to reach the Stellar network for reconciliation." });
     }
 
-    // Index DB records by txHash and by jobId for matching.
-    const dbByTxHash = new Map(dbRecords.map((r) => [r.txHash, r]));
-    const dbByJobId = new Map(
-      dbRecords.filter((r) => r.jobId).map((r) => [r.jobId as string, r]),
-    );
-
-    const matchedTxHashes = new Set<string>();
-    const matched: Array<{
-      txHash: string;
-      jobId: string | null;
-      jobTitle: string | null;
-      amount: number;
-      onChainAmount: number;
-      createdAt: string;
-    }> = [];
-    const onChainOnly: Array<{
-      txHash: string;
-      memoJobId: string | null;
-      amount: number;
-      assetCode: string;
-      createdAt: string;
-      horizonUrl: string;
-    }> = [];
-
-    for (const payment of onChainPayments) {
-      const dbRecord =
-        dbByTxHash.get(payment.txHash) ??
-        (payment.memoJobId ? dbByJobId.get(payment.memoJobId) : undefined);
-
-      if (dbRecord) {
-        matchedTxHashes.add(dbRecord.txHash);
-        matched.push({
-          txHash: payment.txHash,
-          jobId: dbRecord.jobId,
-          jobTitle: dbRecord.jobTitle,
-          amount: dbRecord.amount,
-          onChainAmount: payment.amount,
-          createdAt: payment.createdAt,
-        });
-      } else {
-        onChainOnly.push({
-          txHash: payment.txHash,
-          memoJobId: payment.memoJobId,
-          amount: payment.amount,
-          assetCode: payment.assetCode,
-          createdAt: payment.createdAt,
-          horizonUrl: `${config.stellar.horizonUrl.replace(/\/+$/, "")}/transactions/${payment.txHash}`,
-        });
-      }
-    }
-
-    const dbOnly = dbRecords
-      .filter((r) => !matchedTxHashes.has(r.txHash))
-      .map((r) => ({
-        txHash: r.txHash,
-        jobId: r.jobId,
-        jobTitle: r.jobTitle,
-        amount: r.amount,
-        createdAt: r.createdAt.toISOString(),
-      }));
-
-    // on_chain_only entries indicate the DB failed to record a settled payment.
-    if (onChainOnly.length > 0) {
-      logger.warn(
-        { userId: auth.userId, wallet: auth.wallet, count: onChainOnly.length },
-        "[Reconciliation] On-chain payments missing from DB — possible sync failure",
-      );
-    }
-
-    res.json({
-      range: { from: from.toISOString(), to: to.toISOString() },
-      summary: {
-        onChainCount: onChainPayments.length,
-        dbCount: dbRecords.length,
-        matchedCount: matched.length,
-        onChainOnlyCount: onChainOnly.length,
-        dbOnlyCount: dbOnly.length,
-        allMatched: onChainOnly.length === 0 && dbOnly.length === 0,
-      },
-      matched,
-      onChainOnly,
-      dbOnly,
-    });
+    res.json(result);
   }),
 );
 

--- a/backend/src/services/__tests__/earnings-reconciliation.service.test.ts
+++ b/backend/src/services/__tests__/earnings-reconciliation.service.test.ts
@@ -185,7 +185,11 @@ describe("fetchOnChainPayments — shared Redis cache across backend instances",
   });
 
   it("falls back to a direct Horizon fetch (not a crash) when Redis is unreachable", async () => {
-    const RedisClient = (jest.requireMock("../../lib/redis") as { default: any }).default;
+    const RedisClient = (
+      jest.requireMock("../../lib/redis") as {
+        default: { isRedisConnected: jest.Mock; connect: jest.Mock };
+      }
+    ).default;
     RedisClient.isRedisConnected.mockReturnValue(false);
     RedisClient.connect.mockRejectedValueOnce(new Error("ECONNREFUSED"));
 
@@ -318,6 +322,6 @@ describe("flagDbOnlyForReview — never auto-deletes", () => {
     expect(mockTransaction.upsert).not.toHaveBeenCalled();
     // No delete method exists on the mock at all — flagging must never call
     // one, so there is nothing wired up for it to reach.
-    expect((mockTransaction as any).delete).toBeUndefined();
+    expect((mockTransaction as Record<string, unknown>).delete).toBeUndefined();
   });
 });

--- a/backend/src/services/__tests__/earnings-reconciliation.service.test.ts
+++ b/backend/src/services/__tests__/earnings-reconciliation.service.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for the earnings reconciliation cache migration and automated
+ * remediation (issue #874):
+ *
+ *  - The Horizon payment cache is Redis-backed and shared across backend
+ *    instances, not a per-process Map — a cache write triggered by "instance A"
+ *    is visible to "instance B" without a second Horizon fetch.
+ *  - `onChainOnly` discrepancies are automatically, idempotently backfilled
+ *    into the DB and every backfill is recorded in the audit trail.
+ *  - `dbOnly` discrepancies are flagged for manual review, never auto-deleted
+ *    or mutated.
+ */
+
+// ─── Prisma mock ─────────────────────────────────────────────────────────────
+
+const mockTransaction = {
+  findMany: jest.fn(),
+  findUnique: jest.fn(),
+  upsert: jest.fn(),
+};
+const mockJob = {
+  findUnique: jest.fn(),
+};
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    transaction: mockTransaction,
+    job: mockJob,
+  })),
+}));
+
+// ─── Shared fake Redis — a single in-memory store simulating the ONE real
+// Redis server every backend instance connects to. Two calls into
+// `fetchOnChainPayments` in this file both hit this same object, exactly as
+// two separate backend processes would both hit the same external Redis. ───
+
+const fakeRedisStore = new Map<string, string>();
+const fakeRedis = {
+  get: jest.fn(async (key: string) => fakeRedisStore.get(key) ?? null),
+  setex: jest.fn(async (key: string, _ttl: number, value: string) => {
+    fakeRedisStore.set(key, value);
+    return "OK";
+  }),
+  del: jest.fn(async (...keys: string[]) => {
+    let count = 0;
+    for (const k of keys) {
+      if (fakeRedisStore.delete(k)) count += 1;
+    }
+    return count;
+  }),
+  keys: jest.fn(async () => Array.from(fakeRedisStore.keys())),
+};
+
+jest.mock("../../lib/redis", () => ({
+  __esModule: true,
+  default: {
+    isRedisConnected: jest.fn(() => true),
+    getInstance: jest.fn(() => fakeRedis),
+    connect: jest.fn(async () => {}),
+  },
+}));
+
+jest.mock("../../lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock("../../config", () => ({
+  config: { stellar: { horizonUrl: "https://horizon-testnet.stellar.org" } },
+}));
+
+// ─── Audit service mock ──────────────────────────────────────────────────────
+
+const mockAuditRecord = jest.fn();
+jest.mock("../audit.service", () => ({
+  AuditService: { record: (...args: unknown[]) => mockAuditRecord(...args) },
+}));
+
+// ─── Horizon SDK mock ────────────────────────────────────────────────────────
+//
+// Models the exact chain fetchOnChainPayments calls:
+//   server.payments().forAccount(w).order("asc").limit(n).call()
+// then repeatedly `.next()` until a page comes back empty.
+
+interface FakeHorizonRecord {
+  type: string;
+  to?: string;
+  from?: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  created_at: string;
+  transaction_hash: string;
+  transaction: () => Promise<{ memo_type?: string; memo?: string }>;
+}
+
+let horizonPages: FakeHorizonRecord[][] = [[]];
+let horizonCallCount = 0;
+
+function buildPage(index: number) {
+  const records = horizonPages[index] ?? [];
+  return {
+    records,
+    next: async () => buildPage(index + 1),
+  };
+}
+
+jest.mock("@stellar/stellar-sdk", () => ({
+  Horizon: {
+    Server: jest.fn().mockImplementation(() => ({
+      payments: () => ({
+        forAccount: () => ({
+          order: () => ({
+            limit: () => ({
+              call: async () => {
+                horizonCallCount += 1;
+                return buildPage(0);
+              },
+            }),
+          }),
+        }),
+      }),
+    })),
+  },
+}));
+
+// ─── Import after mocks are in place ────────────────────────────────────────
+
+import {
+  fetchOnChainPayments,
+  remediateOnChainOnly,
+  flagDbOnlyForReview,
+  type OnChainOnlyEarning,
+  type DbOnlyEarning,
+} from "../earnings-reconciliation.service";
+
+function makeMemoRecord(overrides: Partial<FakeHorizonRecord> = {}): FakeHorizonRecord {
+  return {
+    type: "payment",
+    to: "GFREELANCER",
+    from: "GCLIENT",
+    amount: "100.0000000",
+    asset_type: "native",
+    created_at: "2026-01-10T00:00:00Z",
+    transaction_hash: "HASH_A",
+    transaction: async () => ({ memo_type: "text", memo: "job-1" }),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fakeRedisStore.clear();
+  horizonPages = [[]];
+  horizonCallCount = 0;
+});
+
+// ─── Cross-instance Redis cache sharing ──────────────────────────────────────
+
+describe("fetchOnChainPayments — shared Redis cache across backend instances", () => {
+  it("a cache write from one simulated instance is visible to another, without a second Horizon fetch", async () => {
+    horizonPages = [[makeMemoRecord()]];
+
+    const from = new Date("2026-01-01T00:00:00Z");
+    const to = new Date("2026-01-31T00:00:00Z");
+
+    // "Instance A" handles the first request: cache miss, fetches Horizon,
+    // and writes the result into the shared Redis store.
+    const resultFromInstanceA = await fetchOnChainPayments("GFREELANCER", from, to);
+    expect(horizonCallCount).toBe(1);
+    expect(resultFromInstanceA).toHaveLength(1);
+    expect(resultFromInstanceA[0].txHash).toBe("HASH_A");
+
+    // Prove the write actually landed in the shared store, not some
+    // per-call/in-memory structure private to the first call.
+    expect(fakeRedisStore.size).toBe(1);
+
+    // "Instance B": a *separate* call simulating a different backend process.
+    // It reads from the exact same fakeRedisStore Map — the thing standing in
+    // for the one real Redis server both instances would be connected to.
+    // Unlike the old per-process Map cache, this must be a cache HIT.
+    const resultFromInstanceB = await fetchOnChainPayments("GFREELANCER", from, to);
+
+    expect(horizonCallCount).toBe(1); // no second Horizon call — served from Redis
+    expect(resultFromInstanceB).toEqual(resultFromInstanceA);
+  });
+
+  it("falls back to a direct Horizon fetch (not a crash) when Redis is unreachable", async () => {
+    const RedisClient = (jest.requireMock("../../lib/redis") as { default: any }).default;
+    RedisClient.isRedisConnected.mockReturnValue(false);
+    RedisClient.connect.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    horizonPages = [[makeMemoRecord({ transaction_hash: "HASH_NOCACHE" })]];
+
+    const result = await fetchOnChainPayments(
+      "GFREELANCER",
+      new Date("2026-01-01T00:00:00Z"),
+      new Date("2026-01-31T00:00:00Z"),
+    );
+
+    expect(result[0].txHash).toBe("HASH_NOCACHE");
+    expect(horizonCallCount).toBe(1);
+  });
+});
+
+// ─── Idempotent onChainOnly remediation ──────────────────────────────────────
+
+describe("remediateOnChainOnly — idempotent backfill", () => {
+  const payment: OnChainOnlyEarning = {
+    txHash: "HASH_ONCHAIN_ONLY",
+    memoJobId: "job-42",
+    amount: 250,
+    assetCode: "XLM",
+    createdAt: "2026-01-15T12:00:00.000Z",
+    horizonUrl: "https://horizon-testnet.stellar.org/transactions/HASH_ONCHAIN_ONLY",
+  };
+
+  it("backfills a missing Transaction row and records an audit entry on first remediation", async () => {
+    mockTransaction.findUnique.mockResolvedValueOnce(null); // not present yet
+    mockJob.findUnique.mockResolvedValueOnce({ id: "job-42" });
+    mockTransaction.upsert.mockResolvedValueOnce({});
+
+    const outcome = await remediateOnChainOnly("GFREELANCER", payment);
+
+    expect(outcome).toBe("created");
+    expect(mockTransaction.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { txHash: "HASH_ONCHAIN_ONLY" },
+        update: {},
+        create: expect.objectContaining({
+          txHash: "HASH_ONCHAIN_ONLY",
+          jobId: "job-42",
+          toAddress: "GFREELANCER",
+          amount: 250,
+          type: "RELEASE",
+          status: "SUCCESS",
+          createdAt: new Date("2026-01-15T12:00:00.000Z"),
+        }),
+      }),
+    );
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "ADMIN_ACTION",
+        action: "earnings_reconciliation.onchain_only_backfilled",
+        actorId: "system",
+        target: "HASH_ONCHAIN_ONLY",
+      }),
+    );
+  });
+
+  it("does not create a duplicate record or a second audit entry when run again for the same txHash", async () => {
+    // Second call: the row is now present (findUnique returns it).
+    mockTransaction.findUnique.mockResolvedValueOnce({ id: "existing-row" });
+    mockJob.findUnique.mockResolvedValueOnce({ id: "job-42" });
+    mockTransaction.upsert.mockResolvedValueOnce({});
+
+    const outcome = await remediateOnChainOnly("GFREELANCER", payment);
+
+    expect(outcome).toBe("already_remediated");
+    // The upsert's `update: {}` means an existing row is never overwritten —
+    // still called (upsert is what makes it idempotent), but no new audit
+    // entry should be written for a replay.
+    expect(mockTransaction.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ update: {} }),
+    );
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("leaves jobId null when the memo does not name a real job", async () => {
+    mockTransaction.findUnique.mockResolvedValueOnce(null);
+    mockJob.findUnique.mockResolvedValueOnce(null); // memo job doesn't exist
+    mockTransaction.upsert.mockResolvedValueOnce({});
+
+    await remediateOnChainOnly("GFREELANCER", { ...payment, memoJobId: "bogus-job-id" });
+
+    expect(mockTransaction.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ create: expect.objectContaining({ jobId: null }) }),
+    );
+  });
+
+  it("preserves the on-chain settlement date rather than the backfill's insertion time", async () => {
+    mockTransaction.findUnique.mockResolvedValueOnce(null);
+    mockJob.findUnique.mockResolvedValueOnce(null);
+    mockTransaction.upsert.mockResolvedValueOnce({});
+
+    await remediateOnChainOnly("GFREELANCER", payment);
+
+    const createArg = mockTransaction.upsert.mock.calls[0][0].create;
+    expect(createArg.createdAt.toISOString()).toBe("2026-01-15T12:00:00.000Z");
+  });
+});
+
+// ─── dbOnly — cautious, non-destructive handling ─────────────────────────────
+
+describe("flagDbOnlyForReview — never auto-deletes", () => {
+  const dbOnlyRecord: DbOnlyEarning = {
+    txHash: "HASH_DB_ONLY",
+    jobId: "job-7",
+    jobTitle: "Landing page",
+    amount: 80,
+    createdAt: "2026-01-05T00:00:00.000Z",
+  };
+
+  it("records an audit entry and never calls delete/update on the Transaction row", async () => {
+    await flagDbOnlyForReview("GFREELANCER", dbOnlyRecord);
+
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "ADMIN_ACTION",
+        action: "earnings_reconciliation.db_only_flagged_for_review",
+        actorId: "system",
+        target: "HASH_DB_ONLY",
+        metadata: expect.objectContaining({ jobId: "job-7", amount: 80 }),
+      }),
+    );
+
+    // The whole point of the cautious path: nothing destructive ever happens
+    // to the Transaction table for a dbOnly record.
+    expect(mockTransaction.upsert).not.toHaveBeenCalled();
+    // No delete method exists on the mock at all — flagging must never call
+    // one, so there is nothing wired up for it to reach.
+    expect((mockTransaction as any).delete).toBeUndefined();
+  });
+});

--- a/backend/src/services/earnings-reconciliation.service.ts
+++ b/backend/src/services/earnings-reconciliation.service.ts
@@ -1,7 +1,12 @@
 import { Horizon } from "@stellar/stellar-sdk";
+import { PrismaClient, TransactionType } from "@prisma/client";
 import { config } from "../config";
 import { logger } from "../lib/logger";
 import { withUpstreamTimeout } from "../lib/upstream-timeout";
+import { cache, generateOnChainPaymentsCacheKey } from "../lib/cache";
+import { AuditService } from "./audit.service";
+
+const prisma = new PrismaClient();
 
 /**
  * A payment that settled on-chain to the freelancer's wallet, as reported by Horizon.
@@ -20,20 +25,25 @@ export interface OnChainPayment {
 }
 
 const HORIZON_PAGE_LIMIT = 200;
-const CACHE_TTL_MS = 60_000; // 60 seconds
+const CACHE_TTL_SECONDS = 60; // 60 seconds
+
+/** DB earnings record shape used for matching against on-chain payments. */
+export interface EarningsRecord {
+  txHash: string;
+  jobId: string | null;
+  jobTitle: string | null;
+  clientName: string | null;
+  category: string | null;
+  amount: number;
+  createdAt: Date;
+}
+
+export const EARNING_TX_TYPES = ["RELEASE", "DISPUTE_PAYOUT"] as const;
+
+/** The type assigned to a Transaction row created by automated remediation. */
+const REMEDIATION_TX_TYPE = "RELEASE" as const;
 
 let cachedServer: Horizon.Server | null = null;
-
-interface CacheEntry {
-  payments: OnChainPayment[];
-  expiresAt: number;
-}
-
-const paymentCache = new Map<string, CacheEntry>();
-
-function cacheKey(wallet: string, from: Date, to: Date): string {
-  return `${wallet}:${from.toISOString()}:${to.toISOString()}`;
-}
 
 function getServer(): Horizon.Server {
   if (!cachedServer) {
@@ -65,23 +75,11 @@ const PAYMENT_TYPES = new Set([
   "path_payment_strict_receive",
 ]);
 
-/**
- * Fetch every inbound payment credited to `walletAddress` between `from` and
- * `to`, walking Horizon's pagination cursor until the window closes.
- *
- * Results are cached for CACHE_TTL_MS to avoid hammering Horizon when the
- * reconciliation panel is polled frequently.
- */
-export async function fetchOnChainPayments(
+async function fetchOnChainPaymentsUncached(
   walletAddress: string,
   from: Date,
   to: Date,
 ): Promise<OnChainPayment[]> {
-  const key = cacheKey(walletAddress, from, to);
-  const cached = paymentCache.get(key);
-  if (cached && Date.now() < cached.expiresAt) {
-    return cached.payments;
-  }
   const server = getServer();
   const results: OnChainPayment[] = [];
 
@@ -135,6 +133,349 @@ export async function fetchOnChainPayments(
     });
   }
 
-  paymentCache.set(key, { payments: results, expiresAt: Date.now() + CACHE_TTL_MS });
   return results;
+}
+
+/**
+ * Fetch every inbound payment credited to `walletAddress` between `from` and
+ * `to`, walking Horizon's pagination cursor until the window closes.
+ *
+ * Results are cached in the shared Redis instance for `CACHE_TTL_SECONDS` so
+ * every backend instance sees the same recently-fetched window instead of each
+ * process building its own independent, inconsistent view under horizontal
+ * scaling (issue #874). Redis is unreachable-safe: `cache()` falls back to a
+ * direct Horizon fetch (no caching) rather than failing the request.
+ */
+export async function fetchOnChainPayments(
+  walletAddress: string,
+  from: Date,
+  to: Date,
+): Promise<OnChainPayment[]> {
+  const key = generateOnChainPaymentsCacheKey(walletAddress, from, to);
+  const { data } = await cache(key, CACHE_TTL_SECONDS, () =>
+    fetchOnChainPaymentsUncached(walletAddress, from, to),
+  );
+  return data;
+}
+
+/** Load DB earnings (RELEASE / DISPUTE_PAYOUT) for a wallet within a date range. */
+export async function loadDbEarnings(
+  wallet: string,
+  from: Date,
+  to: Date,
+): Promise<EarningsRecord[]> {
+  const txs = await prisma.transaction.findMany({
+    where: {
+      toAddress: wallet,
+      type: { in: [...EARNING_TX_TYPES] as TransactionType[] },
+      createdAt: { gte: from, lte: to },
+    },
+    orderBy: { createdAt: "desc" },
+    include: {
+      job: {
+        select: {
+          id: true,
+          title: true,
+          category: true,
+          client: { select: { username: true } },
+        },
+      },
+    },
+  });
+
+  return txs.map((tx) => ({
+    txHash: tx.txHash,
+    jobId: tx.jobId,
+    jobTitle: tx.job?.title ?? null,
+    clientName: tx.job?.client?.username ?? null,
+    category: tx.job?.category ?? null,
+    amount: tx.amount ?? 0,
+    createdAt: tx.createdAt,
+  }));
+}
+
+export interface MatchedEarning {
+  txHash: string;
+  jobId: string | null;
+  jobTitle: string | null;
+  amount: number;
+  onChainAmount: number;
+  createdAt: string;
+}
+
+export interface OnChainOnlyEarning {
+  txHash: string;
+  memoJobId: string | null;
+  amount: number;
+  assetCode: string;
+  createdAt: string;
+  horizonUrl: string;
+}
+
+export interface DbOnlyEarning {
+  txHash: string;
+  jobId: string | null;
+  jobTitle: string | null;
+  amount: number;
+  createdAt: string;
+}
+
+export interface ReconciliationResult {
+  range: { from: string; to: string };
+  summary: {
+    onChainCount: number;
+    dbCount: number;
+    matchedCount: number;
+    onChainOnlyCount: number;
+    dbOnlyCount: number;
+    allMatched: boolean;
+  };
+  matched: MatchedEarning[];
+  onChainOnly: OnChainOnlyEarning[];
+  dbOnly: DbOnlyEarning[];
+}
+
+function horizonTxUrl(txHash: string): string {
+  return `${config.stellar.horizonUrl.replace(/\/+$/, "")}/transactions/${txHash}`;
+}
+
+/**
+ * Cross-check DB earnings records against on-chain escrow releases from
+ * Horizon for a single wallet/window. Pure classification — no side effects —
+ * shared by the on-demand route and the proactive background job so the
+ * matching logic has a single source of truth.
+ */
+export async function reconcileEarnings(
+  wallet: string,
+  from: Date,
+  to: Date,
+): Promise<ReconciliationResult> {
+  const [dbRecords, onChainPayments] = await Promise.all([
+    loadDbEarnings(wallet, from, to),
+    fetchOnChainPayments(wallet, from, to),
+  ]);
+
+  const dbByTxHash = new Map(dbRecords.map((r) => [r.txHash, r]));
+  const dbByJobId = new Map(dbRecords.filter((r) => r.jobId).map((r) => [r.jobId as string, r]));
+
+  const matchedTxHashes = new Set<string>();
+  const matched: MatchedEarning[] = [];
+  const onChainOnly: OnChainOnlyEarning[] = [];
+
+  for (const payment of onChainPayments) {
+    const dbRecord =
+      dbByTxHash.get(payment.txHash) ??
+      (payment.memoJobId ? dbByJobId.get(payment.memoJobId) : undefined);
+
+    if (dbRecord) {
+      matchedTxHashes.add(dbRecord.txHash);
+      matched.push({
+        txHash: payment.txHash,
+        jobId: dbRecord.jobId,
+        jobTitle: dbRecord.jobTitle,
+        amount: dbRecord.amount,
+        onChainAmount: payment.amount,
+        createdAt: payment.createdAt,
+      });
+    } else {
+      onChainOnly.push({
+        txHash: payment.txHash,
+        memoJobId: payment.memoJobId,
+        amount: payment.amount,
+        assetCode: payment.assetCode,
+        createdAt: payment.createdAt,
+        horizonUrl: horizonTxUrl(payment.txHash),
+      });
+    }
+  }
+
+  const dbOnly = dbRecords
+    .filter((r) => !matchedTxHashes.has(r.txHash))
+    .map((r) => ({
+      txHash: r.txHash,
+      jobId: r.jobId,
+      jobTitle: r.jobTitle,
+      amount: r.amount,
+      createdAt: r.createdAt.toISOString(),
+    }));
+
+  return {
+    range: { from: from.toISOString(), to: to.toISOString() },
+    summary: {
+      onChainCount: onChainPayments.length,
+      dbCount: dbRecords.length,
+      matchedCount: matched.length,
+      onChainOnlyCount: onChainOnly.length,
+      dbOnlyCount: dbOnly.length,
+      allMatched: onChainOnly.length === 0 && dbOnly.length === 0,
+    },
+    matched,
+    onChainOnly,
+    dbOnly,
+  };
+}
+
+export interface RemediationSummary {
+  backfilled: number;
+  alreadyRemediated: number;
+  flaggedForReview: number;
+}
+
+/**
+ * Automatically remediate an `onChainOnly` discrepancy: a payment Horizon
+ * confirms but the DB has no record of, indicating a DB sync failure. Backfills
+ * the missing Transaction row from the on-chain data.
+ *
+ * Idempotent: `txHash` is uniquely constrained, so upserting with an empty
+ * `update` is a no-op on a record that already exists — running reconciliation
+ * twice (e.g. the on-demand route and the scheduled job overlapping, or two
+ * job ticks in a row) never creates a duplicate or double-counts earnings.
+ *
+ * Every backfill is recorded in the tamper-evident audit trail so the
+ * correction is traceable (issue #874's auditability requirement).
+ *
+ * Returns "created" only when this call actually inserted the row, so callers
+ * can distinguish a fresh backfill from a no-op replay.
+ */
+export async function remediateOnChainOnly(
+  wallet: string,
+  payment: OnChainOnlyEarning,
+): Promise<"created" | "already_remediated"> {
+  // Only attach a jobId FK if the memo actually names a real job — an
+  // unrelated or malformed memo must not corrupt the ledger with a false link.
+  let jobId: string | null = null;
+  if (payment.memoJobId) {
+    const job = await prisma.job.findUnique({
+      where: { id: payment.memoJobId },
+      select: { id: true },
+    });
+    if (job) jobId = job.id;
+  }
+
+  const before = await prisma.transaction.findUnique({
+    where: { txHash: payment.txHash },
+    select: { id: true },
+  });
+
+  await prisma.transaction.upsert({
+    where: { txHash: payment.txHash },
+    update: {}, // Already present — idempotent no-op, not a second insert.
+    create: {
+      txHash: payment.txHash,
+      jobId,
+      toAddress: wallet,
+      amount: payment.amount,
+      type: REMEDIATION_TX_TYPE,
+      status: "SUCCESS",
+      createdAt: new Date(payment.createdAt),
+    },
+  });
+
+  if (before) {
+    return "already_remediated";
+  }
+
+  await AuditService.record({
+    category: "ADMIN_ACTION",
+    action: "earnings_reconciliation.onchain_only_backfilled",
+    actorId: "system",
+    target: payment.txHash,
+    metadata: {
+      wallet,
+      jobId,
+      memoJobId: payment.memoJobId,
+      amount: payment.amount,
+      assetCode: payment.assetCode,
+      onChainCreatedAt: payment.createdAt,
+      horizonUrl: payment.horizonUrl,
+    },
+  });
+
+  return "created";
+}
+
+/**
+ * Flag a `dbOnly` discrepancy (a DB record with no matching on-chain payment
+ * in the window) for manual review. Unlike `onChainOnly`, this path is
+ * deliberately non-destructive: a missing on-chain match could mean the
+ * payment hasn't settled yet, settled outside the queried window, or the DB
+ * record is genuinely wrong — none of which an automated job can safely
+ * disambiguate, so it never deletes or mutates the Transaction row. The flag
+ * itself is the audit entry a human reviewer later triages.
+ */
+export async function flagDbOnlyForReview(wallet: string, record: DbOnlyEarning): Promise<void> {
+  await AuditService.record({
+    category: "ADMIN_ACTION",
+    action: "earnings_reconciliation.db_only_flagged_for_review",
+    actorId: "system",
+    target: record.txHash,
+    metadata: {
+      wallet,
+      jobId: record.jobId,
+      jobTitle: record.jobTitle,
+      amount: record.amount,
+      dbCreatedAt: record.createdAt,
+      reason: "No matching on-chain payment found in the reconciliation window.",
+    },
+  });
+}
+
+/**
+ * Reconcile a single freelancer's earnings and automatically remediate what
+ * can be safely remediated: backfill `onChainOnly` discrepancies (idempotent)
+ * and flag `dbOnly` discrepancies for manual review (never auto-deleted).
+ *
+ * Shared by the on-demand `/earnings/reconcile` route and the proactive
+ * scheduled job, so a discrepancy gets fixed whether a freelancer happens to
+ * load the page or not.
+ */
+export async function reconcileAndRemediate(
+  wallet: string,
+  from: Date,
+  to: Date,
+): Promise<ReconciliationResult & { remediation: RemediationSummary }> {
+  const result = await reconcileEarnings(wallet, from, to);
+
+  const remediation: RemediationSummary = {
+    backfilled: 0,
+    alreadyRemediated: 0,
+    flaggedForReview: 0,
+  };
+
+  for (const payment of result.onChainOnly) {
+    try {
+      const outcome = await remediateOnChainOnly(wallet, payment);
+      if (outcome === "created") {
+        remediation.backfilled += 1;
+      } else {
+        remediation.alreadyRemediated += 1;
+      }
+    } catch (err) {
+      logger.error(
+        { err, wallet, txHash: payment.txHash },
+        "[Reconciliation] Failed to remediate onChainOnly discrepancy",
+      );
+    }
+  }
+
+  for (const record of result.dbOnly) {
+    try {
+      await flagDbOnlyForReview(wallet, record);
+      remediation.flaggedForReview += 1;
+    } catch (err) {
+      logger.error(
+        { err, wallet, txHash: record.txHash },
+        "[Reconciliation] Failed to flag dbOnly discrepancy for review",
+      );
+    }
+  }
+
+  if (result.onChainOnly.length > 0) {
+    logger.warn(
+      { wallet, count: result.onChainOnly.length, remediation },
+      "[Reconciliation] On-chain payments missing from DB — auto-remediated",
+    );
+  }
+
+  return { ...result, remediation };
 }

--- a/frontend/src/app/dashboard/__tests__/earnings-page.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/earnings-page.test.tsx
@@ -128,12 +128,28 @@ describe("Earnings page preset shortcuts", () => {
     await renderPage();
     await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
 
+    // `last_30_days` is already the default preset on a fresh mount (no stored
+    // localStorage override — see "highlights the active preset button"
+    // above), so clicking it directly here would set state to the same value
+    // it already holds. React bails out of that update (Object.is-equal), so
+    // no re-render, no `range` recompute, and no second fetch ever fires.
+    // Move to a different preset first so the later click to `last_30_days`
+    // is a genuine state transition, exactly like a real user switching back.
+    fireEvent.click(screen.getByTestId("preset-all_time"));
+    await waitFor(() => {
+      const latest = mockedAxios.get.mock.calls.map((c) => c[0] as string).at(-1);
+      expect(latest).toBeDefined();
+      expect(latest).not.toMatch(/from=/);
+    });
+
     mockedAxios.get.mockClear();
     fireEvent.click(screen.getByTestId("preset-last_30_days"));
 
     await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
 
-    const url: string = mockedAxios.get.mock.calls[0][0] as string;
+    const url: string = mockedAxios.get.mock.calls
+      .map((c) => c[0] as string)
+      .find((u) => u.includes("/earnings?"))!;
     expect(url).toMatch(/from=/);
 
     const fromMatch = url.match(/from=([^&]+)/);


### PR DESCRIPTION
## Summary

Closes #874.

The earnings reconciliation cache was a module-level `Map`, so each backend instance built its own independent, inconsistent view of recent Horizon payments under horizontal scaling. Reconciliation itself was purely read-only: `GET /freelancer/earnings/reconcile` logged discrepancies but never corrected anything, and nothing ran proactively — a discrepancy only surfaced when a freelancer happened to load the page.

## What changed

**Shared cache.** `fetchOnChainPayments` (`backend/src/services/earnings-reconciliation.service.ts`) now caches through the same Redis helper (`backend/src/lib/cache.ts`) already used for job listings and user profiles, instead of a local `Map`. A payment window fetched by one backend instance is immediately visible to every other instance (60s TTL). Falls back to a direct Horizon fetch if Redis is unreachable — matches the existing cache-aside convention, never a hard failure.

**Shared reconciliation core.** The `matched`/`onChainOnly`/`dbOnly` bucket-matching logic that used to live inline in the route handler is now `reconcileEarnings()` in the service, so the on-demand route and the new background job compute it identically instead of drifting apart.

**Automated remediation.**
- `onChainOnly` (Horizon confirms a payment, the DB has no record) — `remediateOnChainOnly()` backfills the missing `Transaction` row from the on-chain data. Idempotent via `Transaction.txHash`'s unique constraint (`upsert(..., update: {})`), so replaying reconciliation never creates a duplicate. `jobId` is only attached when the memo names a real, existing `Job` — an unrelated or malformed memo can't corrupt the ledger with a false link. `createdAt` is set to the on-chain settlement time, not the backfill's insertion time, so historical earnings charts stay accurate.
- `dbOnly` (a DB record with no matching on-chain payment) — deliberately **not** auto-corrected. `flagDbOnlyForReview()` only writes an audit entry; the missing match could mean the payment hasn't settled yet, settled outside the window, or the DB record is genuinely wrong, and an automated job can't safely tell which. A human reviewer triages from the audit trail.
- Both paths write through the existing tamper-evident, hash-chained `AuditService` (#875) with `actorId: "system"` — every automated correction is traceable and independently verifiable via `AuditService.verifyChain()`.

**Proactive scheduling.** `backend/src/jobs/earnings-reconciliation.job.ts` follows the existing `setInterval` job convention (`pending-tx.job.ts`, `escrow-ttl.job.ts`): every 15 minutes it reconciles every active freelancer (has a wallet, not deleted, not suspended — deliberately *not* gated on recent login, since the point is catching freelancers who are *not* currently loading the page) over a trailing 48-hour window, batched 25 at a time so one freelancer's failure doesn't stop the sweep for everyone else. Wired into `backend/src/index.ts` alongside the other startup jobs.

The `/earnings/reconcile` route now also runs remediation (via the same shared function the job uses) and returns a `remediation: { backfilled, alreadyRemediated, flaggedForReview }` summary alongside the existing buckets.

## Tests

- `backend/src/services/__tests__/earnings-reconciliation.service.test.ts` (new, 7 tests) — a cache write from one simulated backend instance is visible to another without a second Horizon call (and falls back gracefully when Redis is down); `onChainOnly` backfill is idempotent and only links a memo that resolves to a real `Job`; the on-chain settlement date is preserved on backfill; `dbOnly` discrepancies are audit-flagged and never touch the `Transaction` table.
- `backend/src/__tests__/earnings-reconciliation-job.test.ts` (new, 4 tests) — the scheduled sweep reconciles an inactive freelancer (no page load, no route call — only the job itself) purely on its own schedule; batches freelancers and one failure doesn't stop the sweep; no-ops with no active freelancers or a null wallet.
- `backend/src/routes/__tests__/freelancer.earnings.test.ts` (updated) — reconcile route now asserts against `reconcileAndRemediate`'s full response shape including the `remediation` summary; export route tests updated to mock `loadDbEarnings` directly since that logic moved into the service.

All verification commands below were run locally.

## Pre-existing issues found and disclosed (not introduced by this PR)

- **`backend/src/routes/admin.ts` had a literal unresolved git merge-conflict marker** (`<<<<<<< HEAD` / `=======` / `>>>>>>> e75ac4f`) committed directly to `main`, breaking `tsc` for the entire backend. I fixed it as a prerequisite since it blocked verifying my own changes: the conflicted region was an exact duplicate of three routes (`/horizon/status`, `/horizon/cursor`, `/horizon/dlq/replay`) already defined earlier in the same file, so I removed the duplicate and fixed one real name mismatch inside it (`replayDLQ` → the actual exported `replayHorizonDlq`). Confirmed via a clean worktree that `origin/main` itself failed `tsc --noEmit` the same way before this fix.
- **`admin.horizon.test.ts` has 2 failing tests, pre-existing on `main`** (confirmed in a clean worktree, independent of this branch). The route's `/horizon/cursor` and `/horizon/dlq/replay` handlers use inline `prisma.horizonCursor`/hardcoded logic that doesn't match what the test expects (calls to `overrideHorizonCursor()`/`replayHorizonDlq()` from `horizon-listener.service.ts` with no response wrapping). Deeper look: `overrideHorizonCursor` operates on a completely different model (`SyncState.lastIndexedLedger`) than the route's `prisma.horizonCursor`, and `replayHorizonDlq()` itself is a hardcoded stub (`return { replayed: 0, failed: 0 }`, comment: "Simplistic implementation for tests"). Real, worth fixing, but a separate, non-trivial undertaking (reconciling two parallel data models plus building a real DLQ replay) unrelated to earnings reconciliation — out of scope here.
- **5 more pre-existing failures, unrelated to anything in this diff**, all confirmed failing identically on a clean `origin/main` worktree: `admin.validation.test.ts` (2), `dispute.validation.test.ts` (2), `report.validation.test.ts` (1) all fail with the same root cause — an `express-rate-limit` IPv6 `keyGenerator` compatibility error (`ERR_ERL_KEY_GEN_IPV6`) thrown from `report.routes.ts`'s rate limiter — and `escrow-ttl.test.ts` (2) / `evidence-chunked-upload.test.ts` (4), unrelated to rate-limiting, also confirmed pre-existing.
- **`npm run lint` fails repo-wide regardless of this PR** (`--max-warnings=0`, currently ~500+ pre-existing warnings/errors across the codebase, unrelated to files this PR touches). Every file this PR created or modified is fully lint-clean (verified below).

## Verification

```
cd backend
npx tsc --noEmit                                   # 0 errors
npx eslint <files this PR touches> --max-warnings=0  # 0 problems
ENCRYPTION_KEY=<64-char hex> npx jest \
  src/services/__tests__/earnings-reconciliation.service.test.ts \
  src/__tests__/earnings-reconciliation-job.test.ts \
  src/routes/__tests__/freelancer.earnings.test.ts   # 17/17 passing
ENCRYPTION_KEY=<64-char hex> npm test -- --passWithNoTests
  # 530 passed, 13 pre-existing failures (see above), all confirmed
  # to fail identically on a clean origin/main worktree
```

Rebased cleanly onto current `main` with zero merge conflicts (`git merge-base --is-ancestor origin/main HEAD`).
