### PR TITLE
feat: add focus trap and aria-label to UnsavedChangesModal

### DIFF
--- a/frontend/src/app/jobs/[id]/JobDetailClient.tsx
+++ b/frontend/src/app/jobs/[id]/JobDetailClient.tsx
@@ -120,6 +120,8 @@ export default function JobDetailClient() {
   } = useQuery<Job | null>({
     queryKey: ["job", id],
     queryFn: async () => {
+      // Read the auth token with the correct key (stellarmarket_jwt) falling
+      // back to the legacy "token" key for backward compatibility (#958).
       const token = localStorage.getItem("stellarmarket_jwt") ?? localStorage.getItem("token");
       const res = await axios.get(`${API_URL}/jobs/${id}`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},

--- a/frontend/src/app/jobs/[id]/JobDetailClient.tsx
+++ b/frontend/src/app/jobs/[id]/JobDetailClient.tsx
@@ -120,7 +120,7 @@ export default function JobDetailClient() {
   } = useQuery<Job | null>({
     queryKey: ["job", id],
     queryFn: async () => {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt") ?? localStorage.getItem("token");
       const res = await axios.get(`${API_URL}/jobs/${id}`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
       });
@@ -135,7 +135,7 @@ export default function JobDetailClient() {
   } = useQuery<Review[]>({
     queryKey: ["reviews", id],
     queryFn: async () => {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt") ?? localStorage.getItem("token");
       const res = await axios.get<PaginatedResponse<Review>>(`${API_URL}/reviews`, {
         params: { jobId: id, page: 1, limit: 50 },
         headers: token ? { Authorization: `Bearer ${token}` } : {},
@@ -150,7 +150,7 @@ export default function JobDetailClient() {
   } = useQuery<{ applied: boolean; appId: string | null }>({
     queryKey: ["application", id, user?.id],
     queryFn: async () => {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt") ?? localStorage.getItem("token");
       if (!token || !user) return { applied: false, appId: null };
       try {
         const res = await axios.get<PaginatedResponse<Application>>(`${API_URL}/applications`, {
@@ -184,7 +184,7 @@ export default function JobDetailClient() {
   } = useInfiniteQuery({
     queryKey: ["applications", id],
     queryFn: async ({ pageParam = 1 }: { pageParam: number }) => {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt") ?? localStorage.getItem("token");
       const res = await axios.get<{ data: Application[]; total: number; page: number; totalPages: number }>(
         `${API_URL}/jobs/${id}/applications`,
         {
@@ -273,7 +273,7 @@ export default function JobDetailClient() {
   ) => {
     setActioningApp(appId);
     try {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt") ?? localStorage.getItem("token");
       await axios.put(
         `${API_URL}/applications/${appId}/status`,
         { status },
@@ -383,7 +383,7 @@ export default function JobDetailClient() {
     }
 
     try {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt") ?? localStorage.getItem("token");
       const txType = MONEY_MOVING_TX_TYPE[action.confirmType];
       const meta = txType
         ? { type: txType, jobId: String(id), milestoneId: action.milestoneId }
@@ -487,7 +487,7 @@ export default function JobDetailClient() {
     setError(null);
 
     try {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt") ?? localStorage.getItem("token");
       let endpoint = "";
       let payload: Record<string, unknown> = { jobId: id };
       let type: PendingOnChainAction["confirmType"] = "CREATE_JOB";
@@ -593,7 +593,7 @@ export default function JobDetailClient() {
     setError(null);
     setProcessing(true);
     try {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt") ?? localStorage.getItem("token");
       await axios.patch(
         `${API_URL}/jobs/${id}/complete`,
         {},
@@ -743,7 +743,7 @@ export default function JobDetailClient() {
   ) => {
     setError(null);
     try {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt") ?? localStorage.getItem("token");
       let endpoint = "";
       let type: PendingOnChainAction["confirmType"] = "PROPOSE_REVISION";
       let title = "";

--- a/frontend/src/app/services/new/page.tsx
+++ b/frontend/src/app/services/new/page.tsx
@@ -12,7 +12,7 @@ const categories = ["Development", "Design", "Writing", "Marketing", "Other"];
 
 export default function NewServicePage() {
   const router = useRouter();
-  const { user, isLoading } = useAuth();
+  const { user, isLoading, token } = useAuth();
   const { toast } = useToast();
   const [loading, setLoading] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -91,8 +91,6 @@ export default function NewServicePage() {
     setErrors({});
 
     try {
-      const token = localStorage.getItem("token");
-      
       await axios.post(
         `${API_URL}/services`,
         {

--- a/frontend/src/app/services/new/page.tsx
+++ b/frontend/src/app/services/new/page.tsx
@@ -13,6 +13,10 @@ const STORAGE_KEY = "service-form-draft";
 
 export default function NewServicePage() {
   const router = useRouter();
+  // Destructure `token` from useAuth() so the Authorization header uses the
+  // correct key (stellarmarket_jwt) rather than reading the non-existent
+  // localStorage key "token" (issue #950).  token is null when not logged in,
+  // which matches the original guard behaviour.
   const { user, isLoading, token } = useAuth();
   const { toast } = useToast();
   const [loading, setLoading] = useState(false);

--- a/frontend/src/components/FilterSidebar.tsx
+++ b/frontend/src/components/FilterSidebar.tsx
@@ -226,7 +226,14 @@ export default function FilterSidebar({
             type="number"
             placeholder="Min"
             value={filters.minBudget}
-            onChange={(e) => updateFilter("minBudget", e.target.value)}
+            onChange={(e) => {
+              const val = e.target.value;
+              if (val && filters.maxBudget && Number(val) > Number(filters.maxBudget)) {
+                updateFilter("minBudget", filters.maxBudget);
+              } else {
+                updateFilter("minBudget", val);
+              }
+            }}
             className="input-field text-sm"
             min={0}
           />
@@ -236,7 +243,14 @@ export default function FilterSidebar({
             type="number"
             placeholder="Max"
             value={filters.maxBudget}
-            onChange={(e) => updateFilter("maxBudget", e.target.value)}
+            onChange={(e) => {
+              const val = e.target.value;
+              if (val && filters.minBudget && Number(val) < Number(filters.minBudget)) {
+                updateFilter("maxBudget", filters.minBudget);
+              } else {
+                updateFilter("maxBudget", val);
+              }
+            }}
             className="input-field text-sm"
             min={0}
           />

--- a/frontend/src/components/FilterSidebar.tsx
+++ b/frontend/src/components/FilterSidebar.tsx
@@ -217,7 +217,12 @@ export default function FilterSidebar({
         </div>
       </FilterSection>
 
-      {/* Budget Range */}
+      {/* Budget Range
+           The min/max budget inputs auto-clamp to prevent a contradictory
+           range (e.g. Min = 5000, Max = 100) which would silently return
+           zero results from the API.  If the user enters a min above the
+           current max, min is clamped down to max; if they enter a max
+           below the current min, max is raised to min (issue #954).     */}
       <FilterSection title="Budget (XLM)">
         <div className="flex gap-2">
           <label htmlFor="filter-budget-min" className="sr-only">Minimum budget</label>

--- a/frontend/src/components/UnsavedChangesModal.tsx
+++ b/frontend/src/components/UnsavedChangesModal.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useRef } from "react";
 import { AlertTriangle, X } from "lucide-react";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 
 type Props = {
   isOpen: boolean;
@@ -9,11 +11,15 @@ type Props = {
 };
 
 export default function UnsavedChangesModal({ isOpen, onConfirm, onCancel }: Props) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(modalRef, { open: isOpen, onClose: onCancel });
+
   if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm animate-in fade-in duration-200">
       <div 
+        ref={modalRef}
         className="bg-theme-card border border-theme-border rounded-xl shadow-xl max-w-md w-full p-6 animate-in zoom-in-95 duration-200"
         role="dialog"
         aria-modal="true"
@@ -25,6 +31,7 @@ export default function UnsavedChangesModal({ isOpen, onConfirm, onCancel }: Pro
           <button 
             onClick={onCancel}
             className="text-theme-text hover:text-theme-heading transition-colors"
+            aria-label="Close unsaved changes modal"
           >
             <X size={20} />
           </button>

--- a/frontend/src/components/UnsavedChangesModal.tsx
+++ b/frontend/src/components/UnsavedChangesModal.tsx
@@ -11,6 +11,9 @@ type Props = {
 };
 
 export default function UnsavedChangesModal({ isOpen, onConfirm, onCancel }: Props) {
+  // Create a ref to the dialog container so useFocusTrap can restrict
+  // keyboard focus within the modal while it is open, preventing users
+  // from tabbing to elements behind the overlay (issues #966).
   const modalRef = useRef<HTMLDivElement>(null);
   useFocusTrap(modalRef, { open: isOpen, onClose: onCancel });
 


### PR DESCRIPTION
## PR Description

### Summary

**Four accessibility and bugfix patches across the frontend:**

- #966 — Added useFocusTrap hook and aria-label to UnsavedChangesModal to trap keyboard focus and label the close button for screen readers
- #950 — Fixed services/new page reading the wrong localStorage key ("token" → now uses token from useAuth()) for authenticated service submissions
- #954 — Added min/max budget clamping in FilterSidebar so contradictory ranges (e.g. Min > Max) are auto-corrected instead of silently returning zero results
- #958 — Replaced all 9 bare localStorage.getItem("token") calls in JobDetailClient.tsx with the correct fallback pattern matching the rest of the codebase

**Checklist**

- Focus is trapped within UnsavedChangesModal while open, matching useFocusTrap usage elsewhere
- Close button has a descriptive aria-label
- Escape/close behavior is consistent with other modals using useFocusTrap
- services/new reads the correct token (from useAuth()) before submitting
- Setting a min budget greater than max is auto-corrected (clamped)
- Setting a max budget lower than min is auto-corrected (clamped)
- All 9 localStorage.getItem("token") call sites in JobDetailClient.tsx read the correct fallback key
- Applied-filters chips never display a contradictory min/max pair

Closes #966
Closes #950
Closes #954
Closes #958