### PR TITLE
fix: atomic, idempotent job + milestone creation (#1125)

### DIFF
--- a/ATOMIC_JOB_CREATION.md
+++ b/ATOMIC_JOB_CREATION.md
@@ -1,0 +1,71 @@
+# Atomic, Idempotent Job + Milestone Creation (issue #1125)
+
+Fixes the non-transactional, non-idempotent job-creation flow in `JobWizard`.
+
+## The bug
+
+`JobWizard.onSubmit` used to `POST /jobs`, then loop `POST /milestones` one by
+one. If the job was created but a milestone POST failed partway through:
+
+- the job was left persisted with a **partial milestone set**;
+- the localStorage draft was **not** cleared, but re-clicking "Publish Job" ran
+  the whole sequence again, creating a **duplicate job**;
+- the client-computed `totalBudget` could **diverge** from what was persisted.
+
+## The fix
+
+### Backend — one atomic, idempotent endpoint
+
+New `POST /jobs/with-milestones` (`backend/src/routes/job.routes.ts`):
+
+- **Atomic**: the job and all milestones are created inside a single
+  `prisma.$transaction` (a nested `job.create`), so it is all-or-nothing. A
+  failure on any milestone rolls the entire thing back — no partial job.
+- **Idempotent (DB-guaranteed)**: an optional client `idempotencyKey` is stored
+  on a new unique `Job.idempotencyKey` column. A retry with the same key returns
+  the original job (`200`) instead of creating a second one. A concurrent race
+  that trips the unique constraint (`P2002`) is caught and resolved to the
+  existing job, so duplication is impossible even under concurrency — and this
+  holds regardless of Redis availability (unlike the Redis-only idempotency
+  middleware, which fails open).
+- **Consistent budget**: the job budget is **derived server-side** from the sum
+  of milestone amounts, so the persisted total can never diverge from the
+  milestone set. It is validated against the platform minimum.
+- A key belonging to another user returns `409`; non-clients `403`; unknown
+  category `422`; empty milestones `400`.
+
+Schema: `backend/prisma/schema.prisma` adds `idempotencyKey String? @unique`;
+migration `20260801000000_add_job_idempotency_key`. NULL keys stay distinct under
+Postgres, so existing/legacy jobs are unaffected.
+
+The original `POST /jobs` and `POST /milestones` endpoints are left intact for
+backward compatibility.
+
+### Frontend — single call + safe draft lifecycle
+
+`frontend/src/app/post-job/JobWizard.tsx`:
+
+- `onSubmit` now makes the single atomic call instead of the job-then-loop.
+- A stable `idempotencyKey` is generated once and persisted
+  (`job-wizard-idempotency-key`). A retry after a failure reuses the **same**
+  key, so the backend cannot create a duplicate.
+- The draft **and** the key are cleared only on confirmed success; on failure
+  both are kept so the user can retry without re-entering anything.
+- A `published` guard stops the draft auto-save effect from re-writing a draft
+  we just cleared on success (a real lifecycle race the old code was exposed to).
+
+## Tests
+
+- `backend/src/routes/__tests__/job-atomic-creation.test.ts` (10): happy-path
+  atomic create + derived budget + 1-based order; **mid-sequence failure rolls
+  back with no partial job**; **retry with the same key returns the original job
+  and never calls create twice**; **P2002 race resolves to the existing job**;
+  cross-user key `409`; non-client `403`; below-minimum budget `422`; bad
+  category `422`; empty milestones `400`; auth required.
+- `frontend/src/app/post-job/__tests__/JobWizard.atomic.test.tsx` (4): single
+  atomic call carrying all milestones + a key; draft/key cleared only on success;
+  **draft + key preserved on failure (no navigation)**; **retry reuses the same
+  key (no duplicate)** and clears it after the eventual success.
+
+All 11 backend job/milestone suites and the full 232-test frontend suite pass;
+both typechecks are clean.

--- a/backend/prisma/migrations/20260801000000_add_job_idempotency_key/migration.sql
+++ b/backend/prisma/migrations/20260801000000_add_job_idempotency_key/migration.sql
@@ -1,0 +1,10 @@
+-- Add a unique, client-supplied idempotency key to Job so that atomic
+-- job+milestone creation can be safely retried after a partial failure without
+-- creating a duplicate job (issue #1125). NULL keys are allowed and are not
+-- subject to the unique constraint (Postgres treats NULLs as distinct).
+
+-- AlterTable
+ALTER TABLE "Job" ADD COLUMN "idempotencyKey" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Job_idempotencyKey_key" ON "Job"("idempotencyKey");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -216,6 +216,11 @@ model Job {
   clientId      String
   freelancerId  String?
   contractJobId String?      @unique
+  // Client-supplied key that makes atomic job+milestone creation idempotent:
+  // retrying a partially-failed "Publish Job" reuses the same key, and the
+  // unique constraint guarantees the retry returns the original job instead of
+  // creating a duplicate (issue #1125).
+  idempotencyKey String?     @unique
   escrowStatus  EscrowStatus @default(UNFUNDED)
   skills        String[]
   deadline      DateTime

--- a/backend/src/routes/__tests__/job-atomic-creation.test.ts
+++ b/backend/src/routes/__tests__/job-atomic-creation.test.ts
@@ -1,0 +1,287 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { config } from "../../config";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+// Atomic job+milestone creation (#1125). The handler runs its writes inside
+// `prisma.$transaction(cb)`; the mock invokes the callback with a `tx` that has
+// `job.create`, so a single rejection from `job.create` models a mid-sequence
+// failure that rolls the whole thing back (nothing persisted, nothing returned).
+jest.mock("@prisma/client", () => {
+  const mockPrisma = {
+    user: {
+      findUnique: jest.fn().mockResolvedValue({ role: "CLIENT", emailVerified: true }),
+    },
+    job: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+
+  class PrismaClientKnownRequestError extends Error {
+    code: string;
+    constructor(message: string, opts: { code: string }) {
+      super(message);
+      this.code = opts.code;
+    }
+  }
+
+  return {
+    PrismaClient: jest.fn(() => mockPrisma),
+    Prisma: { PrismaClientKnownRequestError },
+    JobStatus: { OPEN: "OPEN" },
+  };
+});
+
+jest.mock("../../lib/cache", () => ({
+  cache: jest.fn(),
+  invalidateCache: jest.fn(),
+  invalidateCacheKey: jest.fn(),
+  generateJobsCacheKey: jest.fn(() => "key"),
+  generateJobCacheKey: jest.fn(() => "key"),
+  generateJobOnChainStatusCacheKey: jest.fn(() => "key"),
+}));
+
+jest.mock("../../services/recommendation-queue.service", () => ({
+  RecommendationQueueService: { enqueueRebuild: jest.fn() },
+}));
+
+jest.mock("../../services/fraud-detection.service", () => ({
+  FraudDetectionService: { onJobCreated: jest.fn() },
+}));
+
+jest.mock("../../services/contract.service", () => ({
+  ContractService: {},
+}));
+
+jest.mock("../../socket", () => ({ getIo: jest.fn(() => ({ emit: jest.fn() })) }));
+
+import { PrismaClient, Prisma } from "@prisma/client";
+import jobRouter from "../job.routes";
+import { errorHandler } from "../../middleware/error";
+
+const prismaMock = new PrismaClient() as unknown as {
+  user: { findUnique: jest.Mock };
+  job: { findUnique: jest.Mock; create: jest.Mock };
+  $transaction: jest.Mock;
+};
+const jobMock = prismaMock.job;
+const userMock = prismaMock.user;
+const txMock = prismaMock.$transaction;
+
+const app = express();
+app.use(express.json());
+app.use("/api/jobs", jobRouter);
+app.use(errorHandler);
+
+const CLIENT_ID = "00000000-0000-4000-8000-000000000001";
+const OTHER_CLIENT_ID = "00000000-0000-4000-8000-000000000002";
+
+function authHeader(userId = CLIENT_ID) {
+  const token = jwt.sign({ userId }, config.jwtSecret, { expiresIn: "1h" });
+  return { Authorization: `Bearer ${token}` };
+}
+
+const futureDate = (days: number) =>
+  new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+
+function baseBody(overrides: Record<string, unknown> = {}) {
+  return {
+    title: "Build a Soroban DEX frontend",
+    description:
+      "Develop a responsive Stellar dApp frontend with escrow integration and tests.",
+    category: "Frontend",
+    skills: ["React", "TypeScript"],
+    deadline: futureDate(30),
+    paymentToken: "XLM",
+    milestones: [
+      { title: "Wireframes", description: "Design all screens", amount: 100, dueDate: futureDate(7) },
+      { title: "Implementation", description: "Build the components", amount: 200, dueDate: futureDate(14) },
+      { title: "Testing", description: "Write the test suite", amount: 150, dueDate: futureDate(21) },
+    ],
+    ...overrides,
+  };
+}
+
+/** Make `$transaction(cb)` run the callback against a tx whose job.create is `impl`. */
+function wireTransaction(impl: jest.Mock) {
+  txMock.mockImplementation(async (cb: (tx: unknown) => unknown) =>
+    cb({ job: { create: impl } }),
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  userMock.findUnique.mockResolvedValue({ role: "CLIENT", emailVerified: true });
+});
+
+describe("POST /api/jobs/with-milestones — atomic creation (#1125)", () => {
+  it("creates the job and all milestones in one transaction and returns 201", async () => {
+    const created = {
+      id: "job-1",
+      title: baseBody().title,
+      budget: 450,
+      clientId: CLIENT_ID,
+      milestones: [{ id: "m1" }, { id: "m2" }, { id: "m3" }],
+    };
+    const createImpl = jest.fn().mockResolvedValue(created);
+    wireTransaction(createImpl);
+
+    const res = await request(app)
+      .post("/api/jobs/with-milestones")
+      .set(authHeader())
+      .send(baseBody({ idempotencyKey: "idem-happy-0001" }));
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe("job-1");
+    // One transaction, one create, three nested milestones.
+    expect(txMock).toHaveBeenCalledTimes(1);
+    expect(createImpl).toHaveBeenCalledTimes(1);
+    const createArg = createImpl.mock.calls[0][0];
+    expect(createArg.data.milestones.create).toHaveLength(3);
+    // Budget is derived from the milestone amounts (100+200+150), not the client.
+    expect(createArg.data.budget).toBe(450);
+    // Milestones carry sequential 1-based order.
+    expect(createArg.data.milestones.create.map((m: { order: number }) => m.order)).toEqual([1, 2, 3]);
+  });
+
+  it("rolls back cleanly on a mid-sequence milestone failure — no partial job returned", async () => {
+    // Model the 3rd-of-5 failure: the single transactional create rejects, so
+    // nothing is persisted and no job is returned.
+    const createImpl = jest.fn().mockRejectedValue(new Error("milestone write failed"));
+    wireTransaction(createImpl);
+
+    const res = await request(app)
+      .post("/api/jobs/with-milestones")
+      .set(authHeader())
+      .send(baseBody());
+
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(res.body.id).toBeUndefined();
+    expect(txMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("is idempotent: retrying with the same key returns the original job, not a duplicate", async () => {
+    const original = { id: "job-1", clientId: CLIENT_ID, milestones: [{ id: "m1" }] };
+
+    // First attempt: no existing job, create succeeds.
+    jobMock.findUnique.mockResolvedValueOnce(null);
+    const createImpl = jest.fn().mockResolvedValue(original);
+    wireTransaction(createImpl);
+
+    const first = await request(app)
+      .post("/api/jobs/with-milestones")
+      .set(authHeader())
+      .send(baseBody({ idempotencyKey: "idem-retry-0001" }));
+    expect(first.status).toBe(201);
+
+    // Retry with the same key: the job now exists → return it, do NOT create again.
+    jobMock.findUnique.mockResolvedValueOnce(original);
+
+    const retry = await request(app)
+      .post("/api/jobs/with-milestones")
+      .set(authHeader())
+      .send(baseBody({ idempotencyKey: "idem-retry-0001" }));
+
+    expect(retry.status).toBe(200);
+    expect(retry.body.id).toBe("job-1");
+    // Create was only ever invoked for the first attempt — no duplicate job.
+    expect(createImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves a concurrent unique-constraint race (P2002) to the existing job", async () => {
+    const existing = { id: "job-1", clientId: CLIENT_ID, milestones: [] };
+    // No job found on the pre-check...
+    jobMock.findUnique.mockResolvedValueOnce(null);
+    // ...but the create loses the race and hits the unique constraint...
+    const p2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+    } as never);
+    wireTransaction(jest.fn().mockRejectedValue(p2002));
+    // ...so we fetch and return the job the winning request created.
+    jobMock.findUnique.mockResolvedValueOnce(existing);
+
+    const res = await request(app)
+      .post("/api/jobs/with-milestones")
+      .set(authHeader())
+      .send(baseBody({ idempotencyKey: "idem-race-0001" }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe("job-1");
+  });
+
+  it("returns 409 when the idempotency key belongs to another user", async () => {
+    jobMock.findUnique.mockResolvedValueOnce({
+      id: "job-1",
+      clientId: OTHER_CLIENT_ID,
+      milestones: [],
+    });
+
+    const res = await request(app)
+      .post("/api/jobs/with-milestones")
+      .set(authHeader())
+      .send(baseBody({ idempotencyKey: "idem-someone-else" }));
+
+    expect(res.status).toBe(409);
+    expect(txMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a non-client caller", async () => {
+    userMock.findUnique.mockResolvedValue({ role: "FREELANCER", emailVerified: true });
+
+    const res = await request(app)
+      .post("/api/jobs/with-milestones")
+      .set(authHeader())
+      .send(baseBody());
+
+    expect(res.status).toBe(403);
+    expect(txMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 when the derived budget is below the platform minimum", async () => {
+    const res = await request(app)
+      .post("/api/jobs/with-milestones")
+      .set(authHeader())
+      .send(
+        baseBody({
+          milestones: [
+            { title: "Tiny task", description: "A very small task", amount: 0.0000001, dueDate: futureDate(3) },
+          ],
+        }),
+      );
+
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("BudgetBelowMinimum");
+    expect(txMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 for an unrecognised category", async () => {
+    const res = await request(app)
+      .post("/api/jobs/with-milestones")
+      .set(authHeader())
+      .send(baseBody({ category: "web3-nonsense" }));
+
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("InvalidCategory");
+    expect(txMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when no milestones are provided", async () => {
+    const res = await request(app)
+      .post("/api/jobs/with-milestones")
+      .set(authHeader())
+      .send(baseBody({ milestones: [] }));
+
+    expect(res.status).toBe(400);
+    expect(txMock).not.toHaveBeenCalled();
+  });
+
+  it("requires authentication", async () => {
+    const res = await request(app)
+      .post("/api/jobs/with-milestones")
+      .send(baseBody());
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/src/routes/job.routes.ts
+++ b/backend/src/routes/job.routes.ts
@@ -11,6 +11,7 @@ import { RecommendationQueueService } from "../services/recommendation-queue.ser
 import { FraudDetectionService } from "../services/fraud-detection.service";
 import {
   createJobSchema,
+  createJobWithMilestonesSchema,
   updateJobSchema,
   getJobsQuerySchema,
   getJobByIdParamSchema,
@@ -35,7 +36,7 @@ import {
   ContractService,
   RevisionProposalView,
 } from "../services/contract.service";
-import { MAX_PAGE_SIZE } from "../config";
+import { MAX_PAGE_SIZE, config } from "../config";
 
 const router = Router();
 
@@ -917,6 +918,167 @@ router.post(
 
     // Near-real-time fraud/anomaly scoring (issue #900). Fire-and-forget: this
     // never blocks or fails job creation.
+    FraudDetectionService.onJobCreated(job.id, req.userId!);
+
+    try {
+      const { getIo } = await import("../socket");
+      const io = getIo();
+      io.emit("job:created", job);
+    } catch {
+      // Socket not initialized (e.g., in tests)
+    }
+
+    res.status(201).json(job);
+  }),
+);
+
+// Atomically create a job together with all of its milestones (issue #1125).
+//
+// This replaces the frontend's old "POST /jobs then N× POST /milestones" loop,
+// which could leave a job persisted with a partial milestone set if a milestone
+// call failed midway, and could create a duplicate job if the user retried.
+//
+// Guarantees:
+//  - Atomic: the job and every milestone are written in a single transaction —
+//    either all succeed or nothing is persisted.
+//  - Idempotent: an optional client-supplied `idempotencyKey` is stored uniquely
+//    on the job. A retry with the same key returns the original job instead of
+//    creating a second one, even across concurrent requests (unique-constraint
+//    race is caught and resolved to the existing job).
+//  - Consistent budget: the job budget is derived from the sum of milestone
+//    amounts, so the persisted total can never diverge from the milestones.
+router.post(
+  "/with-milestones",
+  authenticate,
+  validate({ body: createJobWithMilestonesSchema }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const user = await prisma.user.findUnique({
+      where: { id: req.userId },
+      select: { role: true },
+    });
+
+    if (!user || user.role !== "CLIENT") {
+      throw new AppError(ErrorCodes.FORBIDDEN, "Only clients can post jobs.", 403);
+    }
+
+    const {
+      title,
+      description,
+      skills,
+      deadline,
+      milestones,
+    } = req.body as {
+      title: string;
+      description: string;
+      skills: string[];
+      deadline: string;
+      milestones: Array<{
+        title: string;
+        description: string;
+        amount: number;
+        dueDate: string;
+      }>;
+    };
+    const category = req.body.category as string | undefined;
+    const paymentToken = req.body.paymentToken as string | undefined;
+    const idempotencyKey = req.body.idempotencyKey as string | undefined;
+
+    if (category && !isValidCategory(category)) {
+      return res.status(422).json({
+        code: "InvalidCategory",
+        message: `"${category}" is not a recognised category. Valid categories: ${VALID_CATEGORIES.join(", ")}.`,
+      });
+    }
+
+    // Budget is the sum of milestone amounts (7-dp rounded to match XLM scale),
+    // never taken from the client — this is what keeps the persisted total in
+    // lockstep with the milestone set.
+    const budget = Number(
+      milestones.reduce((sum, m) => sum + m.amount, 0).toFixed(7),
+    );
+    const platformMinimum = Number.isFinite(config.platformMinBudgetXlm)
+      ? config.platformMinBudgetXlm
+      : 1;
+    if (budget < platformMinimum) {
+      return res.status(422).json({
+        code: "BudgetBelowMinimum",
+        message: `Budget must be at least ${platformMinimum} XLM`,
+      });
+    }
+
+    // Idempotency fast-path: if we've already recorded this key, return the
+    // original job rather than creating another. A retry after a partial failure
+    // lands here and gets the completed job back.
+    if (idempotencyKey) {
+      const existing = await prisma.job.findUnique({
+        where: { idempotencyKey },
+        include: JOB_DETAIL_INCLUDE,
+      });
+      if (existing) {
+        if (existing.clientId !== req.userId) {
+          throw new AppError(
+            ErrorCodes.CONFLICT,
+            "This idempotency key belongs to another user's request.",
+            409,
+          );
+        }
+        return res.status(200).json(existing);
+      }
+    }
+
+    let job;
+    try {
+      // Nested writes in a single create are executed in one transaction by
+      // Prisma, so the job and all milestones commit together or not at all.
+      job = await prisma.$transaction((tx) =>
+        tx.job.create({
+          data: {
+            title,
+            description,
+            budget,
+            category: category || "General",
+            skills,
+            deadline: new Date(deadline),
+            clientId: req.userId!,
+            ...(paymentToken ? { paymentToken } : {}),
+            ...(idempotencyKey ? { idempotencyKey } : {}),
+            milestones: {
+              create: milestones.map((m, index) => ({
+                title: m.title,
+                description: m.description,
+                amount: m.amount,
+                dueDate: new Date(m.dueDate),
+                order: index + 1,
+              })),
+            },
+          },
+          include: JOB_DETAIL_INCLUDE,
+        }),
+      );
+    } catch (err) {
+      // Concurrent retry raced us to the same idempotency key: the unique
+      // constraint fired. Resolve to the job the other request created rather
+      // than surfacing an error or duplicating.
+      if (
+        idempotencyKey &&
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === "P2002"
+      ) {
+        const existing = await prisma.job.findUnique({
+          where: { idempotencyKey },
+          include: JOB_DETAIL_INCLUDE,
+        });
+        if (existing) {
+          return res.status(200).json(existing);
+        }
+      }
+      throw err;
+    }
+
+    await invalidateCache("jobs:list:*");
+    void RecommendationQueueService.enqueueRebuild(job.id);
+
+    // Near-real-time fraud/anomaly scoring (issue #900). Fire-and-forget.
     FraudDetectionService.onJobCreated(job.id, req.userId!);
 
     try {

--- a/backend/src/schemas/job.ts
+++ b/backend/src/schemas/job.ts
@@ -25,6 +25,61 @@ export const createJobSchema = z.object({
   category: z.string().min(2, "Category is required"),
 });
 
+/**
+ * A single milestone supplied inline when creating a job atomically (#1125).
+ * Mirrors `createMilestoneSchema` but without `jobId` (the job is created in the
+ * same request). Per-milestone amount only needs to be positive here; the job
+ * budget is derived from the sum of these amounts server-side.
+ */
+export const inlineMilestoneSchema = z.object({
+  title: z
+    .string()
+    .min(5, "Title must be at least 5 characters long")
+    .max(200, "Title must be less than 200 characters"),
+  description: z
+    .string()
+    .min(10, "Description must be at least 10 characters long")
+    .max(2000, "Description must be less than 2000 characters"),
+  amount: z.number().positive("Amount must be a positive number"),
+  dueDate: z.string().datetime("Invalid due date format"),
+});
+
+/**
+ * Atomic job+milestones creation (#1125). The job and all of its milestones are
+ * created in one transaction, so a partial failure can never leave a job with an
+ * inconsistent milestone set. `budget` is intentionally NOT accepted from the
+ * client — it is computed from the sum of milestone amounts, which removes any
+ * chance of the client's displayed total diverging from what is persisted.
+ * `idempotencyKey` ties a retry to the original attempt so re-submitting after a
+ * failure returns the original job instead of creating a duplicate.
+ */
+export const createJobWithMilestonesSchema = z.object({
+  title: z
+    .string()
+    .min(5, "Title must be at least 5 characters long")
+    .max(200, "Title must be less than 200 characters"),
+  description: z
+    .string()
+    .min(20, "Description must be at least 20 characters long")
+    .max(5000, "Description must be less than 5000 characters"),
+  skills: z
+    .array(z.string())
+    .min(1, "At least one skill is required")
+    .max(10, "Cannot have more than 10 skills"),
+  deadline: z.string().datetime("Invalid deadline format"),
+  category: z.string().min(2, "Category is required"),
+  paymentToken: z.string().min(1).max(64).optional(),
+  idempotencyKey: z
+    .string()
+    .min(8, "Idempotency key must be at least 8 characters")
+    .max(200, "Idempotency key must be less than 200 characters")
+    .optional(),
+  milestones: z
+    .array(inlineMilestoneSchema)
+    .min(1, "At least one milestone is required")
+    .max(20, "Cannot have more than 20 milestones"),
+});
+
 export const updateJobSchema = z.object({
   title: z
     .string()

--- a/frontend/src/app/post-job/JobWizard.tsx
+++ b/frontend/src/app/post-job/JobWizard.tsx
@@ -71,6 +71,35 @@ type FormValues = z.infer<typeof fullSchema>;
 
 const STORAGE_KEY = "job-wizard-draft";
 
+/**
+ * Stable idempotency key for a single publish attempt (#1125).
+ *
+ * The key is generated once and persisted in the draft, so that if the atomic
+ * job-creation request fails and the user clicks "Publish Job" again, the retry
+ * carries the SAME key. The backend then returns the original job instead of
+ * creating a duplicate. It is only cleared once creation is confirmed complete.
+ */
+function getOrCreateIdempotencyKey(): string {
+  try {
+    const existing = localStorage.getItem(IDEMPOTENCY_KEY_STORAGE);
+    if (existing) return existing;
+  } catch {
+    /* localStorage unavailable — fall through to a fresh key */
+  }
+  const key =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `job_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  try {
+    localStorage.setItem(IDEMPOTENCY_KEY_STORAGE, key);
+  } catch {
+    /* ignore persistence failure; the in-memory key is still used this attempt */
+  }
+  return key;
+}
+
+const IDEMPOTENCY_KEY_STORAGE = "job-wizard-idempotency-key";
+
 export default function JobWizard() {
   const { user, isLoading } = useAuth();
   const router = useRouter();
@@ -82,6 +111,9 @@ export default function JobWizard() {
     useState<(typeof PAYMENT_TOKENS)[number]>("XLM");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  // Set once the job is confirmed created, so the draft auto-save effect below
+  // stops re-persisting a draft we've just cleared on success (#1125).
+  const [published, setPublished] = useState(false);
 
   // Today's date in YYYY-MM-DD format for date input min attribute
   const todayStr = new Date().toISOString().split("T")[0];
@@ -156,14 +188,16 @@ export default function JobWizard() {
     [milestones],
   );
 
-  // Save draft to localStorage
+  // Save draft to localStorage. Skipped once the job is published so we don't
+  // re-create a draft we intentionally cleared on success (#1125).
   useEffect(() => {
+    if (published) return;
     const formData = getValues();
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({ formData, skills, paymentToken }),
     );
-  }, [watch(), skills, paymentToken, getValues]);
+  }, [watch(), skills, paymentToken, getValues, published]);
 
   // Validate milestones total matches intended budget in real-time
   useEffect(() => {
@@ -206,46 +240,61 @@ export default function JobWizard() {
     setSubmitting(true);
     setError("");
 
+    // One stable key for this publish attempt. Reused verbatim on retry so a
+    // partial failure never produces a duplicate job (#1125).
+    const idempotencyKey = getOrCreateIdempotencyKey();
+
     try {
       const token = localStorage.getItem("token");
 
+      // Single atomic call: the backend creates the job and every milestone in
+      // one transaction (all-or-nothing), so there is no window in which a job
+      // exists with a partial milestone set. The budget is derived server-side
+      // from the milestone amounts, so it can't diverge from what's persisted.
       const res = await axios.post(
-        `${API_URL}/jobs`,
+        `${API_URL}/jobs/with-milestones`,
         {
           title: values.title,
           description: values.description,
           category: values.category,
           deadline: new Date(values.deadline).toISOString(),
           skills,
-          budget: totalBudget,
           paymentToken,
+          idempotencyKey,
+          milestones: values.milestones.map((m) => ({
+            title: m.title,
+            description: m.description,
+            amount: Number.parseFloat(m.amount),
+            dueDate: new Date(m.deadline).toISOString(),
+          })),
         },
         { headers: { Authorization: `Bearer ${token}` } },
       );
 
-      for (const m of values.milestones) {
-        await axios.post(
-          `${API_URL}/milestones`,
-          {
-            jobId: res.data.id,
-            title: m.title,
-            description: m.description,
-            amount: Number.parseFloat(m.amount),
-            dueDate: m.deadline,
-          },
-          { headers: { Authorization: `Bearer ${token}` } },
-        );
-      }
-
+      // Only now — with the full job+milestones confirmed persisted — clear the
+      // draft and the idempotency key. On a failure both are intentionally kept
+      // so the user can retry the same attempt without re-entering anything and
+      // without risking a duplicate. `setPublished` first so the auto-save
+      // effect can't immediately rewrite the draft we're about to remove.
+      setPublished(true);
       localStorage.removeItem(STORAGE_KEY);
+      try {
+        localStorage.removeItem(IDEMPOTENCY_KEY_STORAGE);
+      } catch {
+        /* ignore */
+      }
       router.push(`/jobs/${res.data.id}`);
     } catch (err: unknown) {
       if (axios.isAxiosError(err)) {
         setError(
-          err.response?.data?.error || "Failed to post job. Please try again.",
+          err.response?.data?.error ||
+            err.response?.data?.message ||
+            "Failed to post job. Your draft is saved — please try again.",
         );
       } else {
-        setError("An unexpected error occurred.");
+        setError(
+          "An unexpected error occurred. Your draft is saved — please try again.",
+        );
       }
     } finally {
       setSubmitting(false);

--- a/frontend/src/app/post-job/JobWizard.tsx
+++ b/frontend/src/app/post-job/JobWizard.tsx
@@ -245,7 +245,10 @@ export default function JobWizard() {
     const idempotencyKey = getOrCreateIdempotencyKey();
 
     try {
-      const token = localStorage.getItem("token");
+      // Must match AuthContext's TOKEN_KEY ("stellarmarket_jwt"); the legacy
+      // "token" key is never set, so it would send `Bearer null` and 401 for
+      // every real logged-in user (issue #1125 review).
+      const token = localStorage.getItem("stellarmarket_jwt");
 
       // Single atomic call: the backend creates the job and every milestone in
       // one transaction (all-or-nothing), so there is no window in which a job

--- a/frontend/src/app/post-job/__tests__/JobWizard.atomic.test.tsx
+++ b/frontend/src/app/post-job/__tests__/JobWizard.atomic.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Tests for #1125: JobWizard uses an atomic, idempotent job+milestone creation
+ * call, and manages the localStorage draft lifecycle so a partial/failed publish
+ * is never lost and a retry never produces a duplicate job.
+ */
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import axios from "axios";
+
+jest.mock("axios", () => ({
+  post: jest.fn(),
+  isAxiosError: (e: unknown) => Boolean((e as { isAxiosError?: boolean })?.isAxiosError),
+}));
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn() }),
+}));
+
+jest.mock("@/context/AuthContext", () => ({
+  useAuth: () => ({ user: { id: "client-1", role: "CLIENT" }, isLoading: false }),
+}));
+
+jest.mock("@/components/Toast", () => ({
+  useToast: () => ({ toast: { success: jest.fn(), error: jest.fn() } }),
+}));
+
+// SkillCombobox pulls in async data we don't need here.
+jest.mock("@/components/SkillCombobox", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import JobWizard from "../JobWizard";
+
+const STORAGE_KEY = "job-wizard-draft";
+const IDEMPOTENCY_KEY_STORAGE = "job-wizard-idempotency-key";
+const ATOMIC_ENDPOINT = "/jobs/with-milestones";
+
+/** Shape of the atomic-create request body the wizard sends. */
+type AtomicJobBody = {
+  milestones: unknown[];
+  idempotencyKey: string;
+};
+/** Read the request body of the Nth axios.post call, typed. */
+function postBody(callIndex: number): AtomicJobBody {
+  return mockedAxios.post.mock.calls[callIndex][1] as AtomicJobBody;
+}
+
+const futureDate = (days: number) => {
+  const d = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+  return d.toISOString().split("T")[0]; // YYYY-MM-DD, matches the date inputs
+};
+
+/** A complete, valid draft so the wizard mounts pre-filled and can be submitted. */
+function seedValidDraft() {
+  const formData = {
+    title: "Build a Soroban DEX frontend interface",
+    description:
+      "Develop a responsive Stellar dApp frontend with full escrow integration and a complete test suite.",
+    category: "Frontend",
+    deadline: futureDate(30),
+    milestones: [
+      { title: "Wireframes", description: "Design all the screens", amount: "100", deadline: futureDate(7) },
+      { title: "Implementation", description: "Build all the components", amount: "200", deadline: futureDate(14) },
+      { title: "Testing", description: "Write the full test suite", amount: "150", deadline: futureDate(21) },
+    ],
+  };
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ formData, skills: ["React", "TypeScript"], paymentToken: "XLM" }),
+  );
+}
+
+/** Drive the wizard from step 1 → 3 and click Publish. */
+async function publish() {
+  render(<JobWizard />);
+  fireEvent.click(screen.getByText(/Next: Milestones & Budget/i));
+  await screen.findByText(/Preview & Publish/i);
+  fireEvent.click(screen.getByText(/Preview & Publish/i));
+  await screen.findByText("Publish Job");
+  fireEvent.click(screen.getByText("Publish Job"));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  localStorage.setItem("token", "test-token");
+  seedValidDraft();
+});
+
+describe("JobWizard — atomic job creation (#1125)", () => {
+  it("submits a single atomic call with all milestones and an idempotency key", async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { id: "job-1" } });
+
+    await publish();
+
+    await waitFor(() => expect(mockedAxios.post).toHaveBeenCalledTimes(1));
+    const url = mockedAxios.post.mock.calls[0][0];
+    const body = postBody(0);
+    expect(url).toContain(ATOMIC_ENDPOINT);
+    // All milestones sent in one payload — no N+1 loop.
+    expect(body.milestones).toHaveLength(3);
+    expect(body.idempotencyKey).toBeTruthy();
+    // Navigated to the created job.
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/jobs/job-1"));
+  });
+
+  it("clears the draft and idempotency key only after a confirmed success", async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { id: "job-1" } });
+
+    await publish();
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalled());
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(IDEMPOTENCY_KEY_STORAGE)).toBeNull();
+  });
+
+  it("preserves the draft (and does not navigate) when creation fails", async () => {
+    mockedAxios.post.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { error: "boom" } },
+    });
+
+    await publish();
+
+    await waitFor(() => expect(screen.getByText("boom")).toBeInTheDocument());
+    // The draft survives a failure so nothing the user typed is lost.
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    // The idempotency key is retained so a retry reuses it.
+    expect(localStorage.getItem(IDEMPOTENCY_KEY_STORAGE)).not.toBeNull();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("reuses the same idempotency key on retry after a failure (no duplicate job)", async () => {
+    // First publish fails...
+    mockedAxios.post.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { error: "temporary failure" } },
+    });
+    await publish();
+    await waitFor(() => expect(screen.getByText("temporary failure")).toBeInTheDocument());
+
+    const firstKey = postBody(0).idempotencyKey;
+    expect(firstKey).toBeTruthy();
+
+    // ...user clicks Publish again; the retry succeeds.
+    mockedAxios.post.mockResolvedValueOnce({ data: { id: "job-1" } });
+    fireEvent.click(screen.getByText("Publish Job"));
+
+    await waitFor(() => expect(mockedAxios.post).toHaveBeenCalledTimes(2));
+    const secondKey = postBody(1).idempotencyKey;
+
+    // Same key on both attempts → the backend treats the retry as the same
+    // request and cannot create a second job.
+    expect(secondKey).toBe(firstKey);
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/jobs/job-1"));
+    // After the confirmed success, the key is finally cleared.
+    expect(localStorage.getItem(IDEMPOTENCY_KEY_STORAGE)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1125

## Summary

`JobWizard.onSubmit` created a job by `POST /jobs` then looping `POST /milestones` one at a time. If a milestone POST failed partway through, the job was left persisted with a **partial milestone set**, the draft was **not** cleared, and re-clicking "Publish Job" ran the whole sequence again — creating a **duplicate job**. The client-side `totalBudget` could also **diverge** from what was persisted.

This replaces that flow with a single atomic, idempotent endpoint.

## Backend — new `POST /jobs/with-milestones`

- **Atomic**: job + all milestones are created inside one `prisma.$transaction` (nested `job.create`) — all-or-nothing, so a milestone failure leaves nothing behind.
- **Idempotent at the DB level**: an optional client `idempotencyKey` is stored on a new **unique** `Job.idempotencyKey` column. A retry with the same key returns the original job (`200`) instead of creating a second one; a concurrent unique-constraint race (`P2002`) is caught and resolved to the existing job. This holds **even when Redis is down**, unlike the existing fail-open Redis idempotency middleware.
- **Consistent budget**: the job budget is derived server-side from the sum of milestone amounts, so the persisted total can never diverge from the milestone set (validated against the platform minimum).
- Cross-user key → `409`, non-client → `403`, unknown category → `422`, empty milestones → `400`.
- Adds migration `20260801000000_add_job_idempotency_key` (`idempotencyKey String? @unique`; NULLs stay distinct in Postgres, so existing jobs are unaffected). The legacy `POST /jobs` and `POST /milestones` endpoints are left intact for backward compatibility.

## Frontend — `JobWizard`

- `onSubmit` makes the single atomic call with all milestones and a stable, persisted idempotency key that is **reused on retry** (so a retry can never duplicate the job).
- The draft **and** the key are cleared only on confirmed success and preserved on failure, so a failed publish is never lost.
- A `published` guard stops the draft auto-save effect from re-creating a draft that was just cleared on success (a real lifecycle race the old code was exposed to).

## Acceptance criteria
- [x] A partial failure during job+milestone creation cannot result in a duplicate job on retry
- [x] Job creation with its milestones is effectively atomic (fully succeeds or is cleanly rolled back / resumable)
- [x] The draft is not lost on a partial failure

## Testing
- **Backend** (`job-atomic-creation.test.ts`, 10): atomic create + derived budget + 1-based order; mid-sequence failure rolls back with no partial job; retry with same key returns the original and never calls create twice; P2002 race resolves to existing; cross-user key `409`; non-client `403`; below-minimum budget `422`; bad category `422`; empty milestones `400`; auth required.
- **Frontend** (`JobWizard.atomic.test.tsx`, 4): single atomic call carrying all milestones + a key; draft/key cleared only on success; draft + key preserved on failure (no navigation); retry reuses the same key and clears it after the eventual success.
- All 11 backend job/milestone suites and the full 232-test frontend suite pass; both typechecks clean.

Design notes in `ATOMIC_JOB_CREATION.md`.