### PR TITLE
fix: unify dispute detail page onto one real-time state source (#1126)

### DIFF
--- a/DISPUTE_UNIFIED_STATE.md
+++ b/DISPUTE_UNIFIED_STATE.md
@@ -1,0 +1,76 @@
+# Unified Dispute Real-Time State (issue #1126)
+
+Consolidates the dispute detail page's three independent, unsynchronized
+real-time state sources into one shared, staleness-guarded source of truth.
+
+## The bug
+
+`frontend/src/app/disputes/[id]/page.tsx` had **three** separate mechanisms
+fetching the same dispute's vote/status data, none coordinating:
+
+1. the page's own `GET /disputes/:id` state (refetched on SSE events via
+   `useDisputeStream`) — gated the "Finalize & Resolve" button;
+2. `DisputeVoteProgress` — its own polling loop (`useDisputeStatus`, 2s→30s);
+3. `ArbitratorVoteView` — a third independent 30s `/tally` poll.
+
+Under normal network jitter they displayed contradictory information at the same
+moment (e.g. the sidebar saying "Ready to resolve" while the gated button stayed
+disabled), and a slow response from one could overwrite fresher data already
+shown by another — none discarded stale/out-of-order responses.
+
+## The fix
+
+### One shared source of truth — `DisputeStateProvider`
+
+`frontend/src/context/DisputeStateContext.tsx` owns a single dispute state object
+that every consumer reads from. SSE (`useDisputeStream`) is the primary live
+mechanism: each event triggers **one** coordinated refetch through a single
+staleness-guarded path.
+
+**Authoritative gating**: the provider exposes `canResolve` (and the derived
+`dispute`/`totalVotes`) as the one gate for the "Finalize & Resolve" button. Every
+vote-status display derives from the same object, so the button state can never
+visibly disagree with the sidebar or arbitrator tally.
+
+### Two staleness guards (a stale response can never overwrite fresher data)
+
+- **Monotonic request sequence** — every fetch goes through one path that stamps
+  an incrementing id; a response older than the newest issued request is
+  discarded. This kills the "slow response clobbers fresh data" race, because all
+  fetches now share one counter.
+- **`updatedAt` high-water mark** — a payload whose `updatedAt` is older than what
+  is already committed is dropped, guarding against an out-of-band stale payload
+  racing a fresher one. (A missing/invalid timestamp is allowed once it clears the
+  sequence check.)
+
+### Consumers now read the shared state
+
+- **`page.tsx`** is split into a thin `DisputeDetailPage` (wraps
+  `DisputeStateProvider`) and `DisputeDetailContent` (consumes `useDisputeState`).
+  It no longer fetches or subscribes to SSE itself; `handleVote`/`handleResolve`
+  call the shared `refetch()`.
+- **`DisputeVoteProgress`** reads the shared state via `useOptionalDisputeState()`
+  instead of its own poll (an explicit `initialDispute` prop still works for
+  standalone/testing use).
+- **`ArbitratorVoteView`** derives its tally from the shared dispute (or its
+  `dispute` prop) instead of the independent 30s `/tally` poll — removing the
+  third source (and a `console.error`).
+
+The `useDisputeStatus` hook is left in the tree (still used by an example) but is
+no longer wired into the page.
+
+## Tests
+
+- `frontend/src/context/__tests__/DisputeStateContext.test.tsx` (4):
+  - all consumers hydrate from one fetch;
+  - **an out-of-order stale response is discarded** (a slow older fetch resolving
+    after a fast fresher one never overwrites it);
+  - **the resolve gate and the sidebar flip together** across an update — never in
+    the contradictory state the issue describes;
+  - **SSE-reconnection recovery**: a refetch after reconnect updates every
+    consumer consistently.
+- `frontend/src/components/__tests__/DisputeVoteProgress.test.tsx` (7): migrated to
+  feed the dispute via the shared source / `initialDispute`; same rendering
+  assertions.
+
+All 42 frontend suites (232 tests) pass; typecheck and lint are clean.

--- a/frontend/src/app/disputes/[id]/page.tsx
+++ b/frontend/src/app/disputes/[id]/page.tsx
@@ -1,68 +1,73 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, CheckCircle, AlertCircle, Loader2, ShieldCheck, User as UserIcon } from "lucide-react";
 import axios, { AxiosError } from "axios";
 import { useWallet } from "@/context/WalletContext";
 import { useAuth } from "@/context/AuthContext";
-import { Dispute, Vote } from "@/types";
+import { Vote } from "@/types";
 import DisputeVoteProgress from "@/components/DisputeVoteProgress";
 import EvidenceViewer from "@/components/EvidenceViewer";
 import EvidenceUpload from "@/components/EvidenceUpload";
 import DisputeOutcomeBanner from "@/components/DisputeOutcomeBanner";
 import DisputeTimeline from "@/components/DisputeTimeline";
 import { DisputeOpenedElapsed, VoteDeadlineCountdown } from "@/components/DisputeElapsedTime";
-import { useDisputeStream } from "@/hooks/useDisputeStream";
+import {
+  DisputeStateProvider,
+  useDisputeState,
+} from "@/context/DisputeStateContext";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api/v1";
 
+/**
+ * Page wrapper: establishes the single shared dispute-state source (#1126) that
+ * the page body, the vote-progress sidebar, and the arbitrator view all read
+ * from. No component below fetches or polls dispute state independently.
+ */
 export default function DisputeDetailPage() {
+  const { id } = useParams();
+  return (
+    <DisputeStateProvider disputeId={id as string}>
+      <DisputeDetailContent />
+    </DisputeStateProvider>
+  );
+}
+
+function DisputeDetailContent() {
   const { id } = useParams();
   const { signAndBroadcastTransaction } = useWallet();
   const { user } = useAuth();
-  
-  const [dispute, setDispute] = useState<Dispute | null>(null);
-  const [loading, setLoading] = useState(true);
+
+  // All dispute/vote state comes from the one shared source of truth.
+  const {
+    dispute,
+    loading,
+    error: fetchError,
+    refetch,
+    timelineEvents,
+    isLive,
+    canResolve,
+  } = useDisputeState();
+
   const [processing, setProcessing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  
+  // Errors from the viewer's own actions (vote/resolve), kept separate from the
+  // shared fetch error so one doesn't clobber the other.
+  const [actionError, setActionError] = useState<string | null>(null);
+
   const [voteChoice, setVoteChoice] = useState<"CLIENT" | "FREELANCER" | null>(null);
   const [voteReason, setVoteReason] = useState("");
 
-  const fetchDispute = useCallback(async () => {
-    try {
-      const token = localStorage.getItem("token");
-      const res = await axios.get(`${API_URL}/disputes/${id}`, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
-      setDispute(res.data);
-    } catch {
-      setError("Failed to fetch dispute details.");
-    } finally {
-      setLoading(false);
-    }
-  }, [id]);
-
-  useEffect(() => {
-    fetchDispute();
-  }, [fetchDispute]);
-
-  const { events: timelineEvents, isLive } = useDisputeStream(id as string, {
-    enabled: Boolean(dispute),
-    onEvent: () => {
-      fetchDispute();
-    },
-  });
+  const error = actionError ?? fetchError;
 
   const handleVote = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!voteChoice) return setError("Please select a side to vote for.");
-    if (voteReason.length < 10) return setError("Please provide a reason for your vote.");
+    if (!voteChoice) return setActionError("Please select a side to vote for.");
+    if (voteReason.length < 10) return setActionError("Please provide a reason for your vote.");
 
     setProcessing(true);
-    setError(null);
+    setActionError(null);
 
     try {
       const token = localStorage.getItem("token");
@@ -101,7 +106,8 @@ export default function DisputeDetailPage() {
 
       setVoteChoice(null);
       setVoteReason("");
-      fetchDispute();
+      // Refetch through the shared, staleness-guarded path.
+      refetch();
     } catch (err: unknown) {
       let errorMsg = "An error occurred";
       if (err instanceof AxiosError) {
@@ -109,7 +115,7 @@ export default function DisputeDetailPage() {
       } else if (err instanceof Error) {
         errorMsg = err.message;
       }
-      setError(errorMsg);
+      setActionError(errorMsg);
     } finally {
       setProcessing(false);
     }
@@ -117,7 +123,7 @@ export default function DisputeDetailPage() {
 
   const handleResolve = async () => {
     setProcessing(true);
-    setError(null);
+    setActionError(null);
 
     try {
       const token = localStorage.getItem("token");
@@ -152,7 +158,7 @@ export default function DisputeDetailPage() {
         { headers: { Authorization: `Bearer ${token}` } }
       );
 
-      fetchDispute();
+      refetch();
     } catch (err: unknown) {
       let errorMsg = "An error occurred";
       if (err instanceof AxiosError) {
@@ -160,7 +166,7 @@ export default function DisputeDetailPage() {
       } else if (err instanceof Error) {
         errorMsg = err.message;
       }
-      setError(errorMsg);
+      setActionError(errorMsg);
     } finally {
       setProcessing(false);
     }
@@ -185,11 +191,6 @@ export default function DisputeDetailPage() {
 
   const isParticipant = user?.id === dispute.initiator.id || user?.id === dispute.respondent.id;
   const hasVoted = dispute.votes.some((v: Vote) => v.voter.walletAddress === user?.walletAddress);
-  const totalVotes = dispute.votesForClient + dispute.votesForFreelancer;
-  const canResolve = totalVotes >= dispute.minVotes && (dispute.status === "OPEN" || dispute.status === "VOTING");
-  
-  const clientWidth = totalVotes > 0 ? (dispute.votesForClient / totalVotes) * 100 : 50;
-  const freelancerWidth = totalVotes > 0 ? (dispute.votesForFreelancer / totalVotes) * 100 : 50;
 
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -231,7 +232,7 @@ export default function DisputeDetailPage() {
             <h1 className="text-2xl font-bold text-theme-heading mb-6">
               Dispute Evidence & Reason
             </h1>
-            
+
             <div className="p-4 bg-theme-bg-secondary rounded-lg border border-theme-border mb-6">
               <div className="flex items-center gap-2 mb-2">
                 <UserIcon size={16} className="text-theme-text" />
@@ -248,7 +249,7 @@ export default function DisputeDetailPage() {
                 {dispute.reason}
               </p>
             </div>
-            
+
             <EvidenceViewer disputeId={dispute.id} />
 
             {isParticipant &&
@@ -257,7 +258,7 @@ export default function DisputeDetailPage() {
                 <div className="card">
                   <EvidenceUpload
                     disputeId={dispute.id}
-                    onUploadComplete={fetchDispute}
+                    onUploadComplete={refetch}
                   />
                 </div>
               )}
@@ -265,7 +266,7 @@ export default function DisputeDetailPage() {
             <h2 className="text-xl font-bold text-theme-heading mb-4 border-b border-theme-border pb-2">
               Community Votes
             </h2>
-            
+
             {dispute.votes.length === 0 ? (
                 <div className="text-center p-8 text-theme-text italic">No votes have been cast yet.</div>
             ) : (
@@ -286,7 +287,7 @@ export default function DisputeDetailPage() {
                   ))}
                 </div>
             )}
-            
+
           </div>
         </div>
 
@@ -294,9 +295,9 @@ export default function DisputeDetailPage() {
         <div className="space-y-6">
           <DisputeTimeline events={timelineEvents} isLive={isLive} />
 
-          {/* Real-time Vote Progress Component */}
-          <DisputeVoteProgress disputeId={id as string} showVoterDetails={true} />
-          
+          {/* Vote progress reads the SAME shared state as the resolve gate. */}
+          <DisputeVoteProgress showVoterDetails={true} />
+
           <div className="card">
             <h3 className="font-semibold text-theme-heading mb-4 flex items-center gap-2">
               <ShieldCheck className="text-stellar-blue" size={18} />
@@ -324,7 +325,7 @@ export default function DisputeDetailPage() {
               )}
             </div>
           </div>
-          
+
           <div className="card border-theme-border border-2">
             <h3 className="font-semibold text-theme-heading mb-4 flex items-center justify-center gap-2 text-lg">
               <ShieldCheck className="text-stellar-blue" />
@@ -332,7 +333,7 @@ export default function DisputeDetailPage() {
             </h3>
 
             {canResolve && !isParticipant && (
-                <button 
+                <button
                   onClick={handleResolve}
                   disabled={processing}
                   className="btn-primary w-full flex justify-center py-3 mb-4 text-sm font-semibold shadow-[0_0_15px_rgba(42,92,246,0.3)] animate-pulse"
@@ -361,8 +362,8 @@ export default function DisputeDetailPage() {
                         type="button"
                         onClick={() => setVoteChoice("CLIENT")}
                         className={`py-2 px-3 rounded-lg text-sm font-medium border transition-colors ${
-                            voteChoice === "CLIENT" 
-                            ? "bg-stellar-blue/20 border-stellar-blue text-stellar-blue" 
+                            voteChoice === "CLIENT"
+                            ? "bg-stellar-blue/20 border-stellar-blue text-stellar-blue"
                             : "bg-theme-bg border-theme-border text-theme-text hover:border-indigo-500/50"
                         }`}
                     >
@@ -372,25 +373,25 @@ export default function DisputeDetailPage() {
                         type="button"
                         onClick={() => setVoteChoice("FREELANCER")}
                         className={`py-2 px-3 rounded-lg text-sm font-medium border transition-colors ${
-                            voteChoice === "FREELANCER" 
-                            ? "bg-theme-warning/20 border-theme-warning text-theme-warning" 
+                            voteChoice === "FREELANCER"
+                            ? "bg-theme-warning/20 border-theme-warning text-theme-warning"
                             : "bg-theme-bg border-theme-border text-theme-text hover:border-orange-500/50"
                         }`}
                     >
                         For Freelancer
                     </button>
                   </div>
-                  
-                  <textarea 
+
+                  <textarea
                     className="input-field min-h-[80px] text-sm resize-none"
                     placeholder="Provide reasoning for your decision..."
                     value={voteReason}
                     onChange={(e) => setVoteReason(e.target.value)}
                     disabled={processing || !voteChoice}
                   />
-                  
-                  <button 
-                    type="submit" 
+
+                  <button
+                    type="submit"
                     className="btn-primary w-full"
                     disabled={processing || !voteChoice || voteReason.length < 10}
                   >

--- a/frontend/src/app/disputes/[id]/page.tsx
+++ b/frontend/src/app/disputes/[id]/page.tsx
@@ -70,7 +70,7 @@ function DisputeDetailContent() {
     setActionError(null);
 
     try {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt");
 
       // 1. Get XDR
       const res = await axios.post(
@@ -126,7 +126,7 @@ function DisputeDetailContent() {
     setActionError(null);
 
     try {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("stellarmarket_jwt");
 
       // 1. Get XDR
       const res = await axios.post(

--- a/frontend/src/components/ArbitratorVoteView.tsx
+++ b/frontend/src/components/ArbitratorVoteView.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useMemo } from "react";
 import { ExternalLink, Loader2, Scale, Shield, TrendingUp } from "lucide-react";
-import axios from "axios";
 import type { Dispute } from "@/types";
+import { useOptionalDisputeState } from "@/context/DisputeStateContext";
 
 interface ArbitratorVoteViewProps {
   dispute: Dispute;
@@ -32,8 +32,6 @@ interface DisputeTally {
   }>;
 }
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api/v1";
-
 export default function ArbitratorVoteView({
   dispute,
   walletAddress,
@@ -43,8 +41,14 @@ export default function ArbitratorVoteView({
   const [clientPct, setClientPct] = useState(50);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const [tally, setTally] = useState<DisputeTally | null>(null);
-  const [loadingTally, setLoadingTally] = useState(false);
+
+  // Read the single shared dispute state (issue #1126) when rendered on the
+  // dispute page; fall back to the `dispute` prop otherwise. This replaces the
+  // component's former independent 30s `/tally` poll, so the tally shown here can
+  // never disagree with the rest of the page.
+  const shared = useOptionalDisputeState();
+  const liveDispute = shared?.dispute ?? dispute;
+  const loadingTally = shared ? shared.loading : false;
 
   const isArbitrator =
     !!walletAddress &&
@@ -52,30 +56,30 @@ export default function ArbitratorVoteView({
 
   const freelancerPct = 100 - clientPct;
 
-  // Fetch tally on mount and every 30 seconds
-  useEffect(() => {
-    if (!isArbitrator) return;
-
-    const fetchTally = async () => {
-      setLoadingTally(true);
-      try {
-        const token = localStorage.getItem("token");
-        const response = await axios.get<DisputeTally>(
-          `${API_URL}/disputes/${dispute.id}/tally`,
-          { headers: { Authorization: `Bearer ${token}` } },
-        );
-        setTally(response.data);
-      } catch (err) {
-        console.error("Failed to fetch tally:", err);
-      } finally {
-        setLoadingTally(false);
-      }
+  // Derive the tally from the shared dispute rather than a separate fetch, so
+  // there is exactly one source of vote/status truth on the page.
+  const tally = useMemo<DisputeTally | null>(() => {
+    if (!isArbitrator || !liveDispute) return null;
+    const votesForClient = liveDispute.votesForClient ?? 0;
+    const votesForFreelancer = liveDispute.votesForFreelancer ?? 0;
+    const totalVotes = votesForClient + votesForFreelancer;
+    return {
+      disputeId: liveDispute.id,
+      totalVotes,
+      votesForClient,
+      votesForFreelancer,
+      clientPercentage: totalVotes > 0 ? (votesForClient / totalVotes) * 100 : 0,
+      freelancerPercentage:
+        totalVotes > 0 ? (votesForFreelancer / totalVotes) * 100 : 0,
+      status: liveDispute.status,
+      votes: (liveDispute.votes ?? []).map((v) => ({
+        voterId: v.voterId,
+        voterName: v.voter?.username ?? "Anonymous",
+        choice: v.choice,
+        timestamp: v.createdAt,
+      })),
     };
-
-    fetchTally();
-    const interval = setInterval(fetchTally, 30000);
-    return () => clearInterval(interval);
-  }, [dispute.id, isArbitrator]);
+  }, [isArbitrator, liveDispute]);
 
   const handleClientSlider = (val: number) => {
     setClientPct(val);

--- a/frontend/src/components/DisputeVoteProgress.tsx
+++ b/frontend/src/components/DisputeVoteProgress.tsx
@@ -2,38 +2,35 @@
 
 import { useEffect, useState } from "react";
 import { ShieldCheck, Users } from "lucide-react";
-import { useDisputeStatus } from "@/hooks/useDisputeStatus";
-import type { Vote } from "@/types";
+import { useOptionalDisputeState } from "@/context/DisputeStateContext";
+import type { Dispute, Vote } from "@/types";
 
 interface DisputeVoteProgressProps {
-  disputeId: string;
+  /**
+   * Optional explicit dispute. When omitted, the component reads from the shared
+   * `DisputeStateProvider` on the dispute page — the SAME source that gates the
+   * "Finalize & Resolve" button — so the two can never disagree (#1126).
+   */
+  initialDispute?: Dispute;
   showVoterDetails?: boolean;
-  initialDispute?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 /**
- * Real-time dispute vote progress tracker component
- * 
- * Features:
- * - Live polling via useDisputeStatus hook
- * - Visual split progress bar showing votes for client vs freelancer
- * - Vote count display (X of Y votes cast)
- * - Anonymized voter addresses for privacy
- * - Responsive design with Tailwind CSS
+ * Dispute vote-progress tracker.
+ *
+ * Reads vote/status from the single shared dispute state (issue #1126) rather
+ * than running its own independent poll, so its "Ready to resolve" message and
+ * the page's resolve-button gate always reflect the exact same data. An explicit
+ * `initialDispute` prop overrides the context for standalone/testing use.
  */
-export default function DisputeVoteProgress({ 
-  disputeId, 
-  showVoterDetails = false,
+export default function DisputeVoteProgress({
   initialDispute,
+  showVoterDetails = false,
 }: DisputeVoteProgressProps) {
-  const { dispute: liveDispute, isLoading: liveLoading } = useDisputeStatus({
-    disputeId,
-    enabled: !initialDispute,
-    initialInterval: 2000,
-    maxInterval: 30000
-  });
-  const dispute = initialDispute ?? liveDispute;
-  const isLoading = initialDispute ? false : liveLoading;
+  const shared = useOptionalDisputeState();
+  const dispute = initialDispute ?? shared?.dispute ?? null;
+  // Loading only when we have neither an explicit dispute nor shared state yet.
+  const isLoading = initialDispute ? false : shared?.loading ?? true;
 
   const [prevVoteCount, setPrevVoteCount] = useState(0);
   const [isNewVote, setIsNewVote] = useState(false);

--- a/frontend/src/components/__tests__/DisputeVoteProgress.test.tsx
+++ b/frontend/src/components/__tests__/DisputeVoteProgress.test.tsx
@@ -1,14 +1,11 @@
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import DisputeVoteProgress from "../DisputeVoteProgress";
-import { useDisputeStatus } from "@/hooks/useDisputeStatus";
 import type { Dispute } from "@/types";
 
-// Mock the useDisputeStatus hook
-jest.mock("@/hooks/useDisputeStatus");
-
-const mockUseDisputeStatus = useDisputeStatus as jest.MockedFunction<typeof useDisputeStatus>;
-
+// #1126: the component now reads from the shared dispute state (or an explicit
+// `initialDispute` prop) instead of its own poll. These tests feed the dispute
+// via `initialDispute`, exercising the identical rendering logic.
 describe("DisputeVoteProgress", () => {
   const mockDispute = {
     id: "1",
@@ -67,32 +64,14 @@ describe("DisputeVoteProgress", () => {
     ],
   } as unknown as Dispute;
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it("renders loading state initially", () => {
-    mockUseDisputeStatus.mockReturnValue({
-      dispute: null,
-      isLoading: true,
-      error: null,
-      refetch: jest.fn(),
-    });
-
-    const { container } = render(<DisputeVoteProgress disputeId="1" />);
+    const { container } = render(<DisputeVoteProgress />);
 
     expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
   });
 
   it("displays vote counts correctly", async () => {
-    mockUseDisputeStatus.mockReturnValue({
-      dispute: mockDispute,
-      isLoading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-
-    render(<DisputeVoteProgress disputeId="1" />);
+    render(<DisputeVoteProgress initialDispute={mockDispute} />);
 
     await waitFor(() => {
       expect(screen.getByText("5")).toBeInTheDocument(); // totalVotes
@@ -103,14 +82,7 @@ describe("DisputeVoteProgress", () => {
   });
 
   it("shows correct progress percentage", async () => {
-    mockUseDisputeStatus.mockReturnValue({
-      dispute: mockDispute,
-      isLoading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-
-    render(<DisputeVoteProgress disputeId="1" />);
+    render(<DisputeVoteProgress initialDispute={mockDispute} />);
 
     await waitFor(() => {
       expect(screen.getByText("100%")).toBeInTheDocument(); // 5/5 votes = 100%
@@ -118,14 +90,7 @@ describe("DisputeVoteProgress", () => {
   });
 
   it("displays 'Ready to resolve' when minimum votes reached", async () => {
-    mockUseDisputeStatus.mockReturnValue({
-      dispute: mockDispute,
-      isLoading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-
-    render(<DisputeVoteProgress disputeId="1" />);
+    render(<DisputeVoteProgress initialDispute={mockDispute} />);
 
     await waitFor(() => {
       expect(screen.getByText("Ready to resolve")).toBeInTheDocument();
@@ -139,14 +104,7 @@ describe("DisputeVoteProgress", () => {
       votesForFreelancer: 1,
     };
 
-    mockUseDisputeStatus.mockReturnValue({
-      dispute: disputeNeedingVotes,
-      isLoading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-
-    render(<DisputeVoteProgress disputeId="1" />);
+    render(<DisputeVoteProgress initialDispute={disputeNeedingVotes} />);
 
     await waitFor(() => {
       expect(screen.getByText("3 more votes needed")).toBeInTheDocument();
@@ -154,14 +112,7 @@ describe("DisputeVoteProgress", () => {
   });
 
   it("anonymizes voter addresses when showVoterDetails is true", async () => {
-    mockUseDisputeStatus.mockReturnValue({
-      dispute: mockDispute,
-      isLoading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-
-    render(<DisputeVoteProgress disputeId="1" showVoterDetails={true} />);
+    render(<DisputeVoteProgress initialDispute={mockDispute} showVoterDetails={true} />);
 
     await waitFor(() => {
       expect(screen.getByText("Recent Voters (Anonymized)")).toBeInTheDocument();
@@ -171,14 +122,7 @@ describe("DisputeVoteProgress", () => {
   });
 
   it("does not show voter details when showVoterDetails is false", async () => {
-    mockUseDisputeStatus.mockReturnValue({
-      dispute: mockDispute,
-      isLoading: false,
-      error: null,
-      refetch: jest.fn(),
-    });
-
-    render(<DisputeVoteProgress disputeId="1" showVoterDetails={false} />);
+    render(<DisputeVoteProgress initialDispute={mockDispute} showVoterDetails={false} />);
 
     await waitFor(() => {
       expect(screen.queryByText("Recent Voters (Anonymized)")).not.toBeInTheDocument();

--- a/frontend/src/context/DisputeStateContext.tsx
+++ b/frontend/src/context/DisputeStateContext.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+/**
+ * Single shared source of truth for a dispute's live vote/status state
+ * (issue #1126).
+ *
+ * The dispute detail page previously had **three** independent, unsynchronized
+ * data sources for the same dispute:
+ *   1. the page's own `GET /disputes/:id` state (refetched on SSE events),
+ *   2. `DisputeVoteProgress`'s independent polling loop (`useDisputeStatus`),
+ *   3. `ArbitratorVoteView`'s independent 30s `/tally` poll.
+ * Under normal network jitter these could display contradictory information at
+ * the same moment (e.g. the sidebar saying "Ready to resolve" while the gated
+ * "Finalize & Resolve" button stayed disabled), and a slow response from one
+ * could overwrite fresher data already shown by another.
+ *
+ * This provider consolidates all of that into ONE state object that every
+ * consumer reads from, with two staleness guards so a stale response can never
+ * overwrite fresher data:
+ *
+ *   - **Monotonic request sequence** — every fetch goes through a single path
+ *     that stamps an incrementing id; a response older than the newest issued
+ *     request is discarded (kills the "slow response clobbers fresh data" race).
+ *   - **`updatedAt` high-water mark** — a payload whose `updatedAt` is older than
+ *     what is already committed is discarded, guarding against an out-of-band
+ *     stale payload (e.g. a cache) racing a fresher one.
+ *
+ * ## Authoritative gating source
+ *
+ * SSE (`useDisputeStream`) is the primary live-update mechanism; every SSE event
+ * triggers a single coordinated refetch. The `canResolve` flag exposed here is
+ * the ONE authoritative gate for the "Finalize & Resolve" button, and the same
+ * derived `totalVotes`/`dispute` feed every vote-status display — so the button
+ * state can never visibly disagree with the sidebar/tally.
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  type ReactNode,
+} from "react";
+import axios from "axios";
+import type { Dispute } from "@/types";
+import { useDisputeStream, type DisputeEvent } from "@/hooks/useDisputeStream";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api/v1";
+
+export interface DisputeStateValue {
+  dispute: Dispute | null;
+  loading: boolean;
+  error: string | null;
+  /** Force a coordinated refetch (used after the viewer casts a vote/resolves). */
+  refetch: () => Promise<void>;
+  /** Timeline events from the SSE stream. */
+  timelineEvents: DisputeEvent[];
+  /** Whether the SSE stream is currently connected. */
+  isLive: boolean;
+  /** votesForClient + votesForFreelancer, derived once so all displays agree. */
+  totalVotes: number;
+  /**
+   * The single authoritative gate for the "Finalize & Resolve" button. Every
+   * other vote-status display derives from the same `dispute`, so this can never
+   * disagree with what's shown elsewhere.
+   */
+  canResolve: boolean;
+}
+
+const DisputeStateContext = createContext<DisputeStateValue | null>(null);
+
+export function DisputeStateProvider({
+  disputeId,
+  children,
+  /** Test seam: skip the SSE subscription (jsdom has no EventSource/stream). */
+  disableStream = false,
+}: {
+  disputeId: string;
+  children: ReactNode;
+  disableStream?: boolean;
+}) {
+  const [dispute, setDispute] = useState<Dispute | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Monotonic id of the most recently *issued* fetch. A response carrying an id
+  // older than this is out-of-order and must not commit.
+  const latestSeq = useRef(0);
+  // Epoch-ms of the freshest `updatedAt` already committed. A payload older than
+  // this is stale and must not overwrite it.
+  const committedUpdatedAt = useRef(0);
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  // Reset the guards whenever the dispute being viewed changes.
+  useEffect(() => {
+    latestSeq.current = 0;
+    committedUpdatedAt.current = 0;
+    setDispute(null);
+    setLoading(true);
+    setError(null);
+  }, [disputeId]);
+
+  /**
+   * Commit an incoming dispute only if it is both the newest request we issued
+   * and not older than what we've already shown.
+   */
+  const commitIfFresher = useCallback((incoming: Dispute, seq: number) => {
+    if (!isMounted.current) return;
+    // Out-of-order response: a newer fetch has since been issued.
+    if (seq < latestSeq.current) return;
+    const incomingTs = Date.parse(incoming.updatedAt ?? "");
+    // Stale payload: never overwrite fresher data. (A missing/invalid timestamp
+    // parses to NaN; `NaN < x` is false, so such payloads are allowed through
+    // once the sequence check has passed.)
+    if (!Number.isNaN(incomingTs)) {
+      if (incomingTs < committedUpdatedAt.current) return;
+      committedUpdatedAt.current = incomingTs;
+    }
+    setDispute(incoming);
+  }, []);
+
+  const fetchDispute = useCallback(async () => {
+    const seq = ++latestSeq.current;
+    try {
+      const token = localStorage.getItem("token");
+      const res = await axios.get<Dispute>(`${API_URL}/disputes/${disputeId}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      commitIfFresher(res.data, seq);
+      if (isMounted.current) setError(null);
+    } catch {
+      if (isMounted.current) setError("Failed to fetch dispute details.");
+    } finally {
+      if (isMounted.current) setLoading(false);
+    }
+  }, [disputeId, commitIfFresher]);
+
+  useEffect(() => {
+    fetchDispute();
+  }, [fetchDispute]);
+
+  // SSE is the primary live-update mechanism: every event triggers ONE
+  // coordinated refetch that flows through the same staleness-guarded path.
+  const { events, isLive } = useDisputeStream(disputeId, {
+    enabled: !disableStream && Boolean(dispute),
+    onEvent: () => {
+      fetchDispute();
+    },
+  });
+
+  const totalVotes = dispute
+    ? dispute.votesForClient + dispute.votesForFreelancer
+    : 0;
+  const canResolve =
+    !!dispute &&
+    totalVotes >= dispute.minVotes &&
+    (dispute.status === "OPEN" || dispute.status === "VOTING");
+
+  const value = useMemo<DisputeStateValue>(
+    () => ({
+      dispute,
+      loading,
+      error,
+      refetch: fetchDispute,
+      timelineEvents: events,
+      isLive,
+      totalVotes,
+      canResolve,
+    }),
+    [dispute, loading, error, fetchDispute, events, isLive, totalVotes, canResolve],
+  );
+
+  return (
+    <DisputeStateContext.Provider value={value}>
+      {children}
+    </DisputeStateContext.Provider>
+  );
+}
+
+/** Read the shared dispute state. Throws if used outside the provider. */
+export function useDisputeState(): DisputeStateValue {
+  const ctx = useContext(DisputeStateContext);
+  if (!ctx) {
+    throw new Error("useDisputeState must be used within a DisputeStateProvider");
+  }
+  return ctx;
+}
+
+/**
+ * Read the shared dispute state if a provider is present, else `null`. Lets
+ * components (e.g. `DisputeVoteProgress`, `ArbitratorVoteView`) subscribe to the
+ * shared source when rendered on the dispute page, while remaining usable
+ * standalone via their own props.
+ */
+export function useOptionalDisputeState(): DisputeStateValue | null {
+  return useContext(DisputeStateContext);
+}

--- a/frontend/src/context/DisputeStateContext.tsx
+++ b/frontend/src/context/DisputeStateContext.tsx
@@ -132,7 +132,10 @@ export function DisputeStateProvider({
   const fetchDispute = useCallback(async () => {
     const seq = ++latestSeq.current;
     try {
-      const token = localStorage.getItem("token");
+      // Must match AuthContext's TOKEN_KEY ("stellarmarket_jwt"); the legacy
+      // "token" key is never set, so it would send an unauthenticated request
+      // and 401 for every real user (issue #1126 review).
+      const token = localStorage.getItem("stellarmarket_jwt");
       const res = await axios.get<Dispute>(`${API_URL}/disputes/${disputeId}`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
       });

--- a/frontend/src/context/__tests__/DisputeStateContext.test.tsx
+++ b/frontend/src/context/__tests__/DisputeStateContext.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * Tests for #1126: a single shared source of truth for dispute/vote state, with
+ * staleness guards so a stale/out-of-order response can never overwrite fresher
+ * data, and so the resolve-button gate can never disagree with other displays.
+ */
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import axios from "axios";
+
+jest.mock("axios", () => ({ get: jest.fn(), isAxiosError: jest.fn() }));
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// The SSE hook is exercised separately; here we disable the stream and drive
+// refetches explicitly so we can control response ordering deterministically.
+jest.mock("@/hooks/useDisputeStream", () => ({
+  useDisputeStream: () => ({ events: [], isLive: false }),
+}));
+
+import {
+  DisputeStateProvider,
+  useDisputeState,
+} from "@/context/DisputeStateContext";
+import DisputeVoteProgress from "@/components/DisputeVoteProgress";
+import type { Dispute } from "@/types";
+
+function makeDispute(over: Partial<Dispute> = {}): Dispute {
+  return {
+    id: "d1",
+    jobId: "job-1",
+    contractDisputeId: undefined,
+    initiatorId: "u1",
+    respondentId: "u2",
+    reason: "Test dispute reason",
+    status: "VOTING",
+    votesForClient: 0,
+    votesForFreelancer: 0,
+    minVotes: 3,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    job: { id: "job-1", title: "Test Job" } as unknown as Dispute["job"],
+    initiator: { id: "u1", username: "client", walletAddress: "GABC" } as unknown as Dispute["initiator"],
+    respondent: { id: "u2", username: "freelancer", walletAddress: "GDEF" } as unknown as Dispute["respondent"],
+    votes: [],
+    ...over,
+  } as Dispute;
+}
+
+/** A deferred promise so a test can resolve axios responses out of order. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** Harness that surfaces the shared gate + a refetch trigger and the sidebar. */
+function Harness() {
+  const { dispute, totalVotes, canResolve, refetch } = useDisputeState();
+  return (
+    <div>
+      <span data-testid="total">{totalVotes}</span>
+      <span data-testid="can-resolve">{canResolve ? "yes" : "no"}</span>
+      <span data-testid="status">{dispute?.status ?? "none"}</span>
+      <button onClick={() => refetch()}>refetch</button>
+      {/* The sidebar reads the SAME shared state (no props). */}
+      <DisputeVoteProgress />
+    </div>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <DisputeStateProvider disputeId="d1" disableStream>
+      <Harness />
+    </DisputeStateProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.setItem("token", "t");
+});
+
+describe("DisputeStateContext — single source of truth (#1126)", () => {
+  it("hydrates all consumers from one fetch", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: makeDispute({ votesForClient: 2, votesForFreelancer: 1, minVotes: 3 }),
+    });
+
+    renderProvider();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("total")).toHaveTextContent("3"),
+    );
+    // The gate says resolvable...
+    expect(screen.getByTestId("can-resolve")).toHaveTextContent("yes");
+    // ...and the sidebar (same source) agrees.
+    expect(screen.getByText("Ready to resolve")).toBeInTheDocument();
+  });
+
+  it("discards an out-of-order (stale) response so it cannot overwrite fresher data", async () => {
+    // Initial load: 0 votes.
+    mockedAxios.get.mockResolvedValueOnce({ data: makeDispute() });
+    renderProvider();
+    await waitFor(() => expect(screen.getByTestId("total")).toHaveTextContent("0"));
+
+    // Two refetches issued back-to-back. The FIRST is slow (stale, older
+    // updatedAt) and the SECOND is fast (fresh, newer updatedAt). The fresh one
+    // resolves first and commits; the stale one resolves later and must be
+    // dropped by the sequence guard.
+    const slowStale = deferred<{ data: Dispute }>();
+    const fastFresh = deferred<{ data: Dispute }>();
+    mockedAxios.get
+      .mockReturnValueOnce(slowStale.promise as never)
+      .mockReturnValueOnce(fastFresh.promise as never);
+
+    await act(async () => {
+      screen.getByText("refetch").click(); // issues seq=2 (slowStale)
+      screen.getByText("refetch").click(); // issues seq=3 (fastFresh)
+    });
+
+    // Fresh response (5 votes, newer timestamp) resolves first → committed.
+    await act(async () => {
+      fastFresh.resolve({
+        data: makeDispute({
+          votesForClient: 3,
+          votesForFreelancer: 2,
+          updatedAt: "2026-01-01T00:05:00.000Z",
+        }),
+      });
+    });
+    await waitFor(() => expect(screen.getByTestId("total")).toHaveTextContent("5"));
+
+    // Stale response (1 vote, older timestamp) resolves late → MUST be ignored.
+    await act(async () => {
+      slowStale.resolve({
+        data: makeDispute({
+          votesForClient: 1,
+          votesForFreelancer: 0,
+          updatedAt: "2026-01-01T00:01:00.000Z",
+        }),
+      });
+    });
+
+    // Still shows the fresher data; the stale late arrival did not clobber it.
+    await waitFor(() => expect(screen.getByTestId("total")).toHaveTextContent("5"));
+    expect(screen.getByTestId("total")).toHaveTextContent("5");
+  });
+
+  it("keeps the resolve gate and the sidebar in agreement across an update", async () => {
+    // Start below quorum: gate off, sidebar shows 'more votes needed'.
+    mockedAxios.get.mockResolvedValueOnce({
+      data: makeDispute({ votesForClient: 1, votesForFreelancer: 0, minVotes: 3 }),
+    });
+    renderProvider();
+    await waitFor(() => expect(screen.getByTestId("can-resolve")).toHaveTextContent("no"));
+    expect(screen.getByText(/more votes needed/)).toBeInTheDocument();
+
+    // A refetch crosses quorum: both must flip together (one source).
+    mockedAxios.get.mockResolvedValueOnce({
+      data: makeDispute({
+        votesForClient: 2,
+        votesForFreelancer: 1,
+        minVotes: 3,
+        updatedAt: "2026-01-01T01:00:00.000Z",
+      }),
+    });
+    await act(async () => {
+      screen.getByText("refetch").click();
+    });
+
+    await waitFor(() => expect(screen.getByTestId("can-resolve")).toHaveTextContent("yes"));
+    // The sidebar, reading the same source, now shows 'Ready to resolve' too.
+    expect(screen.getByText("Ready to resolve")).toBeInTheDocument();
+    // They can never be in the contradictory state the issue describes.
+    expect(screen.queryByText(/more votes needed/)).not.toBeInTheDocument();
+  });
+
+  it("recovers on SSE reconnection: a refetch after reconnect updates all consumers", async () => {
+    // Simulates the reconnection case — after the stream drops and comes back,
+    // the provider's onEvent refetch (here invoked explicitly) reconciles state.
+    mockedAxios.get.mockResolvedValueOnce({
+      data: makeDispute({ votesForClient: 0, votesForFreelancer: 0 }),
+    });
+    renderProvider();
+    await waitFor(() => expect(screen.getByTestId("total")).toHaveTextContent("0"));
+
+    mockedAxios.get.mockResolvedValueOnce({
+      data: makeDispute({
+        votesForClient: 3,
+        votesForFreelancer: 0,
+        status: "RESOLVED_CLIENT",
+        updatedAt: "2026-01-01T02:00:00.000Z",
+      }),
+    });
+    await act(async () => {
+      screen.getByText("refetch").click();
+    });
+
+    await waitFor(() => expect(screen.getByTestId("status")).toHaveTextContent("RESOLVED_CLIENT"));
+    expect(screen.getByTestId("total")).toHaveTextContent("3");
+    // Resolved disputes are no longer resolvable via the gate.
+    expect(screen.getByTestId("can-resolve")).toHaveTextContent("no");
+  });
+});


### PR DESCRIPTION
Closes #1126

## Summary

The dispute detail page had **three** independent, unsynchronized real-time state sources for the same dispute:
1. the page's own `GET /disputes/:id` state (refetched on SSE events) — gating the "Finalize & Resolve" button;
2. `DisputeVoteProgress`'s own poll (`useDisputeStatus`, 2s→30s);
3. `ArbitratorVoteView`'s third independent 30s `/tally` poll.

Under normal network jitter they could display contradictory data at the same moment (e.g. the sidebar showing "Ready to resolve" while the gated button stayed disabled), and a slow response from one could overwrite fresher data already shown by another.

## The fix — one shared, staleness-guarded source of truth

New **`DisputeStateProvider`** (`frontend/src/context/DisputeStateContext.tsx`) owns a single dispute state object every consumer reads from. SSE (`useDisputeStream`) is the primary live mechanism; each event triggers **one** coordinated refetch through a single fetch path.

**Authoritative gating** — the provider exposes `canResolve` as the one gate for the resolve button, and every vote-status display derives from the same `dispute` object, so the button state can never visibly disagree with the sidebar/tally.

**Two staleness guards** — a stale response can never overwrite fresher data:
- **Monotonic request sequence**: all fetches share one incrementing id; a response older than the newest issued request is discarded (kills the "slow response clobbers fresh data" race).
- **`updatedAt` high-water mark**: a payload older than what's already committed is dropped.

### Consumers
- `page.tsx` is split into a thin `DisputeDetailPage` (wraps the provider) + `DisputeDetailContent` (consumes `useDisputeState`); it no longer fetches/subscribes itself, and `handleVote`/`handleResolve` call the shared `refetch()`.
- `DisputeVoteProgress` and `ArbitratorVoteView` read the shared state via `useOptionalDisputeState()` instead of their own polls — removing both independent poll loops and a `console.error`. An explicit `initialDispute` prop still works standalone.

## Acceptance criteria
- [x] All dispute/vote state derives from one coordinated source of truth
- [x] Stale responses from any mechanism can never overwrite fresher data
- [x] The resolve-button gating can never visibly disagree with other vote-status displays

## Testing
- **New context suite** (`DisputeStateContext.test.tsx`, 4): all consumers hydrate from one fetch; **an out-of-order stale response is discarded** (slow older fetch resolving after a fast fresher one never overwrites it); **the resolve gate and the sidebar flip together** across an update; **SSE-reconnection recovery** updates every consumer consistently.
- **Migrated** `DisputeVoteProgress.test.tsx` (7) to the shared source; same rendering assertions.
- All 42 frontend suites (232 tests) pass; typecheck and lint clean.

Design notes in `DISPUTE_UNIFIED_STATE.md`.