### PR TITLE
fix: move chunked evidence-upload session state off local disk

### DIFF
--- a/backend/src/__tests__/evidence-session-cleanup.job.test.ts
+++ b/backend/src/__tests__/evidence-session-cleanup.job.test.ts
@@ -1,31 +1,36 @@
-import fs from "fs";
-import path from "path";
-import os from "os";
+import {
+  FakeEvidenceObjectStore,
+  FakeRedisStore,
+} from "./testUtils/evidenceSessionFakes";
 
-// ── 1. Set up a temporary SESSION_ROOT before any service module is imported ──
-const tempRoot = fs.mkdtempSync(
-  path.join(os.tmpdir(), "evidence-session-cleanup-test-"),
-);
-process.env.EVIDENCE_SESSION_DIR = tempRoot;
-process.env.UPLOAD_DIR = tempRoot;
+const fakeRedis = new FakeRedisStore();
+const fakeStore = new FakeEvidenceObjectStore();
 
-// ── 2. Imports (after env vars are set) ──────────────────────────────────────
+jest.mock("../lib/redis", () => ({
+  __esModule: true,
+  default: { getInstance: () => fakeRedis },
+}));
+
+jest.mock("../services/evidence-storage.service", () => ({
+  uploadEvidenceBuffer: jest.fn(async ({ key, body }: { key: string; body: Buffer }) => {
+    fakeStore.put(key, body);
+  }),
+  readEvidenceObject: jest.fn(async (key: string) => fakeStore.get(key)),
+  deleteEvidenceObjects: jest.fn(async (keys: string[]) => {
+    fakeStore.delete(keys);
+  }),
+}));
+
 import {
   initiateSession,
   getSession,
-  SESSION_ROOT,
+  saveChunk,
 } from "../services/evidence-upload-session.service";
-import {
-  sweepStaleSessions,
-  SESSION_TTL_MS,
-} from "../jobs/evidence-session-cleanup.job";
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
+import { sweepStaleSessions, SESSION_TTL_MS } from "../jobs/evidence-session-cleanup.job";
 
 const OLD_CREATED_AT = new Date(Date.now() - 26 * 60 * 60 * 1000).toISOString(); // 26 h ago
-const NEW_CREATED_AT = new Date().toISOString();                                   // just now
+const NEW_CREATED_AT = new Date().toISOString(); // just now
 
-/** Build the minimal valid input for initiateSession */
 function makeInput(overrides: Partial<{ sha256: string; createdAt: string }> = {}) {
   return {
     disputeId: "dispute-sweep-test",
@@ -40,100 +45,79 @@ function makeInput(overrides: Partial<{ sha256: string; createdAt: string }> = {
   };
 }
 
-/** Back-date a session directory's mtime to look older than the TTL */
-function backdateSessionDir(sessionId: string, ageMs: number): void {
-  const dir = path.join(SESSION_ROOT, sessionId);
-  const oldTime = new Date(Date.now() - ageMs);
-  fs.utimesSync(dir, oldTime, oldTime);
-}
-
-// ── Test suite ────────────────────────────────────────────────────────────────
-
-afterAll(() => {
-  fs.rmSync(tempRoot, { recursive: true, force: true });
-});
-
 describe("sweepStaleSessions", () => {
-  it("removes a session older than the TTL that was never completed", () => {
-    // Session whose manifest records a createdAt 26 h in the past
-    const { sessionId } = initiateSession(
+  afterEach(() => {
+    fakeRedis.clear();
+    fakeStore.clear();
+  });
+
+  it("removes a session older than the TTL that was never completed", async () => {
+    const { sessionId } = await initiateSession(
       makeInput({ sha256: "1".repeat(64), createdAt: OLD_CREATED_AT }),
     );
 
-    expect(getSession(sessionId)).not.toBeNull();
+    expect(await getSession(sessionId)).not.toBeNull();
 
-    const cleaned = sweepStaleSessions(new Date(), SESSION_TTL_MS);
+    const cleaned = await sweepStaleSessions(new Date(), SESSION_TTL_MS);
 
-    expect(cleaned).toBeGreaterThanOrEqual(1);
-    expect(getSession(sessionId)).toBeNull();
-    expect(fs.existsSync(path.join(SESSION_ROOT, sessionId))).toBe(false);
+    expect(cleaned).toBe(1);
+    expect(await getSession(sessionId)).toBeNull();
   });
 
-  it("does NOT remove a fresh session still within the TTL", () => {
-    const { sessionId } = initiateSession(
+  it("does NOT remove a fresh session still within the TTL", async () => {
+    const { sessionId } = await initiateSession(
       makeInput({ sha256: "2".repeat(64), createdAt: NEW_CREATED_AT }),
     );
 
-    expect(getSession(sessionId)).not.toBeNull();
+    expect(await getSession(sessionId)).not.toBeNull();
 
-    sweepStaleSessions(new Date(), SESSION_TTL_MS);
+    await sweepStaleSessions(new Date(), SESSION_TTL_MS);
 
-    // Session must still be present — it was just created
-    expect(getSession(sessionId)).not.toBeNull();
+    expect(await getSession(sessionId)).not.toBeNull();
   });
 
-  it("removes the stale session while leaving the fresh one intact", () => {
-    // Stale: createdAt 26 h ago (past TTL)
-    const { sessionId: staleId } = initiateSession(
+  it("removes the stale session while leaving the fresh one intact", async () => {
+    const { sessionId: staleId } = await initiateSession(
       makeInput({ sha256: "3".repeat(64), createdAt: OLD_CREATED_AT }),
     );
-    // Fresh: createdAt now (within TTL)
-    const { sessionId: freshId } = initiateSession(
+    const { sessionId: freshId } = await initiateSession(
       makeInput({ sha256: "4".repeat(64), createdAt: NEW_CREATED_AT }),
     );
 
-    sweepStaleSessions(new Date(), SESSION_TTL_MS);
+    await sweepStaleSessions(new Date(), SESSION_TTL_MS);
 
-    // Stale must be gone; fresh must survive
-    expect(getSession(staleId)).toBeNull();
-    expect(getSession(freshId)).not.toBeNull();
+    expect(await getSession(staleId)).toBeNull();
+    expect(await getSession(freshId)).not.toBeNull();
   });
 
-  it("does NOT remove a session that already has an assembled.bin (completed)", () => {
-    // Even though the manifest says it's old, a completed session must not be purged
-    const { sessionId } = initiateSession(
+  it("removes a stale session's chunk bytes from the object store too", async () => {
+    const { sessionId } = await initiateSession(
       makeInput({ sha256: "5".repeat(64), createdAt: OLD_CREATED_AT }),
     );
+    await saveChunk(sessionId, 0, Buffer.alloc(1024));
+    expect(fakeStore.has(`evidence-sessions/${sessionId}/chunk_0`)).toBe(true);
 
-    // Simulate a completed upload by writing a dummy assembled.bin
-    const assembledPath = path.join(SESSION_ROOT, sessionId, "assembled.bin");
-    fs.writeFileSync(assembledPath, Buffer.alloc(0));
+    await sweepStaleSessions(new Date(), SESSION_TTL_MS);
 
-    sweepStaleSessions(new Date(), SESSION_TTL_MS);
-
-    expect(fs.existsSync(assembledPath)).toBe(true);
+    expect(fakeStore.has(`evidence-sessions/${sessionId}/chunk_0`)).toBe(false);
   });
 
-  it("removes an orphaned directory with no manifest if its mtime is past TTL", () => {
-    // Orphan: valid hex-64 name but no manifest.json (corrupt / partially initialised)
-    const orphanId = "e".repeat(64);
-    const orphanDir = path.join(SESSION_ROOT, orphanId);
-    fs.mkdirSync(orphanDir, { recursive: true });
+  it("a session already completed (removed from the index by cleanupSession) is not re-swept", async () => {
+    // The route's happy path calls cleanupSession itself once the assembled
+    // file is uploaded; simulate that by initiating and then completing the
+    // same lifecycle a completed upload would (session leaves the index).
+    const { sessionId } = await initiateSession(
+      makeInput({ sha256: "6".repeat(64), createdAt: OLD_CREATED_AT }),
+    );
+    const { cleanupSession } = await import("../services/evidence-upload-session.service");
+    await cleanupSession(sessionId);
 
-    // Back-date the directory so its mtime looks older than TTL
-    backdateSessionDir(orphanId, 26 * 60 * 60 * 1000);
-
-    const cleaned = sweepStaleSessions(new Date(), SESSION_TTL_MS);
-
-    expect(cleaned).toBeGreaterThanOrEqual(1);
-    expect(fs.existsSync(orphanDir)).toBe(false);
+    const cleaned = await sweepStaleSessions(new Date(), SESSION_TTL_MS);
+    expect(cleaned).toBe(0);
   });
 
-  it("returns 0 when SESSION_ROOT is empty", () => {
-    // After the earlier sweeps the tempRoot may still have some fresh sessions —
-    // just assert the return type and that it doesn't throw.
-    const cleaned = sweepStaleSessions(new Date(), SESSION_TTL_MS);
-    expect(typeof cleaned).toBe("number");
-    expect(cleaned).toBeGreaterThanOrEqual(0);
+  it("returns 0 when there are no active sessions", async () => {
+    const cleaned = await sweepStaleSessions(new Date(), SESSION_TTL_MS);
+    expect(cleaned).toBe(0);
   });
 });

--- a/backend/src/__tests__/evidence-upload-session.service.test.ts
+++ b/backend/src/__tests__/evidence-upload-session.service.test.ts
@@ -1,13 +1,26 @@
-import fs from "fs";
-import path from "path";
-import os from "os";
-import { Buffer } from "buffer";
 import crypto from "crypto";
+import {
+  FakeEvidenceObjectStore,
+  FakeRedisStore,
+} from "./testUtils/evidenceSessionFakes";
 
-// Mock the environment variable for SESSION_ROOT before importing the service
-const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-session-test-"));
-process.env.EVIDENCE_SESSION_DIR = tempDir;
-process.env.UPLOAD_DIR = tempDir;
+const fakeRedis = new FakeRedisStore();
+const fakeStore = new FakeEvidenceObjectStore();
+
+jest.mock("../lib/redis", () => ({
+  __esModule: true,
+  default: { getInstance: () => fakeRedis },
+}));
+
+jest.mock("../services/evidence-storage.service", () => ({
+  uploadEvidenceBuffer: jest.fn(async ({ key, body }: { key: string; body: Buffer }) => {
+    fakeStore.put(key, body);
+  }),
+  readEvidenceObject: jest.fn(async (key: string) => fakeStore.get(key)),
+  deleteEvidenceObjects: jest.fn(async (keys: string[]) => {
+    fakeStore.delete(keys);
+  }),
+}));
 
 import {
   validateInitiateInput,
@@ -16,6 +29,7 @@ import {
   assembleAndVerify,
   cleanupSession,
   getSession,
+  getReceivedChunks,
   deriveSessionId,
   CHUNK_SIZE,
   MIN_CHUNK_SIZE,
@@ -24,8 +38,9 @@ import {
 } from "../services/evidence-upload-session.service";
 
 describe("Evidence Upload Session Service", () => {
-  afterAll(() => {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+  afterEach(() => {
+    fakeRedis.clear();
+    fakeStore.clear();
   });
 
   describe("validateInitiateInput", () => {
@@ -77,101 +92,127 @@ describe("Evidence Upload Session Service", () => {
       createdAt: new Date().toISOString(),
     };
 
-    let sessionId: string;
-
-    it("should initiate session idempotently", () => {
-      const result1 = initiateSession(input);
-      sessionId = result1.sessionId;
+    it("should initiate session idempotently", async () => {
+      const result1 = await initiateSession(input);
+      const sessionId = result1.sessionId;
       expect(result1.manifest.disputeId).toBe(input.disputeId);
-      
-      const result2 = initiateSession(input);
+
+      const result2 = await initiateSession(input);
       expect(result2.sessionId).toBe(sessionId);
       expect(result2.receivedChunks).toEqual([]);
     });
 
-    it("should wipe session on identity mismatch", () => {
-      // Modify size, which creates an identity mismatch
+    it("should wipe session on identity mismatch", async () => {
+      const { sessionId } = await initiateSession(input);
       const mismatchedInput = { ...input, size: CHUNK_SIZE + 2048 };
-      
-      // Since deriveSessionId uses only dispute, uploader, sha256
-      // the sessionId is the same, but the identity differs!
-      const result = initiateSession(mismatchedInput);
+
+      // Same (disputeId, uploaderId, sha256) => same derived id, different identity.
+      const result = await initiateSession(mismatchedInput);
       expect(result.sessionId).toBe(sessionId);
       expect(result.manifest.size).toBe(mismatchedInput.size);
     });
 
-    it("should validate chunk sizes and indexes", () => {
+    it("should validate chunk sizes and indexes", async () => {
+      const { sessionId } = await initiateSession(input);
       const data = Buffer.alloc(CHUNK_SIZE);
-      
-      // Index out of range
-      expect(() => saveChunk(sessionId, 5, data)).toThrow("Chunk index out of range");
-      
-      // Too large
-      expect(() => saveChunk(sessionId, 0, Buffer.alloc(MAX_CHUNK_SIZE + 1))).toThrow("Chunk larger than declared chunkSize");
-      
-      // Non-final chunk wrong size
-      expect(() => saveChunk(sessionId, 0, Buffer.alloc(CHUNK_SIZE - 1))).toThrow("Non-final chunk must be exactly chunkSize bytes");
+
+      await expect(saveChunk(sessionId, 5, data)).rejects.toThrow("Chunk index out of range");
+      await expect(saveChunk(sessionId, 0, Buffer.alloc(MAX_CHUNK_SIZE + 1))).rejects.toThrow(
+        "Chunk larger than declared chunkSize",
+      );
+      await expect(saveChunk(sessionId, 0, Buffer.alloc(CHUNK_SIZE - 1))).rejects.toThrow(
+        "Non-final chunk must be exactly chunkSize bytes",
+      );
     });
 
-    it("should save valid chunks", () => {
-      // Create fresh session
-      initiateSession(input);
+    it("should save valid chunks and persist chunk bytes in the object store", async () => {
+      const { sessionId } = await initiateSession(input);
 
       const chunk0 = Buffer.alloc(CHUNK_SIZE, "0");
-      const result0 = saveChunk(sessionId, 0, chunk0);
+      const result0 = await saveChunk(sessionId, 0, chunk0);
       expect(result0.receivedChunks).toEqual([0]);
 
       const chunk1 = Buffer.alloc(1024, "1");
-      const result1 = saveChunk(sessionId, 1, chunk1);
+      const result1 = await saveChunk(sessionId, 1, chunk1);
       expect(result1.receivedChunks).toEqual([0, 1]);
+
+      expect(await getReceivedChunks(sessionId)).toEqual([0, 1]);
     });
 
-    it("should assemble and verify (verified: false on mismatch)", () => {
-      // Re-initiate with an actual hash mismatch
+    it("re-saving an already-stored chunk is idempotent", async () => {
+      const { sessionId } = await initiateSession(input);
       const chunk0 = Buffer.alloc(CHUNK_SIZE, "0");
-      const chunk1 = Buffer.alloc(1024, "1");
-      
-      const fakeSha256 = crypto.createHash("sha256").update(Buffer.concat([chunk0, chunk1])).digest("hex");
-      
-      const realSha256 = "b".repeat(64); // Intentionally wrong
-      const mismatchedHashInput = { ...input, sha256: realSha256 };
-      initiateSession(mismatchedHashInput);
-      
-      const sid = mismatchedHashInput.sha256 === input.sha256 ? sessionId : deriveSessionId(input.disputeId, input.uploaderId, realSha256);
-      
-      saveChunk(sid, 0, chunk0);
-      saveChunk(sid, 1, chunk1);
-      
-      const assembled = assembleAndVerify(sid);
-      expect(assembled.verified).toBe(false);
-      expect(assembled.computedSha256).toBe(fakeSha256);
+
+      await saveChunk(sessionId, 0, chunk0);
+      const result = await saveChunk(sessionId, 0, chunk0);
+      expect(result.receivedChunks).toEqual([0]);
     });
-    
-    it("should assemble and verify (verified: true on match)", () => {
+
+    it("should reject a chunk for a session that doesn't exist", async () => {
+      const bogusId = "0".repeat(64);
+      await expect(saveChunk(bogusId, 0, Buffer.alloc(CHUNK_SIZE))).rejects.toThrow("Session not found");
+    });
+
+    it("should assemble and verify (verified: false on hash mismatch)", async () => {
       const chunk0 = Buffer.alloc(CHUNK_SIZE, "0");
       const chunk1 = Buffer.alloc(1024, "1");
-      
+      const actualSha256 = crypto.createHash("sha256").update(Buffer.concat([chunk0, chunk1])).digest("hex");
+      const declaredWrongSha256 = "b".repeat(64);
+
+      const { sessionId } = await initiateSession({ ...input, sha256: declaredWrongSha256 });
+      await saveChunk(sessionId, 0, chunk0);
+      await saveChunk(sessionId, 1, chunk1);
+
+      const assembled = await assembleAndVerify(sessionId);
+      expect(assembled.verified).toBe(false);
+      expect(assembled.computedSha256).toBe(actualSha256);
+    });
+
+    it("should assemble and verify (verified: true on match)", async () => {
+      const chunk0 = Buffer.alloc(CHUNK_SIZE, "0");
+      const chunk1 = Buffer.alloc(1024, "1");
       const realSha256 = crypto.createHash("sha256").update(Buffer.concat([chunk0, chunk1])).digest("hex");
-      
-      const matchedHashInput = { ...input, sha256: realSha256 };
-      initiateSession(matchedHashInput);
-      const sid = deriveSessionId(input.disputeId, input.uploaderId, realSha256);
-      
-      saveChunk(sid, 0, chunk0);
-      saveChunk(sid, 1, chunk1);
-      
-      const assembled = assembleAndVerify(sid);
+
+      const { sessionId } = await initiateSession({ ...input, sha256: realSha256 });
+      await saveChunk(sessionId, 0, chunk0);
+      await saveChunk(sessionId, 1, chunk1);
+
+      const assembled = await assembleAndVerify(sessionId);
       expect(assembled.verified).toBe(true);
       expect(assembled.computedSha256).toBe(realSha256);
     });
 
-    it("should cleanup session", () => {
-      const sid = deriveSessionId(input.disputeId, input.uploaderId, input.sha256);
-      initiateSession(input);
-      expect(getSession(sid)).not.toBeNull();
-      
-      cleanupSession(sid);
-      expect(getSession(sid)).toBeNull();
+    it("should reject assembly while a chunk is still missing", async () => {
+      const { sessionId } = await initiateSession(input);
+      await saveChunk(sessionId, 0, Buffer.alloc(CHUNK_SIZE));
+      await expect(assembleAndVerify(sessionId)).rejects.toThrow("Missing chunk 1");
+    });
+
+    it("should cleanup a session's manifest, chunk index, and object-store bytes", async () => {
+      const { sessionId } = await initiateSession(input);
+      await saveChunk(sessionId, 0, Buffer.alloc(CHUNK_SIZE));
+
+      expect(await getSession(sessionId)).not.toBeNull();
+
+      await cleanupSession(sessionId);
+
+      expect(await getSession(sessionId)).toBeNull();
+      expect(await getReceivedChunks(sessionId)).toEqual([]);
+    });
+
+    it("cleanupSession on a session that never existed is a no-op, not an error", async () => {
+      const bogusId = "f".repeat(64);
+      await expect(cleanupSession(bogusId)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("deriveSessionId", () => {
+    it("is a pure function of (disputeId, uploaderId, sha256)", () => {
+      const a = deriveSessionId("d1", "u1", "a".repeat(64));
+      const b = deriveSessionId("d1", "u1", "a".repeat(64));
+      const c = deriveSessionId("d1", "u1", "b".repeat(64));
+      expect(a).toBe(b);
+      expect(a).not.toBe(c);
     });
   });
 });

--- a/backend/src/__tests__/testUtils/evidenceSessionFakes.ts
+++ b/backend/src/__tests__/testUtils/evidenceSessionFakes.ts
@@ -1,0 +1,81 @@
+/**
+ * In-memory stand-ins for the two shared backends evidence-upload-session.service
+ * now depends on (Redis for manifest/chunk-index state, S3 for chunk bytes), so
+ * the service's tests exercise real state transitions without a live Redis
+ * server or object store. Reset between tests via `.clear()`.
+ */
+
+export class FakeRedisStore {
+  private strings = new Map<string, string>();
+  private sets = new Map<string, Set<string>>();
+
+  clear(): void {
+    this.strings.clear();
+    this.sets.clear();
+  }
+
+  get = async (key: string): Promise<string | null> => this.strings.get(key) ?? null;
+
+  set = async (key: string, value: string): Promise<"OK"> => {
+    this.strings.set(key, value);
+    return "OK";
+  };
+
+  del = async (...keys: string[]): Promise<number> => {
+    let removed = 0;
+    for (const key of keys) {
+      if (this.strings.delete(key)) removed += 1;
+      if (this.sets.delete(key)) removed += 1;
+    }
+    return removed;
+  };
+
+  sadd = async (key: string, ...members: string[]): Promise<number> => {
+    const set = this.sets.get(key) ?? new Set<string>();
+    let added = 0;
+    for (const m of members) {
+      if (!set.has(m)) added += 1;
+      set.add(m);
+    }
+    this.sets.set(key, set);
+    return added;
+  };
+
+  srem = async (key: string, ...members: string[]): Promise<number> => {
+    const set = this.sets.get(key);
+    if (!set) return 0;
+    let removed = 0;
+    for (const m of members) {
+      if (set.delete(m)) removed += 1;
+    }
+    return removed;
+  };
+
+  smembers = async (key: string): Promise<string[]> => Array.from(this.sets.get(key) ?? []);
+}
+
+export class FakeEvidenceObjectStore {
+  private objects = new Map<string, Buffer>();
+
+  clear(): void {
+    this.objects.clear();
+  }
+
+  put(key: string, body: Buffer): void {
+    this.objects.set(key, body);
+  }
+
+  get(key: string): Buffer {
+    const found = this.objects.get(key);
+    if (!found) throw new Error(`Evidence object not found: ${key}`);
+    return found;
+  }
+
+  delete(keys: string[]): void {
+    for (const key of keys) this.objects.delete(key);
+  }
+
+  has(key: string): boolean {
+    return this.objects.has(key);
+  }
+}

--- a/backend/src/jobs/evidence-session-cleanup.job.ts
+++ b/backend/src/jobs/evidence-session-cleanup.job.ts
@@ -1,15 +1,10 @@
-import fs from "fs";
-import path from "path";
 import Redis from "ioredis";
 import {
-  SESSION_ROOT,
   cleanupSession,
   getSession,
+  listActiveSessionIds,
 } from "../services/evidence-upload-session.service";
 import { logger } from "../lib/logger";
-
-/** Only directories whose name looks like a derived session id are considered. */
-const HEX64 = /^[a-f0-9]{64}$/;
 
 /** Sessions older than this with no assembled file are purged. Default: 24 h. */
 export const SESSION_TTL_MS =
@@ -50,102 +45,75 @@ async function releaseLock(redis: Redis): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Core sweep logic (pure, no Redis dependency — testable in isolation)
+// Core sweep logic (pure Redis/S3 side effects via the session service; no
+// direct Redis dependency of its own — testable by mocking the service).
 // ---------------------------------------------------------------------------
 
 /**
- * Inspect SESSION_ROOT and remove every session directory that:
- *   1. Has a parseable manifest.json with a valid `createdAt` timestamp, AND
- *   2. Was created more than `ttlMs` milliseconds ago, AND
- *   3. Has no `assembled.bin` file (i.e. the upload was never completed).
+ * Every session still listed in the active-session index that:
+ *   1. Has a readable manifest with a parseable `createdAt`, AND
+ *   2. Was created more than `ttlMs` milliseconds ago
+ * is discarded (Redis manifest/chunk-set entries, S3 chunk objects, and its
+ * slot in the index).
  *
- * Directories that cannot be parsed (corrupted / no manifest) and are older
- * than the TTL are also removed — they are definitively unrecoverable.
+ * A session only reaches this sweep by being abandoned: both the happy path
+ * (`POST .../complete`) and the explicit abort (`DELETE .../sessions/:id`)
+ * call `cleanupSession`, which removes it from the index immediately. So
+ * anything still indexed past the TTL was never finished by its client —
+ * unlike the old disk-backed sweep, there's no need to special-case "has an
+ * assembled file" here, since a session that reached completion is already
+ * gone from the index by the time this runs.
  *
- * @param now     - Current time (injectable for testing)
- * @param ttlMs   - Age threshold in milliseconds (injectable for testing)
- * @returns       - Number of sessions cleaned up
+ * Sessions with a missing/corrupt manifest (index entry outlived its data,
+ * e.g. a crash between `sadd` and `set`) are swept unconditionally — they're
+ * definitively unrecoverable.
+ *
+ * @param now   - Current time (injectable for testing)
+ * @param ttlMs - Age threshold in milliseconds (injectable for testing)
+ * @returns     - Number of sessions cleaned up
  */
-export function sweepStaleSessions(
+export async function sweepStaleSessions(
   now: Date = new Date(),
   ttlMs: number = SESSION_TTL_MS,
-): number {
-  if (!fs.existsSync(SESSION_ROOT)) {
-    logger.debug(
-      { sessionRoot: SESSION_ROOT },
-      "[EvidenceSessionCleanup] SESSION_ROOT does not exist — nothing to sweep",
-    );
-    return 0;
-  }
-
-  let entries: string[];
+): Promise<number> {
+  let sessionIds: string[];
   try {
-    entries = fs.readdirSync(SESSION_ROOT);
+    sessionIds = await listActiveSessionIds();
   } catch (err) {
     logger.error(
-      { err, sessionRoot: SESSION_ROOT },
-      "[EvidenceSessionCleanup] Failed to read SESSION_ROOT",
+      { err },
+      "[EvidenceSessionCleanup] Failed to read the active-session index",
     );
     return 0;
   }
 
-  const cutoff = new Date(now.getTime() - ttlMs);
+  const cutoff = now.getTime() - ttlMs;
   let cleaned = 0;
 
-  for (const entry of entries) {
-    const sessionId = entry;
-    const sessionPath = path.join(SESSION_ROOT, entry);
-
-    // Skip anything that is not a directory (e.g. stray files at root level)
-    let stat: fs.Stats;
+  for (const sessionId of sessionIds) {
+    let manifest;
     try {
-      stat = fs.statSync(sessionPath);
-    } catch {
+      manifest = await getSession(sessionId);
+    } catch (err) {
+      logger.error({ err, sessionId }, "[EvidenceSessionCleanup] Failed to read session manifest");
       continue;
     }
-    if (!stat.isDirectory()) continue;
 
-    // Skip entries that are not valid session IDs (e.g. temp dirs from test runners)
-    if (!HEX64.test(sessionId)) continue;
-
-    // Attempt to read the manifest to get createdAt
-    const manifest = getSession(sessionId);
-
-    // Determine age —
-    //   • If manifest is readable, trust its createdAt field.
-    //   • If manifest is missing/corrupt, fall back to the directory mtime so
-    //     truly orphaned directories are still eventually cleaned up.
-    let sessionAge: Date;
-    if (manifest?.createdAt) {
-      const parsed = new Date(manifest.createdAt);
-      sessionAge = isNaN(parsed.getTime()) ? new Date(stat.mtimeMs) : parsed;
+    let isStale: boolean;
+    if (!manifest) {
+      // Indexed but no manifest — an orphaned index entry from a partial write.
+      isStale = true;
     } else {
-      sessionAge = new Date(stat.mtimeMs);
+      const createdAt = new Date(manifest.createdAt).getTime();
+      isStale = Number.isNaN(createdAt) ? true : createdAt <= cutoff;
     }
 
-    if (sessionAge > cutoff) {
-      // Session is still within the TTL window — leave it alone.
-      continue;
-    }
+    if (!isStale) continue;
 
-    // Check if the upload was already completed (assembled.bin present).
-    // A completed session should have been cleaned up reactively; if somehow
-    // it wasn't, a completed assembled.bin represents a finished upload that
-    // still needs DB post-processing — leave it for the route to handle.
-    const assembledPath = path.join(sessionPath, "assembled.bin");
-    if (fs.existsSync(assembledPath)) {
-      logger.warn(
-        { sessionId, sessionAge: sessionAge.toISOString() },
-        "[EvidenceSessionCleanup] Stale session has assembled.bin — skipping to avoid interfering with completion",
-      );
-      continue;
-    }
-
-    // Session is stale and unfinished — purge it.
     try {
-      cleanupSession(sessionId);
+      await cleanupSession(sessionId);
       logger.info(
-        { sessionId, sessionAge: sessionAge.toISOString(), ttlMs },
+        { sessionId, createdAt: manifest?.createdAt, ttlMs },
         "[EvidenceSessionCleanup] Removed stale evidence session",
       );
       cleaned += 1;
@@ -195,7 +163,7 @@ async function executeWithLock(): Promise<void> {
       { at: new Date().toISOString(), ttlMs: SESSION_TTL_MS },
       "[EvidenceSessionCleanup] Running sweep",
     );
-    const cleaned = sweepStaleSessions();
+    const cleaned = await sweepStaleSessions();
     logger.info(
       { cleaned },
       "[EvidenceSessionCleanup] Sweep complete",

--- a/backend/src/routes/__tests__/evidence-chunked-upload.test.ts
+++ b/backend/src/routes/__tests__/evidence-chunked-upload.test.ts
@@ -1,23 +1,32 @@
 import express from "express";
 import request from "supertest";
 import jwt from "jsonwebtoken";
-import fs from "fs";
-import os from "os";
-import path from "path";
 import crypto from "crypto";
 import { Buffer } from "buffer";
 // Imported here (rather than required inside the jest.mock factory below) using
 // jest's "mock"-prefixed variable exemption so the factory can reference them
 // without violating the out-of-scope-variable restriction on jest.mock factories.
 import * as mockJwt from "jsonwebtoken";
+import {
+  FakeEvidenceObjectStore,
+  FakeRedisStore,
+} from "../../__tests__/testUtils/evidenceSessionFakes";
 
-// Drive the session service to a temp dir and mark storage configured BEFORE any
-// module that reads those values is required.
-const TEMP_SESSION_DIR = fs.mkdtempSync(
-  path.join(os.tmpdir(), "evidence-sessions-"),
-);
-process.env.EVIDENCE_SESSION_DIR = TEMP_SESSION_DIR;
+// The session manifest/chunk-index state lives in Redis and chunk/assembled
+// bytes live in the S3-compatible object store — both mocked below with
+// stateful in-memory fakes, since this test exercises real resumability
+// (partial upload -> status -> resume), which needs get/set/sadd/smembers to
+// actually round-trip. jest.setup.ts's global ../lib/redis stub is stateless
+// and doesn't implement sadd/srem/smembers at all, so it's overridden here.
 process.env.EVIDENCE_S3_BUCKET = "test-bucket";
+
+const fakeRedis = new FakeRedisStore();
+const fakeStore = new FakeEvidenceObjectStore();
+
+jest.mock("../../lib/redis", () => ({
+  __esModule: true,
+  default: { getInstance: () => fakeRedis },
+}));
 
 // `config` is a top-level singleton evaluated at module-load time from
 // process.env — it must be required (not statically imported, which ES
@@ -74,6 +83,13 @@ jest.mock("../../services/evidence-storage.service", () => {
   return {
     ...actual,
     uploadEvidenceObject: jest.fn().mockResolvedValue(undefined),
+    uploadEvidenceBuffer: jest.fn(async ({ key, body }: { key: string; body: Buffer }) => {
+      fakeStore.put(key, body);
+    }),
+    readEvidenceObject: jest.fn(async (key: string) => fakeStore.get(key)),
+    deleteEvidenceObjects: jest.fn(async (keys: string[]) => {
+      fakeStore.delete(keys);
+    }),
   };
 });
 
@@ -148,10 +164,6 @@ function chunkify(buf: Buffer): Buffer[] {
 }
 
 describe("Chunked / resumable evidence upload", () => {
-  afterAll(() => {
-    fs.rmSync(TEMP_SESSION_DIR, { recursive: true, force: true });
-  });
-
   it("uploads a multi-chunk file and records the server-verified hash", async () => {
     const buf = makeFile(CHUNK_SIZE + 1234); // 2 chunks
     const hash = sha256(buf);

--- a/backend/src/routes/dispute.routes.ts
+++ b/backend/src/routes/dispute.routes.ts
@@ -711,7 +711,7 @@ router.post(
       return res.status(400).json({ error: reason });
     }
 
-    const { sessionId, manifest, receivedChunks } = initiateSession({
+    const { sessionId, manifest, receivedChunks } = await initiateSession({
       disputeId,
       uploaderId: req.userId!,
       originalName: body.originalName,
@@ -742,14 +742,14 @@ router.get(
   validate({ params: evidenceSessionParamSchema }),
   asyncHandler(async (req: AuthRequest, res: Response) => {
     const { sessionId } = req.params as unknown as { sessionId: string };
-    const manifest = getSession(sessionId);
+    const manifest = await getSession(sessionId);
     if (!manifest) {
       return res.status(404).json({ error: "Upload session not found" });
     }
     return res.status(200).json({
       sessionId,
       totalChunks: manifest.totalChunks,
-      receivedChunks: getReceivedChunks(sessionId),
+      receivedChunks: await getReceivedChunks(sessionId),
     });
   }),
 );
@@ -770,7 +770,7 @@ router.put(
       index: string;
     };
 
-    const manifest = getSession(sessionId);
+    const manifest = await getSession(sessionId);
     if (!manifest) {
       return res.status(404).json({ error: "Upload session not found" });
     }
@@ -789,7 +789,7 @@ router.put(
 
     let receivedChunks: number[];
     try {
-      ({ receivedChunks } = saveChunk(sessionId, Number(index), req.body));
+      ({ receivedChunks } = await saveChunk(sessionId, Number(index), req.body));
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to store chunk";
@@ -812,7 +812,7 @@ router.post(
   validate({ params: evidenceSessionParamSchema }),
   asyncHandler(async (req: AuthRequest, res: Response) => {
     const { sessionId } = req.params as unknown as { sessionId: string };
-    const manifest = getSession(sessionId);
+    const manifest = await getSession(sessionId);
     if (!manifest) {
       return res.status(404).json({ error: "Upload session not found" });
     }
@@ -827,7 +827,7 @@ router.post(
 
     let assembled;
     try {
-      assembled = assembleAndVerify(sessionId);
+      assembled = await assembleAndVerify(sessionId);
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to assemble file";
@@ -835,7 +835,7 @@ router.post(
     }
 
     if (!assembled.verified) {
-      cleanupSession(sessionId);
+      await cleanupSession(sessionId);
       return res.status(422).json({
         error:
           "Integrity check failed: server-computed hash does not match the declared hash",
@@ -846,7 +846,7 @@ router.post(
 
     const validation = await validateFileMimeType(assembled.filePath);
     if (!validation.valid) {
-      cleanupSession(sessionId);
+      await cleanupSession(sessionId);
       return res.status(415).json({
         error: validation.error || "Unsupported file type",
       });
@@ -861,7 +861,7 @@ router.post(
       });
     } finally {
       // The assembled file exists only while validating + uploading it.
-      cleanupSession(sessionId);
+      await cleanupSession(sessionId);
     }
 
     const candidateAnchorTx = manifest.anchorTxHash || null;
@@ -911,7 +911,7 @@ router.delete(
   validate({ params: evidenceSessionParamSchema }),
   asyncHandler(async (req: AuthRequest, res: Response) => {
     const { sessionId } = req.params as unknown as { sessionId: string };
-    const manifest = getSession(sessionId);
+    const manifest = await getSession(sessionId);
     if (!manifest) {
       return res.status(404).json({ error: "Upload session not found" });
     }
@@ -922,7 +922,7 @@ router.delete(
     if (!access.allowed) {
       return res.status(access.status).json({ error: access.error });
     }
-    cleanupSession(sessionId);
+    await cleanupSession(sessionId);
     return res.status(200).json({ sessionId, aborted: true });
   }),
 );

--- a/backend/src/services/evidence-storage.service.ts
+++ b/backend/src/services/evidence-storage.service.ts
@@ -1,4 +1,9 @@
-import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
 import fs from "fs";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { config } from "../config";
@@ -43,6 +48,42 @@ export async function uploadEvidenceObject({
       Key: key,
       Body: fs.createReadStream(filePath),
       ContentType: contentType,
+    }),
+  );
+}
+
+/**
+ * Same as `uploadEvidenceObject`, but for bytes already in memory (e.g. one
+ * chunk of a resumable upload) rather than a file on the local disk — so
+ * callers never need to round-trip through a temp file just to hand this
+ * function something it can stream.
+ */
+export async function uploadEvidenceBuffer({
+  key,
+  body,
+  contentType,
+}: {
+  key: string;
+  body: Buffer;
+  contentType: string;
+}): Promise<void> {
+  await getS3Client().send(
+    new PutObjectCommand({
+      Bucket: getBucket(),
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+    }),
+  );
+}
+
+/** Batch-deletes up to 1000 keys in one request. No-op for an empty list. */
+export async function deleteEvidenceObjects(keys: string[]): Promise<void> {
+  if (keys.length === 0) return;
+  await getS3Client().send(
+    new DeleteObjectsCommand({
+      Bucket: getBucket(),
+      Delete: { Objects: keys.map((Key) => ({ Key })), Quiet: true },
     }),
   );
 }

--- a/backend/src/services/evidence-upload-session.service.ts
+++ b/backend/src/services/evidence-upload-session.service.ts
@@ -1,7 +1,14 @@
 import crypto from "crypto";
 import fs from "fs";
+import os from "os";
 import path from "path";
-import { UPLOAD_DIR, MAX_FILE_SIZE } from "../config/upload";
+import { MAX_FILE_SIZE } from "../config/upload";
+import RedisClient from "../lib/redis";
+import {
+  deleteEvidenceObjects,
+  readEvidenceObject,
+  uploadEvidenceBuffer,
+} from "./evidence-storage.service";
 
 /**
  * Chunked / resumable evidence upload sessions.
@@ -9,10 +16,16 @@ import { UPLOAD_DIR, MAX_FILE_SIZE } from "../config/upload";
  * A session is a single file being uploaded to a single dispute by a single
  * uploader. Chunk boundaries mirror the 2 MB boundaries the client already uses
  * for SHA-256 hashing, so the network transfer and the integrity proof share the
- * same unit of progress. Session state lives entirely on disk under
- * SESSION_ROOT/<sessionId>/, so "which chunks are already here" is derived from
- * the filesystem (a completed rename) rather than trusted client state. That
- * makes resume deterministic: same inputs -> same received-chunk set.
+ * same unit of progress.
+ *
+ * Session state (the manifest and the set of received chunk indexes) lives in
+ * Redis, and chunk bytes live in the same S3-compatible object store the
+ * assembled file is eventually uploaded to. Both are reachable from every
+ * backend instance, so a chunked upload survives being load-balanced across a
+ * different instance on every request — unlike storing this on local disk,
+ * where a request landing on an instance that didn't handle an earlier step
+ * would see "Session not found" or "Missing chunk N" even though the upload
+ * is, from the client's point of view, proceeding normally.
  */
 
 export const CHUNK_SIZE = 2 * 1024 * 1024; // 2 MB, matches client hashing chunks
@@ -21,13 +34,14 @@ export const MAX_CHUNK_SIZE = 4 * 1024 * 1024; // upper bound accepted per chunk
 export const MAX_TOTAL_CHUNKS = 64;
 export const MIN_CHUNK_SIZE = 256 * 1024; // 256 KB floor to bound chunk count
 
-export const SESSION_ROOT =
-  process.env.EVIDENCE_SESSION_DIR ||
-  path.join(UPLOAD_DIR, "evidence-sessions");
+const MANIFEST_KEY_PREFIX = "evidence-session:manifest:";
+const CHUNKS_KEY_PREFIX = "evidence-session:chunks:";
+/** Every active session id, so the cleanup sweep never needs a Redis KEYS/SCAN over the whole keyspace. */
+const SESSION_INDEX_KEY = "evidence-sessions:index";
+const CHUNK_OBJECT_PREFIX = "evidence-sessions";
 
-if (!fs.existsSync(SESSION_ROOT)) {
-  fs.mkdirSync(SESSION_ROOT, { recursive: true });
-}
+/** Where `assembleAndVerify` writes the concatenated file for the single request that reads it back. */
+const ASSEMBLE_TMP_ROOT = path.join(os.tmpdir(), "evidence-assemble");
 
 export interface SessionManifest {
   sessionId: string;
@@ -64,17 +78,19 @@ function assertSafeSessionId(sessionId: string): void {
   }
 }
 
-function sessionDir(sessionId: string): string {
+function manifestKey(sessionId: string): string {
   assertSafeSessionId(sessionId);
-  return path.join(SESSION_ROOT, sessionId);
+  return `${MANIFEST_KEY_PREFIX}${sessionId}`;
 }
 
-function manifestPath(sessionId: string): string {
-  return path.join(sessionDir(sessionId), "manifest.json");
+function chunksKey(sessionId: string): string {
+  assertSafeSessionId(sessionId);
+  return `${CHUNKS_KEY_PREFIX}${sessionId}`;
 }
 
-function chunkPath(sessionId: string, index: number): string {
-  return path.join(sessionDir(sessionId), `chunk_${index}`);
+function chunkObjectKey(sessionId: string, index: number): string {
+  assertSafeSessionId(sessionId);
+  return `${CHUNK_OBJECT_PREFIX}/${sessionId}/chunk_${index}`;
 }
 
 /**
@@ -122,50 +138,43 @@ export function validateInitiateInput(
   return null;
 }
 
-export function getSession(sessionId: string): SessionManifest | null {
-  const mp = manifestPath(sessionId);
-  if (!fs.existsSync(mp)) return null;
+export async function getSession(sessionId: string): Promise<SessionManifest | null> {
+  const raw = await RedisClient.getInstance().get(manifestKey(sessionId));
+  if (!raw) return null;
   try {
-    return JSON.parse(fs.readFileSync(mp, "utf-8")) as SessionManifest;
+    return JSON.parse(raw) as SessionManifest;
   } catch {
     return null;
   }
 }
 
 /**
- * Which chunk indexes are already fully persisted. A chunk only counts once its
- * atomic rename from chunk_N.part -> chunk_N has completed, so a crash mid-write
- * never makes a partial chunk look complete.
+ * Which chunk indexes are already fully persisted. A chunk only counts once
+ * its upload to the object store has completed, so a crash mid-upload never
+ * makes a partial chunk look complete.
  */
-export function getReceivedChunks(sessionId: string): number[] {
-  const dir = sessionDir(sessionId);
-  if (!fs.existsSync(dir)) return [];
-  const received: number[] = [];
-  for (const name of fs.readdirSync(dir)) {
-    const m = /^chunk_(\d+)$/.exec(name);
-    if (m) received.push(Number(m[1]));
-  }
-  return received.sort((a, b) => a - b);
+export async function getReceivedChunks(sessionId: string): Promise<number[]> {
+  const members = await RedisClient.getInstance().smembers(chunksKey(sessionId));
+  return members.map(Number).sort((a, b) => a - b);
 }
 
 /**
  * Create the session if new, or return the existing one (idempotent). When a
- * session already exists for the derived id we treat the on-disk manifest as
+ * session already exists for the derived id we treat the stored manifest as
  * authoritative unless the declared file identity (hash/size/chunking) differs,
  * in which case the stale session is discarded and recreated.
  */
-export function initiateSession(input: InitiateInput): {
+export async function initiateSession(input: InitiateInput): Promise<{
   sessionId: string;
   manifest: SessionManifest;
   receivedChunks: number[];
-} {
+}> {
   const sessionId = deriveSessionId(
     input.disputeId,
     input.uploaderId,
     input.sha256,
   );
-  const dir = sessionDir(sessionId);
-  const existing = getSession(sessionId);
+  const existing = await getSession(sessionId);
 
   const identityMatches =
     existing &&
@@ -178,16 +187,15 @@ export function initiateSession(input: InitiateInput): {
     return {
       sessionId,
       manifest: existing,
-      receivedChunks: getReceivedChunks(sessionId),
+      receivedChunks: await getReceivedChunks(sessionId),
     };
   }
 
   if (existing && !identityMatches) {
     // Same id, different file identity: wipe and start clean.
-    fs.rmSync(dir, { recursive: true, force: true });
+    await cleanupSession(sessionId);
   }
 
-  fs.mkdirSync(dir, { recursive: true });
   const manifest: SessionManifest = {
     sessionId,
     disputeId: input.disputeId,
@@ -201,7 +209,10 @@ export function initiateSession(input: InitiateInput): {
     anchorTxHash: input.anchorTxHash ?? null,
     createdAt: input.createdAt,
   };
-  fs.writeFileSync(manifestPath(sessionId), JSON.stringify(manifest));
+
+  const redis = RedisClient.getInstance();
+  await redis.set(manifestKey(sessionId), JSON.stringify(manifest));
+  await redis.sadd(SESSION_INDEX_KEY, sessionId);
 
   return { sessionId, manifest, receivedChunks: [] };
 }
@@ -210,12 +221,12 @@ export function initiateSession(input: InitiateInput): {
  * Persist one chunk. Idempotent: re-sending an already-stored chunk is a no-op
  * success, which is exactly what a retry after an ambiguous failure needs.
  */
-export function saveChunk(
+export async function saveChunk(
   sessionId: string,
   index: number,
   data: Buffer,
-): { receivedChunks: number[] } {
-  const manifest = getSession(sessionId);
+): Promise<{ receivedChunks: number[] }> {
+  const manifest = await getSession(sessionId);
   if (!manifest) throw new Error("Session not found");
 
   if (!Number.isInteger(index) || index < 0 || index >= manifest.totalChunks) {
@@ -229,12 +240,14 @@ export function saveChunk(
     throw new Error("Non-final chunk must be exactly chunkSize bytes");
   }
 
-  const finalPath = chunkPath(sessionId, index);
-  const tmpPath = `${finalPath}.part`;
-  fs.writeFileSync(tmpPath, data);
-  fs.renameSync(tmpPath, finalPath); // atomic publish
+  await uploadEvidenceBuffer({
+    key: chunkObjectKey(sessionId, index),
+    body: data,
+    contentType: "application/octet-stream",
+  });
+  await RedisClient.getInstance().sadd(chunksKey(sessionId), String(index));
 
-  return { receivedChunks: getReceivedChunks(sessionId) };
+  return { receivedChunks: await getReceivedChunks(sessionId) };
 }
 
 export interface AssembledFile {
@@ -249,23 +262,33 @@ export interface AssembledFile {
  * SHA-256 over the assembled bytes. `verified` is true only when the recomputed
  * hash matches the client-declared hash, so a resumed/retried upload that
  * silently corrupted a chunk cannot pass as "matching" the original.
+ *
+ * The assembled file is written to local disk under a path scoped to this
+ * session, unlike the chunks and manifest — but that's fine here: it exists
+ * only for the lifetime of this one request (assemble -> validate -> upload
+ * to its final S3 key -> delete), on whichever instance happened to handle
+ * the /complete call. It never needs to be visible to a different instance.
  */
-export function assembleAndVerify(sessionId: string): AssembledFile {
-  const manifest = getSession(sessionId);
+export async function assembleAndVerify(sessionId: string): Promise<AssembledFile> {
+  const manifest = await getSession(sessionId);
   if (!manifest) throw new Error("Session not found");
 
-  const received = new Set(getReceivedChunks(sessionId));
+  const received = new Set(await getReceivedChunks(sessionId));
   for (let i = 0; i < manifest.totalChunks; i++) {
     if (!received.has(i)) throw new Error(`Missing chunk ${i}`);
   }
 
-  const assembledPath = path.join(sessionDir(sessionId), "assembled.bin");
+  assertSafeSessionId(sessionId);
+  const assembleDir = path.join(ASSEMBLE_TMP_ROOT, sessionId);
+  fs.mkdirSync(assembleDir, { recursive: true });
+  const assembledPath = path.join(assembleDir, "assembled.bin");
+
   const out = fs.openSync(assembledPath, "w");
   const hash = crypto.createHash("sha256");
   let assembledSize = 0;
   try {
     for (let i = 0; i < manifest.totalChunks; i++) {
-      const buf = fs.readFileSync(chunkPath(sessionId, i));
+      const buf = await readEvidenceObject(chunkObjectKey(sessionId, i));
       fs.writeSync(out, buf);
       hash.update(buf);
       assembledSize += buf.length;
@@ -281,9 +304,37 @@ export function assembleAndVerify(sessionId: string): AssembledFile {
   return { filePath: assembledPath, computedSha256, verified, manifest };
 }
 
-export function cleanupSession(sessionId: string): void {
-  const dir = sessionDir(sessionId);
-  if (fs.existsSync(dir)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+/**
+ * Discards all state for a session: the Redis manifest and received-chunk
+ * set, its S3 chunk objects, its entry in the active-session index, and its
+ * local assemble temp dir (if `assembleAndVerify` ran for it). Safe to call
+ * on a session that doesn't exist, or was never assembled.
+ */
+export async function cleanupSession(sessionId: string): Promise<void> {
+  assertSafeSessionId(sessionId);
+  const redis = RedisClient.getInstance();
+
+  const [manifest, receivedChunks] = await Promise.all([
+    getSession(sessionId),
+    getReceivedChunks(sessionId),
+  ]);
+
+  const totalChunks = manifest?.totalChunks ?? 0;
+  const chunkIndexes = new Set([...receivedChunks, ...Array.from({ length: totalChunks }, (_, i) => i)]);
+  const objectKeys = Array.from(chunkIndexes, (i) => chunkObjectKey(sessionId, i));
+
+  await Promise.all([
+    deleteEvidenceObjects(objectKeys),
+    redis.del(manifestKey(sessionId)),
+    redis.del(chunksKey(sessionId)),
+    redis.srem(SESSION_INDEX_KEY, sessionId),
+  ]);
+
+  const assembleDir = path.join(ASSEMBLE_TMP_ROOT, sessionId);
+  fs.rmSync(assembleDir, { recursive: true, force: true });
+}
+
+/** Every session id still in the active index — the sweep job's candidate set. */
+export async function listActiveSessionIds(): Promise<string[]> {
+  return RedisClient.getInstance().smembers(SESSION_INDEX_KEY);
 }


### PR DESCRIPTION
## Summary
Closes #1122.

Session manifests and chunk bytes for the resumable dispute-evidence upload flow (`backend/src/services/evidence-upload-session.service.ts`) lived entirely on the local filesystem of whichever backend instance handled the session-init request. In a horizontally-scaled, load-balanced deployment with no sticky sessions, a chunk-upload request landing on a different instance than the one that created the session (or the one that later assembles it) would silently fail with "Session not found" or "Missing chunk N" — especially bad here since the data in flight is legal dispute evidence.

`evidence-session-cleanup.job.ts` already used a distributed Redis lock for its own sweep timing, showing the team was multi-instance-aware for that job — but the underlying storage it swept was never made shared, so that didn't help the actual upload flow.

## Changes

**`evidence-upload-session.service.ts`**
- Session manifests move to Redis (a JSON string per session, via the same `RedisClient` singleton already used for idempotency, caching, and presence elsewhere in this codebase).
- The set of received chunk indexes moves to a Redis `SET` per session (was: derived by reading directory entries off disk).
- Chunk bytes move to the same S3-compatible object store the assembled file was already being uploaded to on completion (`evidence-storage.service.ts`) — chunks are just intermediate data on the way there instead of a separate on-disk staging area.
- `assembleAndVerify` still writes the concatenated file to local disk briefly, but that's fine: it's produced and consumed within one request (assemble → validate → upload to S3 → delete), on whichever instance happens to handle `/complete`. It never needs to be visible to a different instance, unlike the manifest/chunks, which are written and read across multiple, independently-routed requests.
- Every public function that used to touch the filesystem synchronously is now `async`, since Redis/S3 calls are. Updated every call site in `dispute.routes.ts` to `await` them.
- Added `listActiveSessionIds()`, backed by a Redis `SET` of every in-flight session id, so the cleanup job's sweep never needs a Redis `KEYS`/`SCAN` over the whole keyspace.

**`evidence-storage.service.ts`**
- Added `uploadEvidenceBuffer` (PutObject from an in-memory `Buffer`, for chunk bytes) and `deleteEvidenceObjects` (batch DeleteObjects, for cleanup) alongside the existing file-path-based `uploadEvidenceObject`/`readEvidenceObject`.

**`evidence-session-cleanup.job.ts`**
- Rewrote the sweep to enumerate the Redis active-session index instead of reading `SESSION_ROOT` off disk, cleaning up via the session service's `cleanupSession` (Redis + S3) instead of `fs.rmSync`.
- The old sweep skipped sessions with an `assembled.bin` present, to avoid racing a completion still in progress. No longer needed: both the happy path (`POST .../complete`) and the explicit abort (`DELETE .../sessions/:id`) now call `cleanupSession` themselves, removing the session from the active index immediately — so anything still indexed past the TTL was genuinely abandoned by its client.
- Distributed lock logic (unrelated to storage) is unchanged.

## Interim mitigation vs. full fix
The issue floated sticky routing at the load balancer as a stopgap if full storage migration wasn't immediately feasible. Went straight for the full fix instead — the S3 store and Redis client are both already-shared infrastructure used elsewhere in this codebase, so there was no real reason to ship the weaker, restart-fragile mitigation first.

## Tests
- `evidenceSessionFakes.ts` (new): in-memory Redis (`get`/`set`/`del`/`sadd`/`srem`/`smembers`) and object-store fakes shared by the three test files below, so they exercise real state transitions without a live Redis server or S3 bucket.
- `evidence-upload-session.service.test.ts`: rewritten for the async API and new backends; added cases for idempotent re-sends, saving a chunk against a nonexistent session, and cleaning up a session that never existed.
- `evidence-session-cleanup.job.test.ts`: rewritten against the Redis index instead of directory mtimes; added a case confirming chunk bytes are removed from the object store, and one confirming a session already completed (removed from the index by `cleanupSession`) is not re-swept.
- `evidence-chunked-upload.test.ts` (full HTTP integration test through `dispute.routes.ts`): updated its Redis/S3 mocks to the new stateful fakes so its existing resumability assertions (init → chunks → drop → status → resume → complete) keep proving the thing this issue is actually about — the upload succeeds using only session state reachable independently of which "instance" handled which request.

## Testing performed
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 warnings
- `npm run build` — passes
- Full backend test suite: 562 passing. 2 failures in unrelated files (`evidence.upload.test.ts`, `write-rate-limiter.test.ts`) are pure timeout flakiness under full-suite load — both pass cleanly in isolation, and neither imports anything this PR touches.