### PR TITLE
updated escrow, test, and lib.res

### DIFF
--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -120,6 +120,12 @@ pub enum ReputationError {
     /// Rejected when `claim_stake` finds a positive `StakeBalance` but no
     /// recorded `StakeToken` for the reviewer (stake predates token tracking).
     StakeTokenNotFound = 28,
+    /// Rejected when `claim_stake` is called before the lockup period has
+    /// elapsed. Stake must remain locked for `STAKE_LOCKUP_SECONDS` after the
+    /// first review that deposited it, preventing flash-loan-funded governance
+    /// weight inflation where an attacker stakes, inflates reputation/governance
+    /// weight, and immediately reclaims the stake in the same block (issue #exploit).
+    StakeLockupActive = 29,
 }
 
 #[contracttype]
@@ -299,6 +305,11 @@ enum DataKey {
     /// The token address a reviewer's current `StakeBalance` is denominated in,
     /// so it can be transferred back correctly on `claim_stake`.
     StakeToken(Address),
+    /// The ledger timestamp at which the reviewer first staked (i.e. submitted
+    /// their first review). Used by `claim_stake` to enforce `STAKE_LOCKUP_SECONDS`.
+    /// Reset to the current timestamp whenever additional stake is added so that
+    /// all stake (including incremental deposits) must age past the lockup.
+    StakeLockupTs(Address),
     ReviewAppeal(Address, Address, u64),
     DisputeContract,
     Endorsement(Address, String, Address),
@@ -353,12 +364,36 @@ const RATE_LIMIT_LEDGERS_DEFAULT: u32 = 120; // ~10 minutes
 /// Hard floor on the stake_weight used as reputation vote weight.
 /// Prevents zero-weight reviews from gaining weight=1 via the fallback path.
 pub const MIN_STAKE_WEIGHT: u64 = 1;
+
+/// Minimum lockup duration in seconds before staked tokens can be reclaimed.
+/// 7 days (604_800 seconds). This ensures that reputation weight established by
+/// a stake cannot be flash-loaned: the economic cost must be borne for at least
+/// this period, making governance manipulation via rapid stake/unstake
+/// economically meaningful rather than free (issue #exploit).
+pub const STAKE_LOCKUP_SECONDS: u64 = 7 * 24 * 60 * 60; // 604_800
+
+/// Per-review cap on the stake weight credited toward `total_score` and
+/// `total_weight`. Any stake_weight above this threshold is clamped before it
+/// is multiplied by the star rating and added to the reviewee's reputation.
+/// This prevents a single self-dealt review with an arbitrarily large
+/// `stake_weight` from dominating `total_score` and thereby inflating
+/// governance voting power via `get_gov_weight` (issue #exploit).
+///
+/// Set to 1_000 units at 7 decimals = 10_000_000_000 stroops. Reviewers who
+/// want more governance influence must earn it across multiple distinct
+/// counterparties rather than from a single inflated stake.
+pub const MAX_STAKE_WEIGHT_PER_REVIEW: u64 = 1_000 * 10_000_000; // 10_000_000_000
+
+/// Absolute cap on the `score` value returned by `get_gov_weight`. Defense-in-
+/// depth against any future bypass of the per-review cap. Equals five 5-star
+/// max-weight reviews times the maximum counted reviews (200), so a legitimately
+/// excellent user is never capped in practice.
+pub const MAX_GOV_WEIGHT: u64 = 5 * MAX_STAKE_WEIGHT_PER_REVIEW * 200; // 10_000_000_000_000
+
 const DEFAULT_REFERRAL_BONUS: u64 = 5; // Equivalates to a 5-star review bonus
 /// Weight used when crediting referral bonus to reputation (not min review stake).
 const REFERRAL_BONUS_REPUTATION_WEIGHT: u64 = 1;
-const ONE_YEAR_IN_SECONDS: u64 = 31_536_000;
-
-/// Default upper bound for the annual reputation `decay_rate` (percent per year).
+const ONE_YEAR_IN_SECONDS: u64 = 31_536_000;/// Default upper bound for the annual reputation `decay_rate` (percent per year).
 /// 20% keeps decay meaningful without destroying accumulated reputation in a
 /// single period. The super-admin can raise this via `set_max_decay_rate` up to
 /// `MAX_DECAY_RATE_HARD_CEILING` (issue #783).
@@ -681,13 +716,29 @@ impl ReputationContract {
             .persistent()
             .extend_ttl(&stake_token_key, MIN_TTL_THRESHOLD, MIN_TTL_EXTEND_TO);
 
+        // Record (or refresh) the lockup start timestamp. We always write the
+        // current timestamp so that incremental stakes cannot use an old anchor
+        // to escape the lockup early. The full lockup window restarts from the
+        // latest deposit, ensuring all accumulated stake is bound for
+        // STAKE_LOCKUP_SECONDS from the most recent review (issue #exploit).
+        let lockup_key = DataKey::StakeLockupTs(reviewer.clone());
+        let current_ts = env.ledger().timestamp();
+        env.storage().persistent().set(&lockup_key, &current_ts);
+        env.storage()
+            .persistent()
+            .extend_ttl(&lockup_key, MIN_TTL_THRESHOLD, MIN_TTL_EXTEND_TO);
+
         // Saturate stake_weight to u64::MAX instead of truncating to prevent
         // large i128 stakes from wrapping to arbitrary values (issue #982).
-        let weight = if stake_weight > 0 {
+        // Then apply the per-review cap (MAX_STAKE_WEIGHT_PER_REVIEW) so that a
+        // single self-dealt review with an arbitrarily large stake_weight cannot
+        // dominate total_score and mint free governance power (issue #exploit).
+        let raw_weight = if stake_weight > 0 {
             i128::min(stake_weight, u64::MAX as i128) as u64
         } else {
             1u64
         };
+        let weight = raw_weight.min(MAX_STAKE_WEIGHT_PER_REVIEW);
 
         // Capture the old tier before mutating reputation so the tier_up event
         // can carry both the previous and new tier values.
@@ -1211,7 +1262,12 @@ impl ReputationContract {
             None => return (0, 0),
         };
         let (total_score, _total_weight, _review_count) = Self::get_decayed_totals(&env, user);
-        (total_score, last_change_ts)
+        // Cap the returned score at MAX_GOV_WEIGHT so that even if per-review
+        // capping is somehow bypassed in a future code path, a single user's
+        // raw total_score cannot translate into unbounded governance voting power
+        // (issue #exploit, defense-in-depth).
+        let capped_score = total_score.min(MAX_GOV_WEIGHT);
+        (capped_score, last_change_ts)
     }
 
     /// Get reputation together with the registered referrer (if any).
@@ -1820,9 +1876,13 @@ impl ReputationContract {
         for idx in start..review_count {
             if let Some(review) = reviews.get(idx) {
                 let factor = get_decay_factor(decay_rate, current_ts, review.timestamp);
-                // Saturate stake_weight to u64::MAX to prevent truncation (issue #982)
+                // Saturate stake_weight to u64::MAX to prevent truncation (issue #982).
+                // Then cap at MAX_STAKE_WEIGHT_PER_REVIEW so that historical reviews
+                // submitted before the per-review cap was enforced in submit_review
+                // cannot still contribute unbounded weight on the read path (issue #exploit).
                 let clamped_weight = i128::min(review.stake_weight, u64::MAX as i128) as u64;
-                let decayed_weight = scale_by_factor_pct(clamped_weight, factor);
+                let capped_weight = clamped_weight.min(MAX_STAKE_WEIGHT_PER_REVIEW);
+                let decayed_weight = scale_by_factor_pct(capped_weight, factor);
                 total_score = total_score
                     .saturating_add((review.rating as u64).saturating_mul(decayed_weight));
                 total_weight = total_weight.saturating_add(decayed_weight);
@@ -2061,6 +2121,13 @@ impl ReputationContract {
 
     /// Claim staked tokens back after a lockup period. Allows reviewers to withdraw
     /// their stakes. Transfers the claimed amount from the contract back to the reviewer.
+    ///
+    /// Enforces a `STAKE_LOCKUP_SECONDS` wait from the timestamp of the last
+    /// `submit_review` that deposited stake. This prevents flash-loan-funded
+    /// governance weight inflation: an attacker who inflates `total_score` via a
+    /// self-dealt high-stake review must leave the capital locked for 7 days
+    /// before recovering it, making the attack economically meaningful rather
+    /// than free-of-cost (issue #exploit).
     pub fn claim_stake(env: Env, reviewer: Address, amount: i128) -> Result<(), ReputationError> {
         reviewer.require_auth();
         require_not_paused(&env)?;
@@ -2070,6 +2137,22 @@ impl ReputationContract {
 
         if balance < amount || amount <= 0 {
             return Err(ReputationError::BelowMinStake);
+        }
+
+        // Lockup enforcement: reject claims where the stake is younger than
+        // STAKE_LOCKUP_SECONDS. Pre-existing stakes without a recorded timestamp
+        // (StakeLockupTs absent) are treated as if they were staked at time 0,
+        // so they immediately satisfy the lockup and remain claimable — no
+        // backward-compatibility breakage for stakes that predate this check.
+        let lockup_key = DataKey::StakeLockupTs(reviewer.clone());
+        let staked_at: u64 = env
+            .storage()
+            .persistent()
+            .get(&lockup_key)
+            .unwrap_or(0u64);
+        let current_ts = env.ledger().timestamp();
+        if current_ts < staked_at.saturating_add(STAKE_LOCKUP_SECONDS) {
+            return Err(ReputationError::StakeLockupActive);
         }
 
         // Update balance
@@ -2093,6 +2176,9 @@ impl ReputationContract {
 
         if new_balance <= 0 {
             env.storage().persistent().remove(&stake_token_key);
+            // Remove the lockup timestamp too — no stake remaining means the
+            // next deposit will anchor a fresh lockup window.
+            env.storage().persistent().remove(&lockup_key);
         }
 
         env.events().publish(

--- a/contracts/reputation/src/test.rs
+++ b/contracts/reputation/src/test.rs
@@ -3479,6 +3479,8 @@ fn test_claim_stake_partial_withdrawal() {
     
     // Mint tokens and submit a review to stake them
     mint(&env, &token_addr, &token_admin, &reviewer, 100_000_000);
+    // Start at t=1000 so advancing by STAKE_LOCKUP_SECONDS gives a clean timestamp.
+    env.ledger().with_mut(|l| l.timestamp = 1000);
     setup_completed_job(&env, &escrow_id, 1u64, &reviewer, &reviewee, &token_addr);
 
     reputation_client.submit_review(
@@ -3490,6 +3492,9 @@ fn test_claim_stake_partial_withdrawal() {
         &String::from_str(&env, "Good work"),
         &MIN_STAKE,
     );
+
+    // Advance past the 7-day lockup window before claiming.
+    env.ledger().with_mut(|l| l.timestamp = 1000 + STAKE_LOCKUP_SECONDS + 1);
 
     // Partial claim: withdraw half of the staked amount
     let claim_amount = MIN_STAKE / 2;
@@ -3515,6 +3520,7 @@ fn test_claim_stake_full_withdrawal() {
     let token_addr = create_token(&env, &token_admin);
     
     mint(&env, &token_addr, &token_admin, &reviewer, 100_000_000);
+    env.ledger().with_mut(|l| l.timestamp = 1000);
     setup_completed_job(&env, &escrow_id, 1u64, &reviewer, &reviewee, &token_addr);
 
     reputation_client.submit_review(
@@ -3526,6 +3532,9 @@ fn test_claim_stake_full_withdrawal() {
         &String::from_str(&env, "Good work"),
         &MIN_STAKE,
     );
+
+    // Advance past the 7-day lockup before claiming.
+    env.ledger().with_mut(|l| l.timestamp = 1000 + STAKE_LOCKUP_SECONDS + 1);
 
     // Full claim: withdraw entire staked amount
     reputation_client.claim_stake(&reviewer, &MIN_STAKE);
@@ -3551,6 +3560,7 @@ fn test_claim_stake_exceeds_balance() {
     let token_addr = create_token(&env, &token_admin);
     
     mint(&env, &token_addr, &token_admin, &reviewer, 100_000_000);
+    env.ledger().with_mut(|l| l.timestamp = 1000);
     setup_completed_job(&env, &escrow_id, 1u64, &reviewer, &reviewee, &token_addr);
 
     reputation_client.submit_review(
@@ -3562,6 +3572,9 @@ fn test_claim_stake_exceeds_balance() {
         &String::from_str(&env, "Good work"),
         &MIN_STAKE,
     );
+
+    // Advance past lockup so the balance-exceeded check is reached, not the lockup check.
+    env.ledger().with_mut(|l| l.timestamp = 1000 + STAKE_LOCKUP_SECONDS + 1);
 
     // Attempt to claim more than the available balance
     // Should fail with BelowMinStake (#11)
@@ -3584,6 +3597,7 @@ fn test_claim_stake_zero_amount() {
     let token_addr = create_token(&env, &token_admin);
     
     mint(&env, &token_addr, &token_admin, &reviewer, 100_000_000);
+    env.ledger().with_mut(|l| l.timestamp = 1000);
     setup_completed_job(&env, &escrow_id, 1u64, &reviewer, &reviewee, &token_addr);
 
     reputation_client.submit_review(
@@ -3595,6 +3609,9 @@ fn test_claim_stake_zero_amount() {
         &String::from_str(&env, "Good work"),
         &MIN_STAKE,
     );
+
+    // Advance past lockup so only the zero-amount check fires.
+    env.ledger().with_mut(|l| l.timestamp = 1000 + STAKE_LOCKUP_SECONDS + 1);
 
     // Attempt to claim zero amount
     // Should fail with BelowMinStake (#11)
@@ -3617,6 +3634,7 @@ fn test_claim_stake_negative_amount() {
     let token_addr = create_token(&env, &token_admin);
     
     mint(&env, &token_addr, &token_admin, &reviewer, 100_000_000);
+    env.ledger().with_mut(|l| l.timestamp = 1000);
     setup_completed_job(&env, &escrow_id, 1u64, &reviewer, &reviewee, &token_addr);
 
     reputation_client.submit_review(
@@ -3628,6 +3646,9 @@ fn test_claim_stake_negative_amount() {
         &String::from_str(&env, "Good work"),
         &MIN_STAKE,
     );
+
+    // Advance past lockup so only the negative-amount check fires.
+    env.ledger().with_mut(|l| l.timestamp = 1000 + STAKE_LOCKUP_SECONDS + 1);
 
     // Attempt to claim negative amount
     // Should fail with BelowMinStake (#11)
@@ -4044,4 +4065,397 @@ fn test_reviewee_rate_limit_resets_after_window() {
     );
 
     assert_eq!(reputation_client.get_review_count(&reviewee), 1);
+}
+
+// ================================================================================================
+// Security fix: stake lockup enforcement, stake_weight cap, and governance weight dampening
+// ================================================================================================
+
+/// Reproduce the flash-loan / same-block claim attack:
+/// 1. Reviewer submits a review (stake deposited, lockup timer starts).
+/// 2. Reviewer immediately tries to reclaim the stake.
+/// 3. Must be rejected with StakeLockupActive (#29) — lockup not elapsed.
+#[test]
+#[should_panic(expected = "Error(Contract, #29)")]
+fn test_claim_stake_rejected_before_lockup_elapses() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register_contract(None, EscrowContract);
+    let reputation_id = env.register_contract(None, ReputationContract);
+    let reputation_client = ReputationContractClient::new(&env, &reputation_id);
+
+    let reviewer = Address::generate(&env);
+    let reviewee = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = create_token(&env, &token_admin);
+
+    mint(&env, &token_addr, &token_admin, &reviewer, 100_000_000);
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+    setup_completed_job(&env, &escrow_id, 1u64, &reviewer, &reviewee, &token_addr);
+
+    reputation_client.submit_review(
+        &escrow_id,
+        &reviewer,
+        &reviewee,
+        &1u64,
+        &5u32,
+        &String::from_str(&env, "Great"),
+        &MIN_STAKE,
+    );
+
+    // Advance only 1 second — far below the 7-day lockup.
+    env.ledger().with_mut(|l| l.timestamp = 1_000_001);
+
+    // Must fail with StakeLockupActive (#29).
+    reputation_client.claim_stake(&reviewer, &MIN_STAKE);
+}
+
+/// Lockup boundary: claim rejected at exactly lockup_end - 1 second, accepted
+/// at lockup_end (staked_at + STAKE_LOCKUP_SECONDS).
+#[test]
+fn test_claim_stake_accepted_exactly_at_lockup_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register_contract(None, EscrowContract);
+    let reputation_id = env.register_contract(None, ReputationContract);
+    let reputation_client = ReputationContractClient::new(&env, &reputation_id);
+
+    let reviewer = Address::generate(&env);
+    let reviewee = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = create_token(&env, &token_admin);
+
+    mint(&env, &token_addr, &token_admin, &reviewer, 100_000_000);
+
+    let stake_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|l| l.timestamp = stake_ts);
+    setup_completed_job(&env, &escrow_id, 1u64, &reviewer, &reviewee, &token_addr);
+
+    reputation_client.submit_review(
+        &escrow_id,
+        &reviewer,
+        &reviewee,
+        &1u64,
+        &5u32,
+        &String::from_str(&env, "Good"),
+        &MIN_STAKE,
+    );
+
+    // One second before lockup ends — must still be rejected.
+    env.ledger()
+        .with_mut(|l| l.timestamp = stake_ts + STAKE_LOCKUP_SECONDS - 1);
+    let result = reputation_client.try_claim_stake(&reviewer, &MIN_STAKE);
+    assert!(
+        result.is_err(),
+        "claim must be rejected 1 second before lockup elapses"
+    );
+
+    // Exactly at lockup_end — must succeed.
+    env.ledger()
+        .with_mut(|l| l.timestamp = stake_ts + STAKE_LOCKUP_SECONDS);
+    reputation_client.claim_stake(&reviewer, &MIN_STAKE);
+
+    assert_eq!(reputation_client.get_stake_balance(&reviewer), 0);
+}
+
+/// Incremental stake refresh: a second review resets the lockup anchor.
+/// The original stake cannot be claimed just because the first lockup elapsed —
+/// the second deposit restarts the window for ALL accumulated stake.
+#[test]
+#[should_panic(expected = "Error(Contract, #29)")]
+fn test_second_review_resets_lockup_for_all_stake() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register_contract(None, EscrowContract);
+    let reputation_id = env.register_contract(None, ReputationContract);
+    let reputation_client = ReputationContractClient::new(&env, &reputation_id);
+
+    let reviewer = Address::generate(&env);
+    let reviewee1 = Address::generate(&env);
+    let reviewee2 = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = create_token(&env, &token_admin);
+
+    mint(&env, &token_addr, &token_admin, &reviewer, 1_000_000_000);
+
+    // First review at t=1000.
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+    setup_completed_job(&env, &escrow_id, 1u64, &reviewer, &reviewee1, &token_addr);
+    reputation_client.submit_review(
+        &escrow_id,
+        &reviewer,
+        &reviewee1,
+        &1u64,
+        &5u32,
+        &String::from_str(&env, "Great"),
+        &MIN_STAKE,
+    );
+
+    // Advance past the first lockup window (8 days).
+    env.ledger().with_mut(|l| l.timestamp = 1000 + STAKE_LOCKUP_SECONDS + 1);
+
+    // Second review — resets lockup anchor to current time.
+    setup_completed_job(&env, &escrow_id, 2u64, &reviewer, &reviewee2, &token_addr);
+    reputation_client.submit_review(
+        &escrow_id,
+        &reviewer,
+        &reviewee2,
+        &2u64,
+        &5u32,
+        &String::from_str(&env, "Also great"),
+        &MIN_STAKE,
+    );
+
+    // Attempting to claim immediately after the second review must fail even
+    // though the first lockup window has fully elapsed.
+    env.ledger().with_mut(|l| l.timestamp = 1000 + STAKE_LOCKUP_SECONDS + 2);
+    reputation_client.claim_stake(&reviewer, &MIN_STAKE);
+}
+
+/// Stake-weight cap: a single review with a stake_weight far above
+/// MAX_STAKE_WEIGHT_PER_REVIEW must contribute no more than
+/// 5 * MAX_STAKE_WEIGHT_PER_REVIEW to total_score (at a 5-star rating).
+/// Before the fix, passing stake_weight = 1_000_000 * MIN_STAKE would have
+/// given governance weight proportional to that huge number.
+#[test]
+fn test_stake_weight_capped_per_review() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register_contract(None, EscrowContract);
+    let reputation_id = env.register_contract(None, ReputationContract);
+    let reputation_client = ReputationContractClient::new(&env, &reputation_id);
+
+    let reviewer = Address::generate(&env);
+    let reviewee = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = create_token(&env, &token_admin);
+
+    // Mint a very large amount so the transfer itself succeeds.
+    // 100 * MAX_STAKE_WEIGHT_PER_REVIEW in raw token units.
+    let huge_stake: i128 = (MAX_STAKE_WEIGHT_PER_REVIEW as i128) * 100;
+    mint(&env, &token_addr, &token_admin, &reviewer, huge_stake);
+
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+    setup_completed_job(&env, &escrow_id, 1u64, &reviewer, &reviewee, &token_addr);
+
+    reputation_client.submit_review(
+        &escrow_id,
+        &reviewer,
+        &reviewee,
+        &1u64,
+        &5u32,
+        &String::from_str(&env, "Five stars"),
+        &huge_stake,
+    );
+
+    let (score, _) = reputation_client.get_gov_weight(&reviewee);
+
+    // With no cap the score would be 5 * 100 * MAX_STAKE_WEIGHT_PER_REVIEW.
+    // With the per-review cap it must be exactly 5 * MAX_STAKE_WEIGHT_PER_REVIEW.
+    let expected_capped = 5u64 * MAX_STAKE_WEIGHT_PER_REVIEW;
+    assert_eq!(
+        score, expected_capped,
+        "governance score must be capped at 5 * MAX_STAKE_WEIGHT_PER_REVIEW, got {score}"
+    );
+}
+
+/// Governance weight hard cap: even if 200 max-rated, max-staked reviews exist,
+/// the score returned by get_gov_weight must not exceed MAX_GOV_WEIGHT.
+#[test]
+fn test_get_gov_weight_capped_at_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let reputation_id = env.register_contract(None, ReputationContract);
+    let client = ReputationContractClient::new(&env, &reputation_id);
+    let admin = Address::generate(&env);
+    client.initialize(&vec![&env, admin.clone()], &1u32, &0u32);
+
+    let user = Address::generate(&env);
+    let reviewer = Address::generate(&env);
+
+    // Inject 200 reviews each with MAX_STAKE_WEIGHT_PER_REVIEW and 5-star rating,
+    // which is exactly the legitimate ceiling. Also inject 1 extra review with a
+    // stake 10x the cap; capping must keep the total at MAX_GOV_WEIGHT.
+    env.as_contract(&reputation_id, || {
+        let mut reviews: Vec<Review> = Vec::new(&env);
+        for i in 0..200u64 {
+            reviews.push_back(Review {
+                reviewer: reviewer.clone(),
+                reviewee: user.clone(),
+                job_id: i,
+                rating: 5u32,
+                comment: String::from_str(&env, ""),
+                // 10x the per-review cap — read-path capping must bring this down.
+                stake_weight: (MAX_STAKE_WEIGHT_PER_REVIEW as i128) * 10,
+                timestamp: 0,
+            });
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::Reviews(user.clone()), &reviews);
+        env.storage().persistent().set(
+            &DataKey::Reputation(user.clone()),
+            &UserReputation {
+                user: user.clone(),
+                total_score: 0,
+                total_weight: 0,
+                review_count: 200,
+                last_updated_ts: 0,
+            },
+        );
+    });
+
+    let (score, _ts) = client.get_gov_weight(&user);
+    assert_eq!(
+        score, MAX_GOV_WEIGHT,
+        "get_gov_weight must be capped at MAX_GOV_WEIGHT, got {score}"
+    );
+}
+
+/// Two-address Sybil exploit end-to-end:
+/// Attacker controls addr_a and addr_b, creates a completed job between them,
+/// each reviews the other with a massive stake_weight.
+/// Assert that get_gov_weight is capped rather than reflecting the raw
+/// inflated stake, AND that the stake cannot be reclaimed before the lockup.
+#[test]
+fn test_sybil_two_address_self_dealt_review_capped() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register_contract(None, EscrowContract);
+    let reputation_id = env.register_contract(None, ReputationContract);
+    let reputation_client = ReputationContractClient::new(&env, &reputation_id);
+
+    // Attacker-controlled addresses.
+    let addr_a = Address::generate(&env);
+    let addr_b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = create_token(&env, &token_admin);
+
+    // Mint enough for both to stake a huge amount.
+    let huge_stake: i128 = (MAX_STAKE_WEIGHT_PER_REVIEW as i128) * 1_000;
+    mint(&env, &token_addr, &token_admin, &addr_a, huge_stake);
+    mint(&env, &token_addr, &token_admin, &addr_b, huge_stake);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+    // Create a completed job between the two attacker addresses.
+    setup_completed_job(&env, &escrow_id, 1u64, &addr_a, &addr_b, &token_addr);
+
+    // addr_a (client) reviews addr_b (freelancer) with inflated stake.
+    reputation_client.submit_review(
+        &escrow_id,
+        &addr_a,
+        &addr_b,
+        &1u64,
+        &5u32,
+        &String::from_str(&env, "Sybil 5 stars"),
+        &huge_stake,
+    );
+
+    // addr_b (freelancer) reviews addr_a (client) with inflated stake.
+    setup_completed_job(&env, &escrow_id, 2u64, &addr_b, &addr_a, &token_addr);
+    reputation_client.submit_review(
+        &escrow_id,
+        &addr_b,
+        &addr_a,
+        &2u64,
+        &5u32,
+        &String::from_str(&env, "Sybil 5 stars back"),
+        &huge_stake,
+    );
+
+    // --- Assertion 1: governance weight is capped, NOT inflated ---
+    let (score_b, _) = reputation_client.get_gov_weight(&addr_b);
+    let (score_a, _) = reputation_client.get_gov_weight(&addr_a);
+    let expected_max_single = 5u64 * MAX_STAKE_WEIGHT_PER_REVIEW;
+    assert_eq!(
+        score_b, expected_max_single,
+        "addr_b gov weight must be capped at {expected_max_single}, got {score_b}"
+    );
+    assert_eq!(
+        score_a, expected_max_single,
+        "addr_a gov weight must be capped at {expected_max_single}, got {score_a}"
+    );
+
+    // --- Assertion 2: stake cannot be reclaimed immediately (flash-loan defence) ---
+    let result_a = reputation_client.try_claim_stake(&addr_a, &huge_stake);
+    assert!(
+        result_a.is_err(),
+        "addr_a must not be able to reclaim stake before lockup elapses"
+    );
+    let result_b = reputation_client.try_claim_stake(&addr_b, &huge_stake);
+    assert!(
+        result_b.is_err(),
+        "addr_b must not be able to reclaim stake before lockup elapses"
+    );
+
+    // --- Assertion 3: stake CAN be reclaimed after the lockup ---
+    env.ledger()
+        .with_mut(|l| l.timestamp = 1_000_000 + STAKE_LOCKUP_SECONDS + 1);
+    reputation_client.claim_stake(&addr_a, &huge_stake);
+    reputation_client.claim_stake(&addr_b, &huge_stake);
+    assert_eq!(reputation_client.get_stake_balance(&addr_a), 0);
+    assert_eq!(reputation_client.get_stake_balance(&addr_b), 0);
+}
+
+/// Legitimate high-stake reviewer: a normal MIN_STAKE review with a 5-star
+/// rating goes through uncapped (stake is below MAX_STAKE_WEIGHT_PER_REVIEW)
+/// and remains claimable after the lockup. Ensures the fix doesn't break
+/// the honest happy path.
+#[test]
+fn test_legitimate_review_and_claim_unaffected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let escrow_id = env.register_contract(None, EscrowContract);
+    let reputation_id = env.register_contract(None, ReputationContract);
+    let reputation_client = ReputationContractClient::new(&env, &reputation_id);
+
+    let reviewer = Address::generate(&env);
+    let reviewee = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = create_token(&env, &token_admin);
+
+    mint(&env, &token_addr, &token_admin, &reviewer, 100_000_000);
+    env.ledger().with_mut(|l| l.timestamp = 5_000_000);
+    setup_completed_job(&env, &escrow_id, 1u64, &reviewer, &reviewee, &token_addr);
+
+    reputation_client.submit_review(
+        &escrow_id,
+        &reviewer,
+        &reviewee,
+        &1u64,
+        &5u32,
+        &String::from_str(&env, "Excellent"),
+        &MIN_STAKE,
+    );
+
+    // Reputation score = 5 * MIN_STAKE (well below both caps).
+    let (score, _) = reputation_client.get_gov_weight(&reviewee);
+    assert_eq!(
+        score,
+        5u64 * MIN_STAKE as u64,
+        "legitimate review score should equal 5 * MIN_STAKE"
+    );
+
+    // Claiming before lockup elapses is still rejected.
+    assert!(
+        reputation_client
+            .try_claim_stake(&reviewer, &MIN_STAKE)
+            .is_err(),
+        "claim must fail inside the lockup window"
+    );
+
+    // After lockup, claim succeeds.
+    env.ledger()
+        .with_mut(|l| l.timestamp = 5_000_000 + STAKE_LOCKUP_SECONDS + 1);
+    reputation_client.claim_stake(&reviewer, &MIN_STAKE);
+    assert_eq!(reputation_client.get_stake_balance(&reviewer), 0);
 }


### PR DESCRIPTION
## Problem

Three independently reasonable contract behaviors combined to allow governance voting power to be minted for free:

1. `claim_stake` had no lockup enforcement despite its doc comment stating "Claim staked tokens back after a lockup period"
2. `submit_review` accepted arbitrary `stake_weight` values with no ceiling, which fed directly into `total_score`
3. `get_gov_weight` returned raw `total_score` with no upper bound into escrow's `snapshot_weight`

An attacker controlling two addresses could create a completed job between them, exchange 5-star reviews with an arbitrarily large `stake_weight`, acquire real governance voting power, then reclaim the stake immediately — potentially same-block via flash loan — making the entire attack essentially free.

## Changes

### `contracts/reputation/src/lib.rs`

**New error variant**
- `StakeLockupActive = 29` — returned by `claim_stake` when the lockup window has not elapsed

**New storage key**
- `DataKey::StakeLockupTs(Address)` — records the timestamp of the most recent stake deposit per reviewer; reset on every incremental stake so the full window always restarts from the latest deposit

**New constants**
- `STAKE_LOCKUP_SECONDS = 604_800` — 7-day lockup window
- `MAX_STAKE_WEIGHT_PER_REVIEW = 10_000_000_000` — per-review cap (1,000 units at 7 decimals)
- `MAX_GOV_WEIGHT = 10_000_000_000_000` — absolute ceiling on `get_gov_weight` output

**`submit_review`**
- Records/refreshes `StakeLockupTs` on every stake deposit
- Caps `stake_weight` at `MAX_STAKE_WEIGHT_PER_REVIEW` before it contributes to `total_score`

**`claim_stake`**
- Reads `StakeLockupTs`, defaults to `0` for pre-existing stakes (backward compatible)
- Rejects with `StakeLockupActive` if `current_ts < staked_at + STAKE_LOCKUP_SECONDS`
- Removes `StakeLockupTs` key when balance reaches zero

**`get_decayed_totals`**
- Applies `MAX_STAKE_WEIGHT_PER_REVIEW` cap on the read path so historical reviews stored before this fix also have their weight bounded

**`get_gov_weight`**
- Applies `total_score.min(MAX_GOV_WEIGHT)` before returning, as defense-in-depth against any future bypass of the per-review cap

### `contracts/escrow/src/governance.rs`

**New constant**
- `GOV_WEIGHT_CAP = 10_000_000_000_000` — mirrors `MAX_GOV_WEIGHT`

**`snapshot_weight`**
- Applies `score.min(GOV_WEIGHT_CAP)` as an independent second barrier inside the escrow governance layer, so the escrow contract is not silently exposed if the reputation contract is later upgraded to remove its own cap

## Backward compatibility

Pre-existing stakes that have no recorded `StakeLockupTs` default to timestamp `0`, which immediately satisfies the lockup condition, so no currently held stake is locked by this change. Historical reviews with `stake_weight` above the new cap are silently clamped on the read path — no migration needed.

## Tests

New tests in `contracts/reputation/src/test.rs`:

| Test | What it verifies |
|---|---|
| `test_claim_stake_rejected_before_lockup_elapses` | Returns `StakeLockupActive` on an immediate reclaim |
| `test_claim_stake_accepted_exactly_at_lockup_boundary` | Rejected at `lockup_end - 1s`, accepted at `lockup_end` |
| `test_second_review_resets_lockup_for_all_stake` | Second deposit resets the lockup window for all accumulated stake |
| `test_stake_weight_capped_per_review` | 100× oversized stake contributes exactly `5 × MAX_STAKE_WEIGHT_PER_REVIEW` |
| `test_get_gov_weight_capped_at_max` | 200 max-weight reviews are bounded to `MAX_GOV_WEIGHT` |
| `test_sybil_two_address_self_dealt_review_capped` | Full end-to-end Sybil attack: weight is capped, stake locked, stake claimable after lockup |
| `test_legitimate_review_and_claim_unaffected` | Normal `MIN_STAKE` reviews and post-lockup claims work unchanged |

Existing `claim_stake` tests updated to advance ledger past `STAKE_LOCKUP_SECONDS` before calling `claim_stake`, preserving their original intent.

## Security properties after this fix

- **Flash-loan cost**: attacker must lock capital for 7 days — no longer same-block reversible
- **Influence ceiling**: a single review contributes at most `5 × MAX_STAKE_WEIGHT_PER_REVIEW` regardless of stake size
- **Governance ceiling**: no single account can exceed `MAX_GOV_WEIGHT` voting units regardless of review count or stake size
- **Two independent caps**: reputation contract and escrow governance each enforce their own ceiling


Closes #1116 